### PR TITLE
jsxslack.fragment for template literal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `jsxslack.fragment` template literal tag ([#32](https://github.com/speee/jsx-slack/pull/32))
+
 ## v0.6.0 - 2019-07-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ export default function exampleBlock({ name }) {
 
 A prgama would work in Babel ([@babel/plugin-transform-react-jsx](https://babeljs.io/docs/en/babel-plugin-transform-react-jsx)) and [TypeScript with `--jsx react`](https://www.typescriptlang.org/docs/handbook/jsx.html#factory-functions). You can use jsx-slack in either one.
 
+> :bulb: In Babel, you can set [an extra pragma comment for using fragment syntax](#short-syntax-for-babel-transpiler) too.
+
 #### Template literal
 
 A much simpler way to build blocks is using **`jsxslack`** tagged template literal.
@@ -101,6 +103,8 @@ export default function exampleBlock({ name }) {
   `
 }
 ```
+
+> :bulb: We also provide `jsxslack.fragment` tag for defining higher-order component (HOC) and custom block.
 
 #### Use template in Slack API
 
@@ -605,7 +609,7 @@ Now the defined block can use in `<Blocks>` as like as the other blocks:
 
 #### Short syntax for Babel transpiler
 
-If you want to use [the short syntax `<></>` for fragments](https://reactjs.org/docs/fragments.html#short-syntax) in Babel transpiler, we recommend to set [additional pragma `/** @jsxFrag JSXSlack.Fragment */` ](https://babeljs.io/docs/en/babel-plugin-transform-react-jsx#custom-1).
+If you want to use [the short syntax `<></>` for fragments](https://reactjs.org/docs/fragments.html#short-syntax) in Babel transpiler, we recommend to set [an extra pragma command `/** @jsxFrag JSXSlack.Fragment */`](https://babeljs.io/docs/en/babel-plugin-transform-react-jsx#custom-1).
 
 ```javascript
 /** @jsx JSXSlack.h */
@@ -623,6 +627,43 @@ const Header = ({ children }) => (
 ```
 
 > :warning: TypeScript cannot customize the factory method for fragment syntax. ([Microsoft/TypeScript#20469](https://github.com/Microsoft/TypeScript/issues/20469)) Please use `<Fragment>` component as usual.
+
+#### `jsxslack.fragment` template literal tag
+
+You should use `jsxslack.fragment` template literal tag instead of `jsxslack` when you want to create HOC or custom block with prefering template literal to JSX transpiler.
+
+```javascript
+// Header.js
+import { jsxslack } from '@speee-js/jsx-slack'
+
+const Header = ({ children }) => jsxslack.fragment`
+  <Section>
+    <b>${children}</b>
+  </Section>
+  <Divider />
+`
+export default Header
+```
+
+`<Fragment>` built-in component does not have to use because [the parser allows multiple elements on the root.](https://github.com/developit/htm#improvements-over-jsx)
+
+A defined component may use in `jsxslack` tag as below:
+
+```javascript
+import { jsxslack } from '@speee-js/jsx-slack'
+import Header from './Header'
+
+console.log(jsxslack`
+  <Blocks>
+    <${Header}>
+      <i>jsx-slack custom block</i> :sunglasses:
+    <//>
+    <Section>Let's build your block.</Section>
+  </Blocks>
+`)
+```
+
+Please notice to a usage of component that has a bit different syntax from JSX.
 
 ## HTML-like formatting
 

--- a/src/tag.ts
+++ b/src/tag.ts
@@ -2,7 +2,12 @@ import htm from 'htm'
 import * as components from './components'
 import { JSXSlack } from './index'
 
-const parse = htm.bind((type, props, ...children) => {
+type JSXSlackTemplate = (
+  template: TemplateStringsArray,
+  ...substitutions: any[]
+) => any
+
+const parse: JSXSlackTemplate = htm.bind((type, props, ...children) => {
   let elm = type
 
   // Support built-in components without import
@@ -16,6 +21,9 @@ const parse = htm.bind((type, props, ...children) => {
   return JSXSlack.h(elm, props, ...children)
 })
 
-export default function jsxslack(...args) {
-  return JSXSlack(parse(...args))
-}
+const jsxslack = (template: TemplateStringsArray, ...substitutions: any[]) =>
+  JSXSlack(parse(template, ...substitutions))
+
+jsxslack.fragment = parse
+
+export default jsxslack

--- a/src/tag.ts
+++ b/src/tag.ts
@@ -7,6 +7,10 @@ type JSXSlackTemplate = (
   ...substitutions: any[]
 ) => any
 
+interface JSXSlackTemplateTag extends JSXSlackTemplate {
+  readonly fragment: JSXSlackTemplate
+}
+
 const parse: JSXSlackTemplate = htm.bind((type, props, ...children) => {
   let elm = type
 
@@ -21,9 +25,11 @@ const parse: JSXSlackTemplate = htm.bind((type, props, ...children) => {
   return JSXSlack.h(elm, props, ...children)
 })
 
-const jsxslack = (template: TemplateStringsArray, ...substitutions: any[]) =>
-  JSXSlack(parse(template, ...substitutions))
-
-jsxslack.fragment = parse
+const jsxslack: JSXSlackTemplateTag = Object.defineProperty(
+  (template: TemplateStringsArray, ...substitutions: any[]) =>
+    JSXSlack(parse(template, ...substitutions)),
+  'fragment',
+  { value: parse }
+)
 
 export default jsxslack

--- a/test/tag.tsx
+++ b/test/tag.tsx
@@ -5,6 +5,7 @@ import JSXSlack, {
   Blocks,
   Button,
   Divider,
+  Fragment,
   Image,
   Section,
 } from '../src/index'
@@ -43,5 +44,43 @@ describe('Tagged template', () => {
         </Blocks>
       )
     )
+  })
+
+  describe('jsxslack.fragment', () => {
+    it('returns raw nodes for reusable as component', () => {
+      const func = title => jsxslack.fragment`
+        <Section><b>${title}</b></Section>
+        <Divider />
+      `
+
+      expect(func('test')).toStrictEqual(
+        <Fragment>
+          <Section>
+            <b>test</b>
+          </Section>
+          <Divider />
+        </Fragment>
+      )
+
+      const Component = ({ children }) => jsxslack.fragment`
+        <Section><b>${children}</b></Section>
+        <Divider />
+      `
+
+      expect(jsxslack`<Blocks><${Component}>Hello<//></Blocks>`).toStrictEqual(
+        JSXSlack(
+          <Blocks>
+            <Section>
+              <b>Hello</b>
+            </Section>
+            <Divider />
+          </Blocks>
+        )
+      )
+
+      expect(jsxslack.fragment`<${Component}>test<//>`).toStrictEqual(
+        func('test')
+      )
+    })
   })
 })


### PR DESCRIPTION
#29 allows `<Fragment>` for placing fragments (HOC and custom block) in JSX. In the other hand, `jsxslack` template literal cannot define HOC because it converts template string into Block Kit JSON directly by internally calling `JSXSlack` function. Thus, we should provide a new tag with returning virtual Node object (`JSX.Element`) to allow defining component in template literal.

An added `jsxslack.fragment` returns `JSX.Element` and can define HOC / custom block without setup the JSX transpiler. Its usage is as like as `<Fragment>` built-in tag.

```javascript
import { jsxslack } from '@speee-js/jsx-slack'

const Header = ({ children }) => jsxslack.fragment`
  <Section><b>{children}</b></Section>
  <Divider />
`
```

Actually `<Fragment>` built-in tag does not have to use because [HTM parser can parse multiple tags on the root by default](https://github.com/developit/htm#improvements-over-jsx).

### ToDo

- [x] Update README.md