### PR TITLE
Support mention to global user ID for Enterprise Grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Support mention to global user ID for Enterprise Grid ([#25](https://github.com/speee/jsx-slack/pull/25))
+
 ## v0.5.0 - 2019-06-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -624,7 +624,7 @@ If defined what except URL as `href` attribute, _you cannot use a custom content
 
 #### Mention to user and user group
 
-As like as channel link, `<a href="@U024BE7LH" />` means a mention to specified user.
+As like as channel link, `<a href="@U024BE7LH" />` (and `<a href="@W41S032FC" />` for [Enterprise Grid](https://api.slack.com/enterprise-grid#user_ids)) means a mention to specified user.
 
 jsx-slack can mention to user groups with a same syntax `<a href="@SAZ94GDB8" />` by detecting user group ID prefixed `S`.
 

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -10,7 +10,7 @@ export enum SpecialLink {
   UserMention,
 }
 
-const spLinkMatcher = /^(#C|@U|@S)[A-Z0-9]{8}$/
+const spLinkMatcher = /^(#C|@[SUW])[A-Z0-9]{8}$/
 
 export function ArrayOutput<P = any>(props: {
   children: JSXSlack.Children<P>
@@ -43,7 +43,8 @@ export function detectSpecialLink(href: string): SpecialLink | undefined {
   if (matched) {
     if (matched[1] === '#C') return SpecialLink.PublicChannel
     if (matched[1] === '@S') return SpecialLink.UserGroupMention
-    if (matched[1] === '@U') return SpecialLink.UserMention
+    if (matched[1] === '@U' || matched[1] === '@W')
+      return SpecialLink.UserMention
   }
 
   return undefined

--- a/test/html.tsx
+++ b/test/html.tsx
@@ -659,6 +659,7 @@ describe('HTML parser for mrkdwn', () => {
 
     it('converts to user mention when referenced user ID', () => {
       expect(html(<a href="@U0123ABCD" />)).toBe('<@U0123ABCD>')
+      expect(html(<a href="@WGLOBALID" />)).toBe('<@WGLOBALID>')
       expect(html(<a href="@UWXYZ9876">Ignore contents</a>)).toBe(
         '<@UWXYZ9876>'
       )


### PR DESCRIPTION
Slack treats user ID beginning with `W` as a global user id for Enterprise Grid. In fact, Slack tries to parse not only the string like `<@U00000000>` but also `<@W00000000>`.

<img width="1152" alt="mentions" src="https://user-images.githubusercontent.com/3993388/60481596-f89de380-9cc8-11e9-9683-f684f4f2e6d6.png">

Since jsx-slack has only supported user id starting with `U`, we cannot parse `<a href="@W00000000" />` correctly. Thus, I've added the support of global user ID starting with `W`.