### PR TITLE
Improve html entity decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Breaking
+
+- Disabled heuristic detection for HTML entities ([#33](https://github.com/speee/jsx-slack/pull/33))
+- Some special characters for mrkdwn link will always escape to entities ([#45](https://github.com/speee/jsx-slack/issues/45))
+
+### Changed
+
+- Improve html entity decoding in JSX and template literal tag ([#33](https://github.com/speee/jsx-slack/pull/33), [#45](https://github.com/speee/jsx-slack/issues/45))
+
 ## v0.8.1 - 2019-08-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking
 
-- Disabled heuristic detection for HTML entities (Now escaping works [just like JSX](https://reactjs.org/docs/jsx-in-depth.html#string-literals)) ([#33](https://github.com/speee/jsx-slack/pull/33))
+- Disabled heuristic detection for HTML entities (Escaping works [just as same as React JSX](https://reactjs.org/docs/jsx-in-depth.html#string-literals)) ([#33](https://github.com/speee/jsx-slack/pull/33))
 - Some raw characters for mrkdwn link, `<`, `>`, and `&` will always escape to entities ([#45](https://github.com/speee/jsx-slack/issues/45))
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Breaking
 
-- Disabled heuristic detection for HTML entities ([#33](https://github.com/speee/jsx-slack/pull/33))
-- Some special characters for mrkdwn link will always escape to entities ([#45](https://github.com/speee/jsx-slack/issues/45))
+- Disabled heuristic detection for HTML entities (Now escaping works [just like JSX](https://reactjs.org/docs/jsx-in-depth.html#string-literals)) ([#33](https://github.com/speee/jsx-slack/pull/33))
+- Some raw characters for mrkdwn link, `<`, `>`, and `&` will always escape to entities ([#45](https://github.com/speee/jsx-slack/issues/45))
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
   },
   "dependencies": {
     "@slack/types": "^1.1.0",
+    "he": "^1.2.0",
     "htm": "^2.2.0",
     "lodash.flatten": "^4.4.0",
     "turndown": "^5.0.3"

--- a/src/html.tsx
+++ b/src/html.tsx
@@ -5,7 +5,7 @@ import { Html, detectSpecialLink } from './utils'
 
 export const escapeEntity = (str: string) =>
   str
-    .replace(/&(?!(?:amp|lt|gt);)/g, '&amp;')
+    .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
 

--- a/src/tag.ts
+++ b/src/tag.ts
@@ -1,3 +1,5 @@
+/* eslint-disable no-new-wrappers */
+import he from 'he'
 import htm from 'htm'
 import * as blockKitComponents from './components'
 import * as dialogComponents from './dialog/components'
@@ -18,8 +20,30 @@ interface VirtualNode {
   children: any[]
 }
 
+const stringSubsitutionSymbol = Symbol('jsxslackStringSubsitution')
+
+const isString = (value: any): value is string =>
+  Object.prototype.toString.call(value) === '[object String]'
+
+const normalize = (value: any, isAttributeValue: boolean = false) => {
+  if (isString(value)) {
+    if (value[stringSubsitutionSymbol]) return value.toString()
+    return he.decode(value, { isAttributeValue })
+  }
+  return value
+}
+
 const firstPass: JSXSlackTemplate<VirtualNode | VirtualNode[]> = htm.bind(
-  (e, props, ...children): VirtualNode => ({ e, props, children })
+  (e, props, ...children): VirtualNode => ({
+    e: normalize(e),
+    props: props
+      ? Object.keys(props).reduce(
+          (prps, key) => ({ ...prps, [key]: normalize(props[key], true) }),
+          {}
+        )
+      : props,
+    children: children.map(c => normalize(c)),
+  })
 )
 
 const render = (parsed: any) =>
@@ -67,7 +91,16 @@ const resolveComponent = (target: VirtualNode, context: any = undefined) => {
 }
 
 const parse = (template: TemplateStringsArray, ...substitutions: any[]) => {
-  const parsed = firstPass(template, ...substitutions)
+  const parsed = firstPass(
+    template,
+    ...substitutions.map(s =>
+      typeof s === 'string'
+        ? Object.defineProperty(new String(s), stringSubsitutionSymbol, {
+            value: true,
+          })
+        : s
+    )
+  )
 
   return Array.isArray(parsed)
     ? parsed.map(p => render(resolveComponent(p)))

--- a/src/turndown.ts
+++ b/src/turndown.ts
@@ -282,6 +282,14 @@ const turndownService = () => {
     if (rules[rule]) td.addRule(rule, rules[rule])
   }
 
+  // Preprocess for each nodes to disable skipping escape in <code>
+  const { forNode } = td.rules
+
+  td.rules.forNode = function forNodeWithPreprocessing(node) {
+    node.isCode = false // eslint-disable-line no-param-reassign
+    return forNode.call(this, node)
+  }
+
   return td
 }
 

--- a/test/html.tsx
+++ b/test/html.tsx
@@ -14,9 +14,9 @@ describe('HTML parser for mrkdwn', () => {
       expect(html('&heart;')).toBe('&amp;heart;')
     })
 
-    it('does not replace already used ampersand for escaping', () => {
-      expect(html('true &amp;& false')).toBe('true &amp;&amp; false')
-      expect(html('A&lt;=&gt;B')).toBe('A&lt;=&gt;B')
+    it('allows double escaping', () => {
+      expect(html('true &amp;& false')).toBe('true &amp;amp;&amp; false')
+      expect(html('A&lt;=&gt;B')).toBe('A&amp;lt;=&amp;gt;B')
     })
 
     it('replaces "<" with "&lt;"', () => expect(html('a<2')).toBe('a&lt;2'))

--- a/test/tag.tsx
+++ b/test/tag.tsx
@@ -143,7 +143,7 @@ describe('Tagged template', () => {
 
     // Slack requires double-escapation to ampersand for holding raw string of "&lt;", "&gt;", and "&amp;".
     expect(jsxRawEntitySection.text.text).toBe(
-      '`&amp;lt;span data-test=&quot;&amp;amp;&quot;&amp;gt;&hearts;&amp;lt;/span&amp;gt;`'
+      '`&amp;lt;span data-test=&amp;quot;&amp;amp;&amp;quot;&amp;gt;&amp;hearts;&amp;lt;/span&amp;gt;`'
     )
 
     const [templateEntitySection] = jsxslack`

--- a/test/tag.tsx
+++ b/test/tag.tsx
@@ -46,6 +46,61 @@ describe('Tagged template', () => {
     )
   })
 
+  it('has same decode behavior compatible with JSX for HTML entities', () => {
+    const [jsxEntitySection] = JSXSlack(
+      <Blocks>
+        <Section>
+          <code>
+            &lt;span data-test=&quot;&amp;&quot;&gt;&hearts;&lt;/span&gt;
+          </code>
+        </Section>
+      </Blocks>
+    )
+
+    expect(jsxEntitySection.text.text).toBe(
+      '`<span data-test="&">\u2665</span>`'
+    )
+
+    const [jsxRawEntitySection] = JSXSlack(
+      <Blocks>
+        <Section>
+          <code>
+            {'&lt;span data-test=&quot;&amp;&quot;&gt;&hearts;&lt;/span&gt;'}
+          </code>
+        </Section>
+      </Blocks>
+    )
+
+    // Slack requires double-escapation to ampersand for holding raw string of "&lt;", "&gt;", and "&amp;".
+    expect(jsxRawEntitySection.text.text).toBe(
+      '`&amp;lt;span data-test=&quot;&amp;amp;&quot;&amp;gt;&hearts;&amp;lt;/span&amp;gt;`'
+    )
+
+    const [templateEntitySection] = jsxslack`
+      <Blocks>
+        <Section>
+          <code>
+            &lt;span data-test=&quot;&amp;&quot;&gt;&hearts;&lt;/span&gt;
+          </code>
+        </Section>
+      </Blocks>
+    `
+
+    expect(templateEntitySection).toStrictEqual(jsxEntitySection)
+
+    const [templateRawEntitySection] = jsxslack`
+      <Blocks>
+        <Section>
+          <code>
+            ${'&lt;span data-test=&quot;&amp;&quot;&gt;&hearts;&lt;/span&gt;'}
+          </code>
+        </Section>
+      </Blocks>
+    `
+
+    expect(templateRawEntitySection).toStrictEqual(jsxRawEntitySection)
+  })
+
   describe('jsxslack.fragment', () => {
     it('returns raw nodes for reusable as component', () => {
       const func = title => jsxslack.fragment`

--- a/test/tag.tsx
+++ b/test/tag.tsx
@@ -128,7 +128,7 @@ describe('Tagged template', () => {
     )
 
     expect(jsxEntitySection.text.text).toBe(
-      '`<span data-test="&">\u2665</span>`'
+      '`&lt;span data-test="&amp;"&gt;\u2665&lt;/span&gt;`'
     )
 
     const [jsxRawEntitySection] = JSXSlack(

--- a/yarn.lock
+++ b/yarn.lock
@@ -3251,6 +3251,11 @@ hash.js@^1.0.0, hash.js@^1.0.3:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
 
+he@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
+  integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
 hex-color-regex@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"


### PR DESCRIPTION
jsx-slack has confusable rendering in HTML entities. Normally it has no problems because entities are preprocessed in JSX. However, the rendering result in explicitly interpolated string is different from HTML.

- `<code>&lt;span data-test=&quot;&amp;&quot;&gt;&hearts;&lt;/span&gt;</code>`
  - HTML view: `<span data-test="&">♥</span>`
  - Slack view: `<span data-test="&">♥</span>` (Correct rendering)\
　
- `<code>{'&lt;span data-test=&quot;&amp;&quot;&gt;&hearts;&lt;/span&gt;'}</code>`
  - HTML view: `&lt;span data-test=&quot;&amp;&quot;&gt;&hearts;&lt;/span&gt`
  - Slack view: `<span data-test=&quot;&&quot;>&hearts;</span>`

The result from `jsxslack` tagged template literal is also different from JSX. (Ignores entitites as same as interpolated string: developit/htm#76)

So we should improve entity decoding behavior to follow HTML rendering.