### PR TITLE
Revert ignored audit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ references:
             - dependencies-{{ .Environment.CI_CACHE_KEY }}-{{ .Environment.CIRCLE_JOB }}-
 
       - run: yarn install
-      - run: yarn audit || true
+      - run: yarn audit
 
       - save_cache:
           key: dependencies-{{ .Environment.CI_CACHE_KEY }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "yarn.lock" }}-{{ .Branch }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Improve `README.md` with some minor fixes ([#4](https://github.com/speee/jsx-slack/pull/4))
+- Revert ignored audit ([#5](https://github.com/speee/jsx-slack/pull/5))
 
 ## v0.1.0 - 2019-03-01
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "scripts": {
     "build": "rimraf lib && tsc",
     "build:demo": "rimraf .cache && parcel build demo/index.html --out-dir demo/build --no-source-maps",
-    "check:audit": "yarn audit || true",
+    "check:audit": "yarn audit",
     "check:format": "yarn -s format -c",
     "check:ts": "tsc --noEmit",
     "demo": "parcel demo/index.html --out-dir demo/build",


### PR DESCRIPTION
It reverts #3. npm advisory (https://www.npmjs.com/advisories/758) was updated.