### PR TITLE
Add style prop to Button component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Add `style` prop for `<Button>` component ([#14](https://github.com/speee/jsx-slack/pull/14))
+
 ## v0.4.1 - 2019-03-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ A simple button to send action to registered Slack App, or open external URL.
 ```jsx
 <Blocks>
   <Actions>
-    <Button actionId="action" value="value">
+    <Button actionId="action" value="value" style="primary">
       Action button
     </Button>
     <Button url="https://example.com/">Link to URL</Button>
@@ -303,13 +303,14 @@ A simple button to send action to registered Slack App, or open external URL.
 </Blocks>
 ```
 
-[<img src="https://raw.githubusercontent.com/speee/jsx-slack/master/docs/preview-btn.svg?sanitize=true" width="240" />](https://api.slack.com/tools/block-kit-builder?blocks=%5B%7B%22type%22%3A%22actions%22%2C%22elements%22%3A%5B%7B%22type%22%3A%22button%22%2C%22text%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Action%20button%22%2C%22emoji%22%3Atrue%7D%2C%22action_id%22%3A%22action%22%2C%22value%22%3A%22value%22%7D%2C%7B%22type%22%3A%22button%22%2C%22text%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Link%20to%20URL%22%2C%22emoji%22%3Atrue%7D%2C%22url%22%3A%22https%3A%2F%2Fexample.com%2F%22%7D%5D%7D%5D)
+[<img src="https://raw.githubusercontent.com/speee/jsx-slack/master/docs/preview-btn.svg?sanitize=true" width="240" />](https://api.slack.com/tools/block-kit-builder?blocks=%5B%7B%22type%22%3A%22actions%22%2C%22elements%22%3A%5B%7B%22type%22%3A%22button%22%2C%22text%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Action%20button%22%2C%22emoji%22%3Atrue%7D%2C%22action_id%22%3A%22action%22%2C%22style%22%3A%22primary%22%2C%22value%22%3A%22value%22%7D%2C%7B%22type%22%3A%22button%22%2C%22text%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Link%20to%20URL%22%2C%22emoji%22%3Atrue%7D%2C%22url%22%3A%22https%3A%2F%2Fexample.com%2F%22%7D%5D%7D%5D)
 
 ##### Props
 
 - `actionId` (optional): An identifier for the action.
 - `value` (optional): A string value to send to Slack App when clicked button.
 - `url` (optional): URL to load when clicked button.
+- `style` (optional): Select the colored button decoration from `primary` and `danger`.
 - `confirm` (optional): [`<Confirm>` element](#confirm-confirmation-dialog) to show confirmation dialog.
 
 #### [`<Select>`: Select menu with static options](https://api.slack.com/reference/messaging/block-elements#static-select)

--- a/demo/schema.js
+++ b/demo/schema.js
@@ -74,7 +74,12 @@ export default {
 
   // Interactive components
   Button: {
-    attrs: { value: null, url: null, ...interactiveCommonAttrs },
+    attrs: {
+      value: null,
+      url: null,
+      style: ['primary', 'danger'],
+      ...interactiveCommonAttrs,
+    },
     children: [],
   },
   Select: {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "lodash.debounce": "^4.0.8",
     "npm-run-all": "^4.1.5",
     "parcel": "^1.12.3",
-    "prettier": "^1.16.4",
+    "prettier": "^1.17.0",
     "rimraf": "^2.6.3",
     "ts-jest": "^24.0.2",
     "typescript": "^3.4.3"

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "@slack/client": "^4.11.0",
+    "@slack/types": "^1.0.0",
     "@types/jest": "^24.0.11",
     "@typescript-eslint/eslint-plugin": "^1.4.2",
     "codemirror": "^5.44.0",

--- a/src/block-kit/Actions.tsx
+++ b/src/block-kit/Actions.tsx
@@ -1,5 +1,5 @@
 /** @jsx JSXSlack.h */
-import { ActionsBlock } from '@slack/client'
+import { ActionsBlock } from '@slack/types'
 import { JSXSlack } from '../jsx'
 import { ArrayOutput, ObjectOutput } from '../utils'
 import { BlockComponentProps } from './Blocks'

--- a/src/block-kit/Context.tsx
+++ b/src/block-kit/Context.tsx
@@ -1,5 +1,5 @@
 /** @jsx JSXSlack.h */
-import { ContextBlock, ImageElement, MrkdwnElement } from '@slack/client'
+import { ContextBlock, ImageElement, MrkdwnElement } from '@slack/types'
 import { JSXSlack } from '../jsx'
 import html from '../html'
 import { ObjectOutput } from '../utils'

--- a/src/block-kit/Divider.tsx
+++ b/src/block-kit/Divider.tsx
@@ -1,5 +1,5 @@
 /** @jsx JSXSlack.h */
-import { DividerBlock } from '@slack/client'
+import { DividerBlock } from '@slack/types'
 import { JSXSlack } from '../jsx'
 import { ObjectOutput } from '../utils'
 import { BlockComponentProps } from './Blocks'

--- a/src/block-kit/Image.tsx
+++ b/src/block-kit/Image.tsx
@@ -1,5 +1,5 @@
 /** @jsx JSXSlack.h */
-import { ImageBlock } from '@slack/client'
+import { ImageBlock } from '@slack/types'
 import { JSXSlack } from '../jsx'
 import { ObjectOutput } from '../utils'
 import { BlockComponentProps } from './Blocks'

--- a/src/block-kit/Section.tsx
+++ b/src/block-kit/Section.tsx
@@ -1,5 +1,5 @@
 /** @jsx JSXSlack.h */
-import { SectionBlock, MrkdwnElement } from '@slack/client'
+import { SectionBlock, MrkdwnElement } from '@slack/types'
 import { JSXSlack } from '../jsx'
 import { ObjectOutput } from '../utils'
 import html from '../html'

--- a/src/block-kit/composition/Confirm.tsx
+++ b/src/block-kit/composition/Confirm.tsx
@@ -1,5 +1,5 @@
 /** @jsx JSXSlack.h */
-import { Confirm as SlackConfirm } from '@slack/client'
+import { Confirm as SlackConfirm } from '@slack/types'
 import html from '../../html'
 import { JSXSlack } from '../../jsx'
 import { ObjectOutput } from '../../utils'

--- a/src/block-kit/interactive/Button.tsx
+++ b/src/block-kit/interactive/Button.tsx
@@ -1,5 +1,5 @@
 /** @jsx JSXSlack.h */
-import { Button as SlackButton } from '@slack/client'
+import { Button as SlackButton } from '@slack/types'
 import { JSXSlack } from '../../jsx'
 import { ObjectOutput, PlainText } from '../../utils'
 import { ConfirmProps } from '../composition/Confirm'

--- a/src/block-kit/interactive/Button.tsx
+++ b/src/block-kit/interactive/Button.tsx
@@ -13,8 +13,11 @@ export interface ButtonProps {
   value?: string
 }
 
+// TODO: Use SlackButton when supported style field on @slack/types
+type JSXSlackButton = SlackButton & Pick<ButtonProps, 'style'>
+
 export const Button: JSXSlack.FC<ButtonProps> = props => (
-  <ObjectOutput<SlackButton>
+  <ObjectOutput<JSXSlackButton>
     type="button"
     text={{
       type: 'plain_text',

--- a/src/block-kit/interactive/Button.tsx
+++ b/src/block-kit/interactive/Button.tsx
@@ -8,6 +8,7 @@ export interface ButtonProps {
   actionId?: string
   children: JSXSlack.Children<{}>
   confirm?: JSXSlack.Node<ConfirmProps>
+  style?: 'primary' | 'danger'
   url?: string
   value?: string
 }
@@ -22,6 +23,7 @@ export const Button: JSXSlack.FC<ButtonProps> = props => (
     }}
     action_id={props.actionId}
     confirm={props.confirm ? JSXSlack(props.confirm) : undefined}
+    style={props.style}
     url={props.url}
     value={props.value}
   />

--- a/src/block-kit/interactive/DatePicker.tsx
+++ b/src/block-kit/interactive/DatePicker.tsx
@@ -1,5 +1,5 @@
 /** @jsx JSXSlack.h */
-import { Datepicker } from '@slack/client'
+import { Datepicker } from '@slack/types'
 import { JSXSlack } from '../../jsx'
 import { ObjectOutput } from '../../utils'
 import { ConfirmProps } from '../composition/Confirm'

--- a/src/block-kit/interactive/Overflow.tsx
+++ b/src/block-kit/interactive/Overflow.tsx
@@ -1,5 +1,5 @@
 /** @jsx JSXSlack.h */
-import { Option, Overflow as SlackOverflow } from '@slack/client'
+import { Option, Overflow as SlackOverflow } from '@slack/types'
 import { ConfirmProps } from '../composition/Confirm'
 import { JSXSlack } from '../../jsx'
 import { ObjectOutput, PlainText } from '../../utils'

--- a/src/block-kit/interactive/Select.tsx
+++ b/src/block-kit/interactive/Select.tsx
@@ -6,7 +6,7 @@ import {
   ExternalSelect as SlackExternalSelect,
   Option as SlackOption,
   UsersSelect as SlackUsersSelect,
-} from '@slack/client'
+} from '@slack/types'
 import flatten from 'lodash.flatten'
 import { ConfirmProps } from '../composition/Confirm'
 import { JSXSlack } from '../../jsx'

--- a/src/turndown.ts
+++ b/src/turndown.ts
@@ -44,7 +44,7 @@ const turndownService = () => {
 
   const applyListIndent = (element: HTMLElement, target: string) => {
     // NOTE: trim() may remove the first spaces for right-aligned number in <ol>
-    let processed = target.trimRight()
+    let processed = target.replace(/[\s\uFEFF\xA0]+$/g, '')
     let breaks = ['\n\n', '\n\n']
 
     if (element.parentNode) {

--- a/test/index.tsx
+++ b/test/index.tsx
@@ -6,7 +6,7 @@ import {
   SectionBlock,
   StaticSelect,
   Option as SlackOption,
-} from '@slack/client'
+} from '@slack/types'
 import JSXSlack, {
   Actions,
   Blocks,

--- a/test/index.tsx
+++ b/test/index.tsx
@@ -286,7 +286,8 @@ describe('jsx-slack', () => {
       })
 
       it('outputs actions block with styled <Button>', () => {
-        const buttonAction = action(
+        // TODO: Remove type casting when supported style field on @slack/types
+        const buttonAction = (action as Function)(
           {
             type: 'button',
             text: { type: 'plain_text', text: 'Default', emoji: true },

--- a/test/index.tsx
+++ b/test/index.tsx
@@ -285,6 +285,37 @@ describe('jsx-slack', () => {
         ).toStrictEqual([buttonAction])
       })
 
+      it('outputs actions block with styled <Button>', () => {
+        const buttonAction = action(
+          {
+            type: 'button',
+            text: { type: 'plain_text', text: 'Default', emoji: true },
+          },
+          {
+            type: 'button',
+            text: { type: 'plain_text', text: 'Primary', emoji: true },
+            style: 'primary',
+          },
+          {
+            type: 'button',
+            text: { type: 'plain_text', text: 'Danger', emoji: true },
+            style: 'danger',
+          }
+        )
+
+        expect(
+          JSXSlack(
+            <Blocks>
+              <Actions blockId="actions">
+                <Button>Default</Button>
+                <Button style="primary">Primary</Button>
+                <Button style="danger">Danger</Button>
+              </Actions>
+            </Blocks>
+          )
+        ).toStrictEqual([buttonAction])
+      })
+
       it('outputs actions block with <Select> for static items', () => {
         const selectAction = action({
           type: 'static_select',

--- a/yarn.lock
+++ b/yarn.lock
@@ -5666,10 +5666,10 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-prettier@^1.16.4:
-  version "1.16.4"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.16.4.tgz#73e37e73e018ad2db9c76742e2647e21790c9717"
-  integrity sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g==
+prettier@^1.17.0:
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.17.0.tgz#53b303676eed22cc14a9f0cec09b477b3026c008"
+  integrity sha512-sXe5lSt2WQlCbydGETgfm1YBShgOX4HxQkFPvbxkcwgDvGDeqVau8h+12+lmSVlP3rHPz0oavfddSZg/q+Szjw==
 
 pretty-format@^24.7.0:
   version "24.7.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -842,32 +842,10 @@
     "@parcel/utils" "^1.11.0"
     physical-cpu-count "^2.0.0"
 
-"@slack/client@^4.11.0":
-  version "4.11.0"
-  resolved "https://registry.yarnpkg.com/@slack/client/-/client-4.11.0.tgz#f5f7b832a90c4bd5456621ed802757fd1e5a2d02"
-  integrity sha512-quL60BiEVlJkFHKCAQlerrf0Z13xvZHO8SPBMbmvdL7x84qe+KCbGnwxDBJKbda/eXStvePuQ3lrz6iwLUCQpg==
-  dependencies:
-    "@types/form-data" "^2.2.1"
-    "@types/is-stream" "^1.1.0"
-    "@types/node" ">=6.0.0"
-    "@types/p-cancelable" "^1.0.0"
-    "@types/p-queue" "^2.3.2"
-    "@types/p-retry" "^3.0.0"
-    "@types/retry" "^0.12.0"
-    "@types/ws" "^5.1.1"
-    axios "^0.18.0"
-    eventemitter3 "^3.1.0"
-    finity "^0.5.4"
-    form-data "^2.3.3"
-    is-stream "^1.1.0"
-    object.entries "^1.1.0"
-    object.getownpropertydescriptors "^2.0.3"
-    object.values "^1.1.0"
-    p-cancelable "^1.0.0"
-    p-queue "^2.4.2"
-    p-retry "^3.0.1"
-    retry "^0.12.0"
-    ws "^5.2.0"
+"@slack/types@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@slack/types/-/types-1.0.0.tgz#1dc7a63b293c4911e474197585c3feda012df17a"
+  integrity sha512-IktC4uD/CHfLQcSitKSmjmRu4a6+Nf/KzfS6dTgUlDzENhh26l8aESKAuIpvYD5VOOE6NxDDIAdPJOXBvUGxlg==
 
 "@types/babel__core@^7.1.0":
   version "7.1.0"
@@ -902,25 +880,6 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
-"@types/events@*":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
-  integrity sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==
-
-"@types/form-data@^2.2.1":
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/@types/form-data/-/form-data-2.2.1.tgz#ee2b3b8eaa11c0938289953606b745b738c54b1e"
-  integrity sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==
-  dependencies:
-    "@types/node" "*"
-
-"@types/is-stream@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@types/is-stream/-/is-stream-1.1.0.tgz#b84d7bb207a210f2af9bed431dc0fbe9c4143be1"
-  integrity sha512-jkZatu4QVbR60mpIzjINmtS1ZF4a/FqdTUTBeQDVOQ2PYyidtwFKr0B5G6ERukKwliq+7mIXvxyppwzG5EgRYg==
-  dependencies:
-    "@types/node" "*"
-
 "@types/istanbul-lib-coverage@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.0.tgz#2cc2ca41051498382b43157c8227fea60363f94a"
@@ -938,50 +897,20 @@
   dependencies:
     "@types/jest-diff" "*"
 
-"@types/node@*", "@types/node@>=6.0.0":
+"@types/node@*":
   version "11.11.1"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-11.11.1.tgz#9ee55ffce20f72e141863b0036a6e51c6fc09a1f"
   integrity sha512-2azXFP9n4aA2QNLkKm/F9pzKxgYj1SMawZ5Eh9iC21RH3XNcFsivLVU2NhpMgQm7YobSByvIol4c42ZFusXFHQ==
-
-"@types/p-cancelable@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@types/p-cancelable/-/p-cancelable-1.0.0.tgz#17373dc63c66f79b418311a60235944eb744f926"
-  integrity sha512-EO87xAv8kULqubh88UhjKSWsmYKGTEiRj5bJsBEkE1NF/HPLSko9kIcToX72eYXoNDozO/51X1pHE2TgAXG3GA==
-
-"@types/p-queue@^2.3.2":
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/@types/p-queue/-/p-queue-2.3.2.tgz#16bc5fece69ef85efaf2bce8b13f3ebe39c5a1c8"
-  integrity sha512-eKAv5Ql6k78dh3ULCsSBxX6bFNuGjTmof5Q/T6PiECDq0Yf8IIn46jCyp3RJvCi8owaEmm3DZH1PEImjBMd/vQ==
-
-"@types/p-retry@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@types/p-retry/-/p-retry-3.0.0.tgz#d0bbf6ebe7fffadebbdd02058c38d39bf85901d9"
-  integrity sha512-whxkmt2onv2KJ8FrKtdzUiLvPns99e7JBk47bKq5OOnhugZrx9+QOp3s4+9W8jv1jfzXxLGbEN+yrT7HjRoijQ==
-  dependencies:
-    "@types/retry" "*"
 
 "@types/q@^1.5.1":
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.1.tgz#48fd98c1561fe718b61733daed46ff115b496e18"
   integrity sha512-eqz8c/0kwNi/OEHQfvIuJVLTst3in0e7uTKeuY+WL/zfKn0xVujOTp42bS/vUUokhK5P2BppLd9JXMOMHcgbjA==
 
-"@types/retry@*", "@types/retry@^0.12.0":
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.0.tgz#2b35eccfcee7d38cd72ad99232fbd58bffb3c84d"
-  integrity sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==
-
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
-
-"@types/ws@^5.1.1":
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-5.1.2.tgz#f02d3b1cd46db7686734f3ce83bdf46c49decd64"
-  integrity sha512-NkTXUKTYdXdnPE2aUUbGOXE1XfMK527SCvU/9bj86kyFF6kZ9ZnOQ3mK5jADn98Y2vEUD/7wKDgZa7Qst2wYOg==
-  dependencies:
-    "@types/events" "*"
-    "@types/node" "*"
 
 "@types/yargs@^12.0.2", "@types/yargs@^12.0.9":
   version "12.0.9"
@@ -1261,14 +1190,6 @@ aws4@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
-
-axios@^0.18.0:
-  version "0.18.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.18.0.tgz#32d53e4851efdc0a11993b6cd000789d70c05102"
-  integrity sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=
-  dependencies:
-    follow-redirects "^1.3.0"
-    is-buffer "^1.1.5"
 
 babel-jest@^24.4.0:
   version "24.4.0"
@@ -2187,13 +2108,6 @@ debug@2.6.9, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.
   dependencies:
     ms "2.0.0"
 
-debug@^3.2.6:
-  version "3.2.6"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
-  integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
-  dependencies:
-    ms "^2.1.1"
-
 debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
@@ -2681,11 +2595,6 @@ etag@~1.8.1:
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
 
-eventemitter3@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.0.tgz#090b4d6cdbd645ed10bf750d4b5407942d7ba163"
-  integrity sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA==
-
 events@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.0.0.tgz#9a0a0dfaf62893d92b875b8f2698ca4114973e88"
@@ -2900,11 +2809,6 @@ find-up@^3.0.0:
   dependencies:
     locate-path "^3.0.0"
 
-finity@^0.5.4:
-  version "0.5.4"
-  resolved "https://registry.yarnpkg.com/finity/-/finity-0.5.4.tgz#f2a8a9198e8286467328ec32c8bfcc19a2229c11"
-  integrity sha512-3l+5/1tuw616Lgb0QBimxfdd2TqaDGpfCBpfX6EqtFmqUV3FtQnVEX4Aa62DagYEqnsTIjZcTfbq9msDbXYgyA==
-
 flat-cache@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-2.0.1.tgz#5d296d6f04bda44a4630a301413bdbc2ec085ec0"
@@ -2918,13 +2822,6 @@ flatted@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.0.tgz#55122b6536ea496b4b44893ee2608141d10d9916"
   integrity sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==
-
-follow-redirects@^1.3.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.7.0.tgz#489ebc198dc0e7f64167bd23b03c4c19b5784c76"
-  integrity sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==
-  dependencies:
-    debug "^3.2.6"
 
 for-in@^1.0.2:
   version "1.0.2"
@@ -2941,7 +2838,7 @@ forever-agent@~0.6.1:
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
 
-form-data@^2.3.3, form-data@~2.3.2:
+form-data@~2.3.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
   integrity sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==
@@ -4893,7 +4790,7 @@ object.assign@^4.1.0:
     has-symbols "^1.0.0"
     object-keys "^1.0.11"
 
-object.entries@^1.0.4, object.entries@^1.1.0:
+object.entries@^1.0.4:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.1.0.tgz#2024fc6d6ba246aee38bdb0ffd5cfbcf371b7519"
   integrity sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==
@@ -5020,11 +4917,6 @@ osenv@^0.1.4:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
 
-p-cancelable@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-1.1.0.tgz#d078d15a3af409220c886f1d9a0ca2e441ab26cc"
-  integrity sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==
-
 p-defer@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-defer/-/p-defer-1.0.0.tgz#9f6eb182f6c9aa8cd743004a7d4f96b196b0fb0c"
@@ -5075,22 +4967,10 @@ p-locate@^3.0.0:
   dependencies:
     p-limit "^2.0.0"
 
-p-queue@^2.4.2:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/p-queue/-/p-queue-2.4.2.tgz#03609826682b743be9a22dba25051bd46724fc34"
-  integrity sha512-n8/y+yDJwBjoLQe1GSJbbaYQLTI7QHNZI2+rpmCDbe++WLf9HC3gf6iqj5yfPAV71W4UF3ql5W1+UBPXoXTxng==
-
 p-reduce@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-reduce/-/p-reduce-1.0.0.tgz#18c2b0dd936a4690a529f8231f58a0fdb6a47dfa"
   integrity sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=
-
-p-retry@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/p-retry/-/p-retry-3.0.1.tgz#316b4c8893e2c8dc1cfa891f406c4b422bebf328"
-  integrity sha512-XE6G4+YTTkT2a0UWb2kjZe8xNwf8bIbnqpc/IS/idOBVhyves0mK5OJgeocjx7q5pvX/6m23xuzVPYT1uGM73w==
-  dependencies:
-    retry "^0.12.0"
 
 p-try@^1.0.0:
   version "1.0.0"
@@ -6144,11 +6024,6 @@ ret@~0.1.10:
   version "0.1.15"
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
-
-retry@^0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
-  integrity sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=
 
 rgb-regex@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Add `style` prop to `<Button>` component to support decorated button. It resolves #13.

`@slack/types` type definition package, from Slack Node SDK, is not yet supported `style` field for the button. I think I should feedback to `@slack/types`, but currently we are using workaround by the extended type.

> It includes update of devDependencies to fix blocked CI by audit of vulnerability, and change of using RegExp instead of `trimRight()` to fix TypeScript compile error.