### PR TITLE
Right-aligned number in ordered list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Right-aligned number in ordered list ([#8](https://github.com/speee/jsx-slack/pull/8))
+
 ## v0.2.0 - 2019-03-07
 
 ### Added

--- a/test/html.tsx
+++ b/test/html.tsx
@@ -506,21 +506,60 @@ describe('HTML parser for mrkdwn', () => {
             </li>
           </ol>
         )
-      ).toBe('9. Change\n10. Start\n\u2007\u2007  number')
+      ).toBe('\u20079. Change\n10. Start\n\u2007\u2007  number') // aligned number
     })
 
-    // TODO: Support nested list
-    it.skip('allows nested list', () => {
+    // TODO: Support sub list
+    it.skip('allows sub list', () => {
       expect(
         html(
           <ul>
             <li>test</li>
             <ul>
-              <li>nesting</li>
+              <li>sub-list with direct nesting</li>
             </ul>
+            <li>
+              <ul>
+                <li>sub-list</li>
+                <li>
+                  and
+                  <ul>
+                    <li>sub-sub-list</li>
+                  </ul>
+                </li>
+              </ul>
+            </li>
           </ul>
         )
-      ).toBe('• test\n\u2007 • nesting')
+      ).toBe(
+        '• test\n\u2007 • sub-list with direct nesting\n• • sub-list\n\u2007 • and\n\u2007 \u2007 • sub-sub-list'
+      )
+    })
+
+    it.skip('allows sub ordered list', () => {
+      expect(
+        html(
+          <ol start={2}>
+            <li>test</li>
+            <ol>
+              <li>sub-list with direct nesting</li>
+            </ol>
+            <li>
+              <ol>
+                <li>sub-list</li>
+                <li>
+                  and
+                  <ul>
+                    <li>sub-sub-list</li>
+                  </ul>
+                </li>
+              </ol>
+            </li>
+          </ol>
+        )
+      ).toBe(
+        '2. test\n\u2007 1. sub-list with direct nesting\n3. 1. sub-list\n\u2007 2, and\n\u2007 \u2007 • sub-sub-list'
+      )
     })
 
     it('does not allow unsupported block components', () => {


### PR DESCRIPTION
For better compatibility with HTML rendering, I updated turndown parser to render right-aligned numbers in ordered list.

```jsx
<Block>
  <Section>
    <ol start={9}>
      <li>Ordered list</li>
      <li>Right-aligned numbers<br />...and indent</li>
    </ol>
  </Section>
</Block>
```

|HTML|Previous jsx-slack|Updated|
|:---:|:---:|:---:|
|<img width="228" alt="HTML" src="https://user-images.githubusercontent.com/3993388/54109065-f1548080-4420-11e9-98fe-359a91a8a83b.png">|<img width="197" alt="Previous jsx-slack" src="https://user-images.githubusercontent.com/3993388/54109076-f9acbb80-4420-11e9-814e-5376d00a5f86.png">|<img width="195" alt="Updated" src="https://user-images.githubusercontent.com/3993388/54109086-00d3c980-4421-11e9-9453-033aa8e9bee6.png">|

We will know improved layout by looking `9. Ordered list`.