### PR TITLE
Convert <span> in <Context> into mrkdwn element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Convert `<span>` in `<Context>` into mrkdwn element ([#26](https://github.com/speee/jsx-slack/issues/26), [#31](https://github.com/speee/jsx-slack/pull/31))
 - `<Fragment>` built-in component ([#29](https://github.com/speee/jsx-slack/pull/29))
 
 ## v0.5.1 - 2019-07-14

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ A block to hold [interactive elements](#interactive-elements). Slack allows a ma
 
 #### [`<Context>`: Context Block](https://api.slack.com/reference/messaging/blocks#context)
 
-Display message context. It allows mixed contents consisted of the text and the `<Image>` component / `<img>` tag.
+Display message context. It allows mixed contents consisted of texts and `<Image>` components / `<img>` tags.
 
 ```jsx
 <Blocks>
@@ -274,7 +274,26 @@ Display message context. It allows mixed contents consisted of the text and the 
 
 [<img src="https://raw.githubusercontent.com/speee/jsx-slack/master/docs/preview-btn.svg?sanitize=true" width="240" />](https://api.slack.com/tools/block-kit-builder?blocks=%5B%7B%22type%22%3A%22context%22%2C%22elements%22%3A%5B%7B%22type%22%3A%22image%22%2C%22image_url%22%3A%22https%3A%2F%2Fplacekitten.com%2F100%2F100%22%2C%22alt_text%22%3A%22Kitten%22%7D%2C%7B%22type%22%3A%22mrkdwn%22%2C%22text%22%3A%22A%20kitten%20and%22%2C%22verbatim%22%3Atrue%7D%2C%7B%22type%22%3A%22image%22%2C%22image_url%22%3A%22https%3A%2F%2Fplacekitten.com%2F100%2F100%22%2C%22alt_text%22%3A%22Kitten%22%7D%2C%7B%22type%22%3A%22mrkdwn%22%2C%22text%22%3A%22more%20kitten.%22%2C%22verbatim%22%3Atrue%7D%5D%7D%5D)
 
-> :warning: Slack restricts the number of elements consisted of text content and image up to 10. jsx-slack throws error if the number of generated elements is going over the limit.
+Text contents will merge in pertinent mrkdwn elements automatically, but they also may divide clearly by using `<span>` HTML intrinsic element.
+
+```jsx
+<Blocks>
+  <Context>
+    <span>
+      ◤<br />◤<br />◤
+    </span>
+    <span>
+      ◤<br />◤
+    </span>
+    <span>◤</span>
+    multiple mrkdwns
+  </Context>
+</Blocks>
+```
+
+[<img src="https://raw.githubusercontent.com/speee/jsx-slack/master/docs/preview-btn.svg?sanitize=true" width="240" />](https://api.slack.com/tools/block-kit-builder?blocks=%5B%7B%22type%22%3A%22context%22%2C%22elements%22%3A%5B%7B%22type%22%3A%22mrkdwn%22%2C%22text%22%3A%22%E2%97%A4%5Cn%E2%97%A4%5Cn%E2%97%A4%22%2C%22verbatim%22%3Atrue%7D%2C%7B%22type%22%3A%22mrkdwn%22%2C%22text%22%3A%22%E2%97%A4%5Cn%E2%97%A4%22%2C%22verbatim%22%3Atrue%7D%2C%7B%22type%22%3A%22mrkdwn%22%2C%22text%22%3A%22%E2%97%A4%22%2C%22verbatim%22%3Atrue%7D%2C%7B%22type%22%3A%22mrkdwn%22%2C%22text%22%3A%22multiple%20mrkdwns%22%2C%22verbatim%22%3Atrue%7D%5D%7D%5D)
+
+> :warning: Slack restricts the number of elements consisted of text contents and images up to 10. jsx-slack throws an error if the number of generated elements is going over the limit.
 
 ##### Props
 

--- a/demo/schema.js
+++ b/demo/schema.js
@@ -84,7 +84,7 @@ export default {
   Actions: { attrs: blockCommonAttrs, children: interactiveComponents },
   Context: {
     attrs: blockCommonAttrs,
-    children: ['Image', 'img', ...markupHTML],
+    children: ['Image', 'img', 'span', ...markupHTML],
   },
 
   // Interactive components
@@ -187,6 +187,7 @@ export default {
       t => t !== 's' && t !== 'strike' && t !== 'del'
     ),
   },
+  span: { attrs: {}, children: markupHTML },
   strike: {
     attrs: {},
     children: markupHTML.filter(

--- a/src/html.tsx
+++ b/src/html.tsx
@@ -99,6 +99,7 @@ export const parse = (
 
       return `<time${attrs}>${format}</time>`
     }
+    case 'span':
     case 'ul':
     case 'li':
       return `<${name}>${text()}</${name}>`

--- a/src/jsx.ts
+++ b/src/jsx.ts
@@ -158,6 +158,7 @@ export namespace JSXSlack {
       pre: {}
       s: {}
       section: { id?: string; children: Children<any> }
+      span: {}
       strike: {}
       strong: {}
       time: {

--- a/src/turndown.ts
+++ b/src/turndown.ts
@@ -36,7 +36,7 @@ const turndownService = () => {
 
   let uniqId = 0
 
-  const elmUniqId = (target: HTMLElement) => {
+  const elmUniqId = () => {
     // eslint-disable-next-line no-plusplus
     elmUniqId[uniqIdSymbol] = elmUniqId[uniqIdSymbol] || ++uniqId
 
@@ -56,7 +56,7 @@ const turndownService = () => {
         breaks = ['', '\n']
         processed = processed
           .split('\n')
-          .map(l => `<<list-indent:${elmUniqId(node)}>>${l}`)
+          .map(l => `<<list-indent:${elmUniqId()}>>${l}`)
           .join('\n')
       }
     }
@@ -122,7 +122,7 @@ const turndownService = () => {
           .replace(/\n+$/, '\n') // replace trailing newlines with just a single one
 
         const parent = node.parentNode as HTMLElement
-        let prefix = `<<list-bullet:${elmUniqId(parent)}>>`
+        let prefix = `<<list-bullet:${elmUniqId()}>>`
 
         if (parent && parent.nodeName === 'OL') {
           // Get the number of order
@@ -141,12 +141,12 @@ const turndownService = () => {
             number.toString().length
           )
 
-          prefix = `<<list-number:${elmUniqId(parent)}:${number}>>`
+          prefix = `<<list-number:${elmUniqId()}:${number}>>`
         }
 
         return [
           prefix,
-          content.replace(/\n/g, `\n<<list-indent:${elmUniqId(parent)}>>`),
+          content.replace(/\n/g, `\n<<list-indent:${elmUniqId()}>>`),
           node.nextSibling && !/\n$/.test(content) ? '\n' : '',
         ]
           .join('')
@@ -168,13 +168,13 @@ const turndownService = () => {
           ul,
           s
             .replace(
-              new RegExp(`<<list-bullet:${elmUniqId(ul)}>>`, 'g'),
+              new RegExp(`<<list-bullet:${elmUniqId()}>>`, 'g'),
               `${
                 bulletListMarkers[Math.min(level, bulletListMarkers.length - 1)]
               } `
             )
             .replace(
-              new RegExp(`<<list-indent:${elmUniqId(ul)}>>`, 'g'),
+              new RegExp(`<<list-indent:${elmUniqId()}>>`, 'g'),
               '\u2007 '
             )
         )
@@ -187,11 +187,11 @@ const turndownService = () => {
           ol,
           s
             .replace(
-              new RegExp(`<<list-number:${elmUniqId(ol)}:(\\d+)>>`, 'g'),
+              new RegExp(`<<list-number:${elmUniqId()}:(\\d+)>>`, 'g'),
               (_, n: string) => `${n.padStart(ol[olDigitsSymbol], '\u2007')}. `
             )
             .replace(
-              new RegExp(`<<list-indent:${elmUniqId(ol)}>>`, 'g'),
+              new RegExp(`<<list-indent:${elmUniqId()}>>`, 'g'),
               `${'\u2007'.repeat(ol[olDigitsSymbol])}  `
             )
         ),

--- a/test/index.tsx
+++ b/test/index.tsx
@@ -781,6 +781,35 @@ describe('jsx-slack', () => {
           },
         ]))
 
+      it('converts <span> elements into mrkdwn elements', () =>
+        expect(
+          JSXSlack(
+            <Blocks>
+              <Context>
+                <span>
+                  <b>A</b>
+                </span>
+                B<br />C<span>D</span>
+                <span>
+                  E <i>F</i> G
+                </span>
+                H
+              </Context>
+            </Blocks>
+          )
+        ).toStrictEqual([
+          {
+            type: 'context',
+            elements: [
+              { type: 'mrkdwn', text: '*A*', verbatim: true },
+              { type: 'mrkdwn', text: 'B\nC', verbatim: true },
+              { type: 'mrkdwn', text: 'D', verbatim: true },
+              { type: 'mrkdwn', text: 'E _F_ G', verbatim: true },
+              { type: 'mrkdwn', text: 'H', verbatim: true },
+            ],
+          },
+        ]))
+
       it('throws error when the number of elements is 11', () =>
         expect(() =>
           JSXSlack(


### PR DESCRIPTION
For holding multiple mrkdwn elements as the contents of `<Context>`, we will convert `<span>` in `<Context>` into mrkdwn element.

```jsx
<Blocks>
  <Context>
    <span>◤<br />◤<br />◤</span>
    <span>◤<br />◤</span>
    <span>◤</span>
    multiple mrkdwns
  </Context>
</Blocks>
```

```json
[
  {
    "type": "context",
    "elements": [
      {
        "type": "mrkdwn",
        "text": "◤\n◤\n◤",
        "verbatim": true
      },
      {
        "type": "mrkdwn",
        "text": "◤\n◤",
        "verbatim": true
      },
      {
        "type": "mrkdwn",
        "text": "◤",
        "verbatim": true
      },
      {
        "type": "mrkdwn",
        "text": "multiple mrkdwns",
        "verbatim": true
      }
    ]
  }
]
```

![context](https://user-images.githubusercontent.com/3993388/61549330-b6c3ba00-aa8a-11e9-8f98-a78935165541.png)

This rendering result is very similar with below HTML.

```html
<div style="display:flex;">
  <span>◤<br />◤<br />◤</span>
  <span>◤<br />◤</span>
  <span>◤</span>
  multiple mrkdwns
</div>
```

It's easy to recognize in JSX by dealing with `<Context>` as flex container. Resolves #26.