### PR TITLE
Allow links in the inside of code and pre element

### DIFF
--- a/src/html.tsx
+++ b/src/html.tsx
@@ -35,8 +35,7 @@ export const parse = (
     elements.some(e => parents.includes(e))
 
   if (name === 'br') return '<br />'
-  if (isInside('pre') || (isInside('code') && !['a', 'time'].includes(name)))
-    return text()
+  if (isInside('pre', 'code') && !['a', 'time'].includes(name)) return text()
 
   switch (name) {
     case 'b':

--- a/src/html.tsx
+++ b/src/html.tsx
@@ -35,7 +35,8 @@ export const parse = (
     elements.some(e => parents.includes(e))
 
   if (name === 'br') return '<br />'
-  if (isInside('code', 'pre')) return text()
+  if (isInside('pre') || (isInside('code') && !['a', 'time'].includes(name)))
+    return text()
 
   switch (name) {
     case 'b':

--- a/src/jsx.ts
+++ b/src/jsx.ts
@@ -30,8 +30,18 @@ export function JSXSlack(
     node.props.children || node.children || []
   )
 
-  const processString = (str: string, ctx: ParseContext) =>
-    ctx.mode !== ParseMode.HTML ? str : escapeEntity(str)
+  const processString = (str: string, ctx: ParseContext) => {
+    if (ctx.mode !== ParseMode.HTML) return str
+
+    const [currentElement] = ctx.elements.slice(-1)
+
+    if (['a', 'code', 'pre', 'time'].includes(currentElement)) {
+      // Escape ampersand forcely in code and elements expected to place in brackets
+      return escapeEntity(str.replace(/&(?!amp;)/g, '&amp;'))
+    }
+
+    return escapeEntity(str)
+  }
 
   const toArray = (nextCtx = context): any[] =>
     children.reduce(

--- a/src/turndown.ts
+++ b/src/turndown.ts
@@ -104,7 +104,9 @@ const turndownService = () => {
         node.firstChild.nodeName === 'CODE',
 
       replacement: (_, node: HTMLElement, opts) => {
+        // TODO: Preprocess the content of pre element to render link and time
         const pre = node.firstChild ? node.firstChild.textContent : ''
+
         const singleLine = node.parentNode && node.parentNode.nodeName === 'A'
         opts[preSymbol].push(pre)
 
@@ -244,7 +246,7 @@ const turndownService = () => {
         if (!datetime || !fallback) return ''
 
         const content = s.replace(/(?:(?:<br \/>)?\n)+/g, ' ').trim()
-        return `<!date^${datetime}^${content}|${fallback}>`
+        return `<!date^${datetime}^${content}|${td.escape(fallback)}>`
       },
     },
   }

--- a/test/html.tsx
+++ b/test/html.tsx
@@ -241,6 +241,26 @@ describe('HTML parser for mrkdwn', () => {
       expect(html(<code>｀code｀</code>)).toBe('`\u02cbcode\u02cb`')
     })
 
+    it('allows containing link by a tag', () => {
+      expect(
+        html(
+          <code>
+            <a href="https://example.com/">example</a>
+          </code>
+        )
+      ).toBe('`<https://example.com/|example>`')
+    })
+
+    it('allows containing time tag for localization', () => {
+      expect(
+        html(
+          <code>
+            <time datetime="1552212000">{'{date_num}'}</time>
+          </code>
+        )
+      ).toBe('`<!date^1552212000^{date_num}|2019-03-10>`')
+    })
+
     it('applies markup per each lines when code has multiline', () => {
       expect(
         html(

--- a/test/html.tsx
+++ b/test/html.tsx
@@ -245,10 +245,10 @@ describe('HTML parser for mrkdwn', () => {
       expect(
         html(
           <code>
-            <a href="https://example.com/">example</a>
+            <a href="https://example.com/">{'&lt;example&gt;'}</a>
           </code>
         )
-      ).toBe('`<https://example.com/|example>`')
+      ).toBe('`<https://example.com/|&lt;example&gt;>`')
 
       // Raw mrkdwn (Escaped brackets & JSX interpolation)
       expect(html(<code>&lt;#C01234567&gt;</code>)).toBe('`<#C01234567>`')
@@ -494,9 +494,11 @@ describe('HTML parser for mrkdwn', () => {
             <a href="https://example.com/">
               <b>Bold</b> link
             </a>
+            <br />
+            {'and plain\ntext'}
           </pre>
         )
-      ).toBe('```\n<https://example.com/|*Bold* link>\n```')
+      ).toBe('```\n<https://example.com/|*Bold* link>\nand plain\ntext\n```')
     })
   })
 
@@ -869,6 +871,16 @@ describe('HTML parser for mrkdwn', () => {
       ).toBe(
         '<!date^1552212000^by XXX \u01c0 {date_num}|by XXX \u01c0 2019-03-10>'
       )
+    })
+
+    it('escapes brackets in contents and fallback', () => {
+      expect(
+        html(
+          <time datetime={1552212000} fallback="<2019-03-10>">
+            {'&lt;{date_num}&gt;'}
+          </time>
+        )
+      ).toBe('<!date^1552212000^&lt;{date_num}&gt;|&lt;2019-03-10&gt;>')
     })
   })
 })

--- a/test/html.tsx
+++ b/test/html.tsx
@@ -241,7 +241,7 @@ describe('HTML parser for mrkdwn', () => {
       expect(html(<code>｀code｀</code>)).toBe('`\u02cbcode\u02cb`')
     })
 
-    it('allows containing link by a tag', () => {
+    it('allows containing link', () => {
       expect(
         html(
           <code>
@@ -249,6 +249,12 @@ describe('HTML parser for mrkdwn', () => {
           </code>
         )
       ).toBe('`<https://example.com/|example>`')
+
+      // Raw mrkdwn via JSX interpolation
+      expect(html(<code>{'<#C01234567>'}</code>)).toBe('`<#C01234567>`')
+
+      // Work escape correctly
+      expect(html(<code>&lt;!channel&gt;</code>)).toBe('`&lt;!channel&gt;`')
     })
 
     it('allows containing time tag for localization', () => {
@@ -259,6 +265,16 @@ describe('HTML parser for mrkdwn', () => {
           </code>
         )
       ).toBe('`<!date^1552212000^{date_num}|2019-03-10>`')
+
+      // Raw mrkdwn via JSX interpolation
+      expect(
+        html(<code>{'<!date^1552212000^{date_num}|2019-03-10>'}</code>)
+      ).toBe('`<!date^1552212000^{date_num}|2019-03-10>`')
+
+      // Work escape correctly
+      expect(
+        html(<code>{'&lt;!date^1552212000^{date_num}|2019-03-10&gt;'}</code>)
+      ).toBe('`&lt;!date^1552212000^{date_num}|2019-03-10&gt;`')
     })
 
     it('applies markup per each lines when code has multiline', () => {

--- a/test/html.tsx
+++ b/test/html.tsx
@@ -250,28 +250,39 @@ describe('HTML parser for mrkdwn', () => {
         )
       ).toBe('`<https://example.com/|example>`')
 
-      // Raw mrkdwn via JSX interpolation
+      // Raw mrkdwn (Escaped brackets & JSX interpolation)
+      expect(html(<code>&lt;#C01234567&gt;</code>)).toBe('`<#C01234567>`')
       expect(html(<code>{'<#C01234567>'}</code>)).toBe('`<#C01234567>`')
 
-      // Work escape correctly
-      expect(html(<code>&lt;!channel&gt;</code>)).toBe('`&lt;!channel&gt;`')
+      // Entity pass-thru via JSX interpolation
+      expect(html(<code>{'&lt;!channel&gt;'}</code>)).toBe('`&lt;!channel&gt;`')
     })
 
     it('allows containing time tag for localization', () => {
+      const expectedDate = '`<!date^1552212000^{date_num}|2019-03-10>`'
+
       expect(
         html(
           <code>
             <time datetime="1552212000">{'{date_num}'}</time>
           </code>
         )
-      ).toBe('`<!date^1552212000^{date_num}|2019-03-10>`')
+      ).toBe(expectedDate)
 
-      // Raw mrkdwn via JSX interpolation
+      // Raw mrkdwn (Escaped brackets & JSX interpolation)
+      expect(
+        html(
+          <code>
+            &lt;!date^1552212000^{'{'}date_num{'}'}|2019-03-10&gt;
+          </code>
+        )
+      ).toBe(expectedDate)
+
       expect(
         html(<code>{'<!date^1552212000^{date_num}|2019-03-10>'}</code>)
-      ).toBe('`<!date^1552212000^{date_num}|2019-03-10>`')
+      ).toBe(expectedDate)
 
-      // Work escape correctly
+      // Entity pass-thru via JSX interpolation
       expect(
         html(<code>{'&lt;!date^1552212000^{date_num}|2019-03-10&gt;'}</code>)
       ).toBe('`&lt;!date^1552212000^{date_num}|2019-03-10&gt;`')
@@ -466,6 +477,27 @@ describe('HTML parser for mrkdwn', () => {
           </s>
         )
       ).toBe('&gt; ~strikethrough and~\n&gt; ```\nquoted\ntext\n```\n&gt;'))
+
+    it('allows containing link', () => {
+      expect(
+        html(
+          <pre>
+            <a href="https://example.com/">example</a>
+          </pre>
+        )
+      ).toBe('```\n<https://example.com/|example>\n```')
+
+      // with format
+      expect(
+        html(
+          <pre>
+            <a href="https://example.com/">
+              <b>Bold</b> link
+            </a>
+          </pre>
+        )
+      ).toBe('```\n<https://example.com/|*Bold* link>\n```')
+    })
   })
 
   describe('List', () => {


### PR DESCRIPTION
Until now, `<a>` tag in the inside of `<code>` and `<pre>` won't recognize as link. It is the correct behavior in regular Markdown's backtick(s), but not in Slack mrkdwn format and regular HTML. It allows link format `<xxx|xxx>` in the inside of inline code and fence.

For consistent HTML element support, we would require to change behavior as these:

- Children in `<code>` and `<pre>` allow `<a>` tag and `<time>` tag.

```jsx
<code><a href="https://example.com/">example</a></code>
<pre><a href="https://example.com/">example</a></pre>
```

<img width="677" alt="スクリーンショット 2019-04-25 18 28 45" src="https://user-images.githubusercontent.com/3993388/56725542-021a4500-6788-11e9-85e6-b5b2acb00c8c.png">


- The raw mrkdwn still supports the link in code: `` `Hello, <https://www.example.com/|example>.`  `` (Requires JSX string interpolation)
- Use `&lt;` and `&gt;` via interpolation explicitly to escape link format.

