### PR TITLE
Get rid of vulnerability from deep deps

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -6225,9 +6225,9 @@ safe-regex@^1.1.0:
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
 safer-eval@^1.3.0:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/safer-eval/-/safer-eval-1.3.3.tgz#0309e9fcc0609e66c1b599fd0d4772132b260ca8"
-  integrity sha512-j/qb0rtnwTp5V1D7nR0Ns/14HU8OiHPaoZNJhM+Lfmv1nbXZCXG9LHaVW157agEocdSVAeeRNddK/yuWfalzGQ==
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/safer-eval/-/safer-eval-1.3.5.tgz#a75a1193a4e1dfadd34a8c87ad08e7b978c494b1"
+  integrity sha512-BJ//K2Y+EgCbOHEsDGS5YahYBcYy7JcFpKDo2ba5t4MnOGHYtk7HvQkcxTDFvjQvJ0CRcdas/PyF+gTTCay+3w==
   dependencies:
     clones "^1.2.0"
 


### PR DESCRIPTION
CI testing on #29 is blocked by a vulnerability from `safer-eval` v1.3.3.

```
yarn audit v1.15.2
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ high          │ Sandbox Breakout / Arbitrary Code Execution                  │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ safer-eval                                                   │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=1.3.4                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ parcel                                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ parcel > serialize-to-js > safer-eval                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/1021                        │
└───────────────┴──────────────────────────────────────────────────────────────┘
1 vulnerabilities found - Packages audited: 882357
Severity: 1 High
Done in 2.51s.
```