### PR TITLE
Fix vanishing styled channel links and mentions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix vanishing styled channel links and mentions ([#15](https://github.com/speee/jsx-slack/issues/15), [#17](https://github.com/speee/jsx-slack/pull/17))
+
 ## v0.4.2 - 2019-04-13
 
 ### Added

--- a/src/html.tsx
+++ b/src/html.tsx
@@ -1,9 +1,7 @@
 /** @jsx JSXSlack.h */
 import formatDate from './date'
 import { JSXSlack, ParseContext } from './jsx'
-import { Html } from './utils'
-
-const spLinkMatcher = /^((#C|@[US])[A-Z0-9]{8}|@(here|channel|everyone))$/
+import { Html, detectSpecialLink } from './utils'
 
 export const escapeEntity = (str: string) =>
   str
@@ -81,8 +79,8 @@ export const parse = (
       let content = text()
 
       // Prevent vanishing special link used as void element
-      if (!content && props.href && spLinkMatcher.test(props.href))
-        content = 'sp'
+      if (!content && props.href && detectSpecialLink(props.href) !== undefined)
+        content = 'specialLink'
 
       return `<a${buildAttr(props)}>${content}</a>`
     }

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -1,6 +1,17 @@
 /** @jsx JSXSlack.h */
 import { JSXSlack } from './jsx'
 
+export enum SpecialLink {
+  ChannelMention,
+  EveryoneMention,
+  HereMention,
+  PublicChannel,
+  UserGroupMention,
+  UserMention,
+}
+
+const spLinkMatcher = /^(#C|@U|@S)[A-Z0-9]{8}$/
+
 export function ArrayOutput<P = any>(props: {
   children: JSXSlack.Children<P>
 }) {
@@ -21,4 +32,19 @@ export function wrap<T>(children: T | T[]): T[] {
   if (children) return [children]
 
   return []
+}
+
+export function detectSpecialLink(href: string): SpecialLink | undefined {
+  if (href === '@channel') return SpecialLink.ChannelMention
+  if (href === '@everyone') return SpecialLink.EveryoneMention
+  if (href === '@here') return SpecialLink.HereMention
+
+  const matched = href.match(spLinkMatcher)
+  if (matched) {
+    if (matched[1] === '#C') return SpecialLink.PublicChannel
+    if (matched[1] === '@S') return SpecialLink.UserGroupMention
+    if (matched[1] === '@U') return SpecialLink.UserMention
+  }
+
+  return undefined
 }

--- a/test/html.tsx
+++ b/test/html.tsx
@@ -648,6 +648,13 @@ describe('HTML parser for mrkdwn', () => {
       expect(html(<a href="#CWXYZ9876">Ignore contents</a>)).toBe(
         '<#CWXYZ9876>'
       )
+      expect(
+        html(
+          <b>
+            <a href="#C0123ABCD" />
+          </b>
+        )
+      ).toBe('*<#C0123ABCD>*')
     })
 
     it('converts to user mention when referenced user ID', () => {
@@ -655,6 +662,13 @@ describe('HTML parser for mrkdwn', () => {
       expect(html(<a href="@UWXYZ9876">Ignore contents</a>)).toBe(
         '<@UWXYZ9876>'
       )
+      expect(
+        html(
+          <i>
+            <a href="@U0123ABCD" />
+          </i>
+        )
+      ).toBe('_<@U0123ABCD>_')
     })
 
     it('converts to user group mention when referenced subteam ID', () => {
@@ -662,6 +676,13 @@ describe('HTML parser for mrkdwn', () => {
       expect(html(<a href="@SWXYZ9876">Ignore contents</a>)).toBe(
         '<!subteam^SWXYZ9876>'
       )
+      expect(
+        html(
+          <s>
+            <a href="@S0123ABCD" />
+          </s>
+        )
+      ).toBe('~<!subteam^S0123ABCD>~')
     })
 
     it('converts special mentions', () => {
@@ -669,6 +690,13 @@ describe('HTML parser for mrkdwn', () => {
       expect(html(<a href="@channel" />)).toBe('<!channel|channel>')
       expect(html(<a href="@everyone" />)).toBe('<!everyone|everyone>')
       expect(html(<a href="@here">Ignore contents</a>)).toBe('<!here|here>')
+      expect(
+        html(
+          <code>
+            <a href="@here" />
+          </code>
+        )
+      ).toBe('`<!here|here>`')
     })
   })
 

--- a/test/html.tsx
+++ b/test/html.tsx
@@ -692,11 +692,13 @@ describe('HTML parser for mrkdwn', () => {
       expect(html(<a href="@here">Ignore contents</a>)).toBe('<!here|here>')
       expect(
         html(
-          <code>
-            <a href="@here" />
-          </code>
+          <b>
+            <i>
+              <a href="@here" />
+            </i>
+          </b>
         )
-      ).toBe('`<!here|here>`')
+      ).toBe('*_<!here|here>_*')
     })
   })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3060,9 +3060,9 @@ growly@^1.3.0:
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
 handlebars@^4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.1.1.tgz#6e4e41c18ebe7719ae4d38e5aca3d32fa3dd23d3"
-  integrity sha512-3Zhi6C0euYZL5sM0Zcy7lInLXKQ+YLcF/olbN010mzGQ4XVm50JeyBnMqofHh696GrciGruC7kCcApPDJvVgwA==
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.1.2.tgz#b6b37c1ced0306b221e094fc7aca3ec23b131b67"
+  integrity sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==
   dependencies:
     neo-async "^2.6.0"
     optimist "^0.6.1"


### PR DESCRIPTION
Fixes #15. jsx-slack would fill a dummy content if detected Slack's special links in `<a>` tag to prevent filtering by turndown's [blank rule](https://github.com/domchristie/turndown#special-rules).