### PR TITLE
Remove deprecated <Block> component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Make interchangeable with `<Image>` component and intrinsic `<img>` tag ([#21](https://github.com/speee/jsx-slack/pull/21))
 
+### Removed
+
+- Remove deprecated `<Block>` component ([#22](https://github.com/speee/jsx-slack/pull/22))
+
 ## v0.4.3 - 2019-05-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -137,8 +137,6 @@ It would post a simple Slack message like this:
 
 A container component to use Block Kit. You should wrap Block Kit elements by `<Blocks>`.
 
-> :warning: A confusable `<Block>` component has deprecated in v0.4.1. See also [#11](https://github.com/speee/jsx-slack/issues/11).
-
 #### [`<Section>`: Section Block](https://api.slack.com/reference/messaging/blocks#section)
 
 Display a simple text message. You have to specify the content as children. It allows [formatting with HTML-like elements](#html-like-formatting).

--- a/src/block-kit/Blocks.tsx
+++ b/src/block-kit/Blocks.tsx
@@ -37,21 +37,3 @@ export const Blocks: JSXSlack.FC<BlocksProps> = props => {
 
   return <ArrayOutput>{normalized}</ArrayOutput>
 }
-
-/**
- * @deprecated `BlockProps` has been deprecated. Please use `BlocksProps`
- *             instead.
- */
-export type BlockProps = BlocksProps
-
-/**
- * @deprecated A confusable `<Block>` component has been deprecated and would
- *             remove shortly. Please use `<Blocks>` instead.
- */
-export const Block: JSXSlack.FC<BlockProps> = props => {
-  console.warn(
-    'Deprecation warning: A confusable <Block> component has been deprecated and would remove shortly. Please use <Blocks> instead.'
-  )
-
-  return Blocks(props)
-}

--- a/src/block-kit/index.ts
+++ b/src/block-kit/index.ts
@@ -1,5 +1,5 @@
 // Block container
-export { Blocks, Block } from './Blocks'
+export { Blocks } from './Blocks'
 
 // Block Kit blocks
 export { Actions } from './Actions'


### PR DESCRIPTION
It's a time to remove deprecated `<Block>` component in #12. If you are seeing this PR and still have using `<Block>`, please migrate to use `<Blocks>`. 🥺