### PR TITLE
Rename npm organization from speee to speee-js

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # jsx-slack
 
 [![CircleCI](https://img.shields.io/circleci/project/github/speee/jsx-slack/master.svg?logo=circleci)][circleci]
-[![npm](https://img.shields.io/npm/v/@speee/jsx-slack.svg?logo=npm)][npm]
+[![npm](https://img.shields.io/npm/v/@speee-js/jsx-slack.svg?logo=npm)][npm]
 [![LICENSE](https://img.shields.io/github/license/speee/jsx-slack.svg)][license]
 
 [circleci]: https://circleci.com/gh/speee/jsx-slack/
-[npm]: https://www.npmjs.com/package/@speee/jsx-slack
+[npm]: https://www.npmjs.com/package/@speee-js/jsx-slack
 [license]: ./LICENSE
 
 Build JSON object for [Slack][slack] [block kit] from readable [JSX].
@@ -45,12 +45,12 @@ Require Node.js >= 8.
 
 ```bash
 # npm
-npm install --save @speee/jsx-slack
+npm install --save @speee-js/jsx-slack
 ```
 
 ```bash
 # yarn
-yarn add @speee/jsx-slack
+yarn add @speee-js/jsx-slack
 ```
 
 ## Block Kit as component
@@ -65,7 +65,7 @@ This is a simple block example `example.jsx` just to say hello to someone. Wrap 
 
 ```jsx
 /** @jsx JSXSlack.h */
-import JSXSlack, { Block, Section } from '@speee/jsx-slack'
+import JSXSlack, { Block, Section } from '@speee-js/jsx-slack'
 
 export default function exampleBlock({ name }) {
   return JSXSlack(

--- a/demo/example.js
+++ b/demo/example.js
@@ -5,7 +5,7 @@ const initialExample = `
       Enjoy building blocks!
     </p>
     <blockquote>
-      <b><a href="https://github.com/speee/jsx-slack">@speee/jsx-slack</a></b>
+      <b><a href="https://github.com/speee/jsx-slack">@speee-js/jsx-slack</a></b>
       <br />
       <i>Build JSON for Slack Block Kit from JSX</i>
     </blockquote>
@@ -18,7 +18,7 @@ const initialExample = `
   <Divider />
   <Actions>
     <Button url="https://github.com/speee/jsx-slack">GitHub</Button>
-    <Button url="https://www.npmjs.com/package/@speee/jsx-slack">npm</Button>
+    <Button url="https://www.npmjs.com/package/@speee-js/jsx-slack">npm</Button>
   </Actions>
 </Block>
 `.trim()

--- a/demo/index.html
+++ b/demo/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
-    <title>@speee/jsx-slack: Build JSON for Slack Block Kit from JSX</title>
+    <title>@speee-js/jsx-slack: Build JSON for Slack Block Kit from JSX</title>
     <meta
       name="Description"
       content="Build JSON object for Slack Block Kit from readable JSX"
@@ -18,7 +18,7 @@
           href="https://github.com/speee/jsx-slack/"
           target="_blank"
           rel="noopener"
-          >@speee/jsx-slack</a
+          >@speee-js/jsx-slack</a
         >
         <small>
           Build JSON for Slack Block Kit from JSX
@@ -36,12 +36,12 @@
           />
         </a>
         <a
-          href="https://www.npmjs.com/package/@speee/jsx-slack"
+          href="https://www.npmjs.com/package/@speee-js/jsx-slack"
           target="_blank"
           rel="noopener"
         >
           <img
-            src="https://img.shields.io/npm/v/@speee/jsx-slack.svg?logo=npm"
+            src="https://img.shields.io/npm/v/@speee-js/jsx-slack.svg?logo=npm"
             alt="npm"
           />
         </a>

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@speee/jsx-slack",
+  "name": "@speee-js/jsx-slack",
   "version": "0.0.0",
   "description": "Build JSON object for Slack Block Kit from readable JSX",
   "author": {


### PR DESCRIPTION
We have some troubles about our npm organization `@speee`.

jsx-slack was planned to release as `@speee/jsx-slack`, but I cannot join as the member and release package because of the trouble.

We have to rename npm organization to use from `@speee` to `@speee-js`.