### PR TITLE
Add template literal tag for using jsx-slack without transpiler, powered by htm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `jsxslack` template literal tag for using jsx-slack without transpiler, powered by [htm](https://github.com/developit/htm) ([#6](https://github.com/speee/jsx-slack/issues/6), [#7](https://github.com/speee/jsx-slack/pull/7))
+
 ### Fixed
 
 - Improve `README.md` with some minor fixes ([#4](https://github.com/speee/jsx-slack/pull/4))

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ export default function exampleBlock({ name }) {
 }
 ```
 
-A prgama would work in Babel ([@babel/plugin-transform-react-jsx](https://babeljs.io/docs/en/babel-plugin-transform-react-jsx)) and [TypeScript with `--jsx react`](https://www.typescriptlang.org/docs/handbook/jsx.html#factory-functions).
+A prgama would work in Babel ([@babel/plugin-transform-react-jsx](https://babeljs.io/docs/en/babel-plugin-transform-react-jsx)) and [TypeScript with `--jsx react`](https://www.typescriptlang.org/docs/handbook/jsx.html#factory-functions). You can use jsx-slack in either one.
 
 #### Template literal
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ Slack has recommended to use **[Block Kit]** for building tempting message. By u
 
 ### Usage
 
-At first, you have to setting JSX to use imported our parser `JSXSlack.h`. Typically, we recommend to use pragma comment `/* @jsx JSXSlack.h */`.
+#### JSX Transpiler
+
+When you want to use jsx-slack with JSX transpiler (Babel / TypeScript), you have to setting to use imported our parser `JSXSlack.h`. Typically, we recommend to use pragma comment `/* @jsx JSXSlack.h */`.
 
 This is a simple block example `example.jsx` just to say hello to someone. Wrap JSX by `JSXSlack()` function.
 
@@ -79,6 +81,28 @@ export default function exampleBlock({ name }) {
 ```
 
 A prgama would work in Babel ([@babel/plugin-transform-react-jsx](https://babeljs.io/docs/en/babel-plugin-transform-react-jsx)) and [TypeScript with `--jsx react`](https://www.typescriptlang.org/docs/handbook/jsx.html#factory-functions).
+
+#### Template literal
+
+A much simpler way to build blocks is using **`jsxslack`** tagged template literal.
+
+It allows the template syntax almost same as JSX, powered by [htm (Hyperscript Tagged Markup)](https://github.com/developit/htm). The troublesome transpiler setup and importing built-in components are not required.
+
+```javascript
+import { jsxslack } from '@speee-js/jsx-slack'
+
+export default function exampleBlock({ name }) {
+  return jsxslack`
+    <Block>
+      <Section>
+        Hello, <b>${name}</b>!
+      </Section>
+    </Block>
+  `
+}
+```
+
+#### Use template in Slack API
 
 After than, just use created template in Slack API. We are using the official Node SDK [`@slack/client`](https://github.com/slackapi/node-slack-sdk) in this example. [See also Slack guide.](https://slackapi.github.io/node-slack-sdk/web_api)
 

--- a/demo/index.js
+++ b/demo/index.js
@@ -1,8 +1,6 @@
-import { registerPlugin, transform } from '@babel/standalone'
-import babelJsx from '@babel/plugin-transform-react-jsx'
 import CodeMirror from 'codemirror'
 import debounce from 'lodash.debounce'
-import * as JSXSlack from '../src/index'
+import { jsxslack } from '../src/index'
 import example from './example'
 import schema from './schema'
 
@@ -14,11 +12,6 @@ import 'codemirror/addon/hint/show-hint'
 import 'codemirror/addon/hint/xml-hint'
 import 'codemirror/lib/codemirror.css'
 import 'codemirror/addon/hint/show-hint.css'
-
-const availableComponents = { ...JSXSlack }
-delete availableComponents.default
-
-registerPlugin('@babel/plugin-transform-react-jsx', babelJsx)
 
 const jsx = document.getElementById('jsx')
 const json = document.getElementById('json')
@@ -74,27 +67,7 @@ const jsxEditor = CodeMirror(jsx, {
 
 const convert = () => {
   try {
-    const { code } = transform(jsxEditor.getValue(), {
-      presets: ['es2015'],
-      plugins: [['@babel/plugin-transform-react-jsx', { pragma: 'h' }]],
-    })
-
-    const matched = code.match(/^"use strict";[\s\S]*\n\nh\([\s\S]+\);$/)
-    if (!matched) throw new Error('Invalid JSX')
-
-    const funcParams = ['h', ...Object.keys(availableComponents), code]
-
-    // eslint-disable-next-line no-new-func
-    const func = new Function(...funcParams)
-
-    let output
-
-    func((...args) => {
-      output = JSXSlack.default.h(...args)
-      return output
-    }, ...Object.values(availableComponents))
-
-    output = JSXSlack.JSXSlack(output)
+    const output = jsxslack([jsxEditor.getValue()])
 
     json.value = JSON.stringify(output, null, '  ')
     previewBtn.setAttribute(

--- a/package.json
+++ b/package.json
@@ -57,8 +57,6 @@
     "access": "public"
   },
   "devDependencies": {
-    "@babel/plugin-transform-react-jsx": "^7.3.0",
-    "@babel/standalone": "^7.3.4",
     "@slack/client": "^4.10.0",
     "@types/jest": "^24.0.9",
     "@typescript-eslint/eslint-plugin": "^1.4.2",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "typescript": "^3.3.3333"
   },
   "dependencies": {
+    "htm": "^2.1.1",
     "lodash.flatten": "^4.4.0",
     "turndown": "^5.0.3"
   }

--- a/src/components.ts
+++ b/src/components.ts
@@ -1,0 +1,2 @@
+export * from './block-kit'
+export { Escape } from './html'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { JSXSlack } from './jsx'
 
 export { JSXSlack }
-export * from './block-kit'
-export { Escape } from './html'
+export * from './components'
+export { default as jsxslack } from './tag'
 export default JSXSlack

--- a/src/tag.ts
+++ b/src/tag.ts
@@ -1,0 +1,20 @@
+import { bind } from 'htm'
+import * as components from './components'
+import { JSXSlack } from './index'
+
+export default function jsxslack(...args) {
+  return JSXSlack(
+    bind((type, props, ...children) => {
+      let elm = type
+
+      if (
+        typeof type === 'string' &&
+        Object.prototype.hasOwnProperty.call(components, type)
+      ) {
+        elm = components[type]
+      }
+
+      return JSXSlack.h(elm, props, ...children)
+    })(...args)
+  )
+}

--- a/src/tag.ts
+++ b/src/tag.ts
@@ -1,8 +1,8 @@
-import { bind } from 'htm'
+import htm from 'htm'
 import * as components from './components'
 import { JSXSlack } from './index'
 
-const parse = bind((type, props, ...children) => {
+const parse = htm.bind((type, props, ...children) => {
   let elm = type
 
   // Support built-in components without import

--- a/src/tag.ts
+++ b/src/tag.ts
@@ -2,19 +2,20 @@ import { bind } from 'htm'
 import * as components from './components'
 import { JSXSlack } from './index'
 
+const parse = bind((type, props, ...children) => {
+  let elm = type
+
+  // Support built-in components without import
+  if (
+    typeof type === 'string' &&
+    Object.prototype.hasOwnProperty.call(components, type)
+  ) {
+    elm = components[type]
+  }
+
+  return JSXSlack.h(elm, props, ...children)
+})
+
 export default function jsxslack(...args) {
-  return JSXSlack(
-    bind((type, props, ...children) => {
-      let elm = type
-
-      if (
-        typeof type === 'string' &&
-        Object.prototype.hasOwnProperty.call(components, type)
-      ) {
-        elm = components[type]
-      }
-
-      return JSXSlack.h(elm, props, ...children)
-    })(...args)
-  )
+  return JSXSlack(parse(...args))
 }

--- a/test/tag.tsx
+++ b/test/tag.tsx
@@ -1,0 +1,47 @@
+/** @jsx JSXSlack.h */
+import JSXSlack, {
+  jsxslack,
+  Actions,
+  Block,
+  Button,
+  Divider,
+  Image,
+  Section,
+} from '../src/index'
+
+describe('Tagged template', () => {
+  it('allows converting JSX to JSON without transpiler', () => {
+    const count = 2
+    const template = jsxslack`
+      <Block>
+        <Section>
+          <Image src="https://example.com/example.jpg" alt="example" />
+          <b>Tagged template</b><br />
+          jsx-slack can use without transpiler by <code>jsxslack</code> tagged template!
+        </Section>
+        <Divider />
+        <Actions>
+          <Button actionId="clap">:clap: ${count}</Button>
+        </Actions>
+      </Block>
+    `
+
+    expect(template).toStrictEqual(
+      JSXSlack(
+        <Block>
+          <Section>
+            <Image src="https://example.com/example.jpg" alt="example" />
+            <b>Tagged template</b>
+            <br />
+            jsx-slack can use without transpiler by <code>jsxslack</code> tagged
+            template!
+          </Section>
+          <Divider />
+          <Actions>
+            <Button actionId="clap">:clap: {count}</Button>
+          </Actions>
+        </Block>
+      )
+    )
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -487,7 +487,7 @@
     "@babel/helper-get-function-arity" "^7.0.0"
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-react-jsx@^7.0.0", "@babel/plugin-transform-react-jsx@^7.3.0":
+"@babel/plugin-transform-react-jsx@^7.0.0":
   version "7.3.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.3.0.tgz#f2cab99026631c767e2745a5368b331cfe8f5290"
   integrity sha512-a/+aRb7R06WcKvQLOu4/TpjKOdvVEKRLWFpKcNuHhiREPgGRB4TQJxq07+EZLS8LFVYpfq1a5lDUnuMdcCpBKg==
@@ -604,11 +604,6 @@
   integrity sha512-IvfvnMdSaLBateu0jfsYIpZTxAc2cKEXEMiezGGN75QcBcecDUKd3PgLAncT0oOgxKy8dd8hrJKj9MfzgfZd6g==
   dependencies:
     regenerator-runtime "^0.12.0"
-
-"@babel/standalone@^7.3.4":
-  version "7.3.4"
-  resolved "https://registry.yarnpkg.com/@babel/standalone/-/standalone-7.3.4.tgz#b622c1e522acef91b2a14f22bdcdd4f935a1a474"
-  integrity sha512-4L9c5i4WlGqbrjOVX0Yp8TIR5cEiw1/tPYYZENW/iuO2uI6viY38U7zALidzNfGdZIwNc+A/AWqMEWKeScWkBg==
 
 "@babel/template@^7.0.0", "@babel/template@^7.1.0", "@babel/template@^7.1.2", "@babel/template@^7.2.2":
   version "7.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3161,6 +3161,11 @@ hsla-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/hsla-regex/-/hsla-regex-1.0.0.tgz#c1ce7a3168c8c6614033a4b5f7877f3b225f9c38"
   integrity sha1-wc56MWjIxmFAM6S194d/OyJfnDg=
 
+htm@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/htm/-/htm-2.1.1.tgz#5a53e5f2845c3181b1672f95c9bffaf3d621bb0e"
+  integrity sha512-jgvB9nvlOE5xpI1W+juW8DPCe+Pn7mRDNaE4EOQNFqROm0O3l5deOvefK8C8hUaL1OHIX45mDEBSj7BMt+22VQ==
+
 html-comment-regex@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/html-comment-regex/-/html-comment-regex-1.1.2.tgz#97d4688aeb5c81886a364faa0cad1dda14d433a7"


### PR DESCRIPTION
jsx-slack had required setup transpiler (Babel or TypeScript). By using added template literal tag `jsxslack`, troublesome settings are not required anymore!

```javascript
import { jsxslack } from '@speee-js/jsx-slack'

// for interpolation
const count = 2

console.log(jsxslack`
  <Block>
    <Section>
      <Image src="https://placekitten.com/300/300" alt="example" />
      <b>Tagged template</b><br />
      jsx-slack can use without transpiler by <code>jsxslack</code> tagged template!
    </Section>
    <Divider />
    <Actions>
      <Button actionId="clap">:clap: ${count}</Button>
    </Actions>
  </Block>
`)
```

Usage is much the same as JSX. It will return an array as follows:

```json
[
  {
    "type": "section",
    "text": {
      "text": "*Tagged template*\njsx-slack can use without transpiler by `jsxslack` tagged template!",
      "type": "mrkdwn",
      "verbatim": true
    },
    "accessory": {
      "type": "image",
      "alt_text": "example",
      "image_url": "https://placekitten.com/300/300"
    }
  },
  {
    "type": "divider"
  },
  {
    "type": "actions",
    "elements": [
      {
        "type": "button",
        "text": {
          "type": "plain_text",
          "text": ":clap: 2",
          "emoji": true
        },
        "action_id": "clap"
      }
    ]
  }
]
```

I also have updated demo site to use template literal. It allows removing too heavy standalone Babel and insecure eval script.

`jsxslack` template literal is powered by [htm](https://github.com/developit/htm) integration. Resolve #6.

## ToDo

- [x] Update documentation (README.md)