### PR TITLE
Add <File> block component

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,22 @@ Text contents will merge in pertinent mrkdwn elements automatically, but they al
 
 - `id` / `blockId` (optional): A string of unique identifier of block.
 
+#### [`<File>`: File Block](https://api.slack.com/reference/messaging/blocks#file)
+
+Display a remote file that was added to Slack workspace. [Learn about adding remote files in the document of Slack API.](https://api.slack.com/messaging/files/remote)
+
+```jsx
+<Blocks>
+  <File externalId="ABCD1" />
+</Blocks>
+```
+
+##### Props
+
+- `externalId` (**required**): A string of unique ID for the file to show.
+- `id` / `blockId` (optional): A string of unique identifier of block.
+- `source` (optional): Override `source` field. At the moment, you should not take care this because only the default value `remote` is available.
+
 ### Interactive elements
 
 Some blocks may include the interactive component to exchange info with Slack app.

--- a/demo/schema.js
+++ b/demo/schema.js
@@ -41,6 +41,7 @@ export default {
       'Image',
       'Actions',
       'Context',
+      'File',
 
       // HTML compatible
       'section',
@@ -85,6 +86,10 @@ export default {
   Context: {
     attrs: blockCommonAttrs,
     children: ['Image', 'img', 'span', ...markupHTML],
+  },
+  File: {
+    attrs: { externalId: null, source: ['remote'], ...blockCommonAttrs },
+    children: [],
   },
 
   // Interactive components

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "typescript": "^3.5.3"
   },
   "dependencies": {
-    "@slack/types": "^1.0.0",
+    "@slack/types": "^1.1.0",
     "htm": "^2.1.1",
     "lodash.flatten": "^4.4.0",
     "turndown": "^5.0.3"

--- a/src/block-kit/File.tsx
+++ b/src/block-kit/File.tsx
@@ -1,0 +1,20 @@
+/** @jsx JSXSlack.h */
+import { FileBlock } from '@slack/types'
+import { JSXSlack } from '../jsx'
+import { ObjectOutput } from '../utils'
+import { BlockComponentProps } from './Blocks'
+
+interface FileProps extends BlockComponentProps {
+  children?: undefined
+  externalId: string
+  source?: string
+}
+
+export const File: JSXSlack.FC<FileProps> = props => (
+  <ObjectOutput<FileBlock>
+    type="file"
+    block_id={props.id || props.blockId}
+    external_id={props.externalId}
+    source={props.source || 'remote'}
+  />
+)

--- a/src/block-kit/index.ts
+++ b/src/block-kit/index.ts
@@ -5,6 +5,7 @@ export { Blocks } from './Blocks'
 export { Actions } from './Actions'
 export { Context } from './Context'
 export { Divider } from './Divider'
+export { File } from './File'
 export { Image } from './Image'
 export { Section, Field } from './Section'
 

--- a/src/block-kit/interactive/Button.tsx
+++ b/src/block-kit/interactive/Button.tsx
@@ -8,16 +8,13 @@ export interface ButtonProps {
   actionId?: string
   children: JSXSlack.Children<{}>
   confirm?: JSXSlack.Node<ConfirmProps>
-  style?: 'primary' | 'danger'
+  style?: SlackButton['style']
   url?: string
   value?: string
 }
 
-// TODO: Use SlackButton when supported style field on @slack/types
-type JSXSlackButton = SlackButton & Pick<ButtonProps, 'style'>
-
 export const Button: JSXSlack.FC<ButtonProps> = props => (
-  <ObjectOutput<JSXSlackButton>
+  <ObjectOutput<SlackButton>
     type="button"
     text={{
       type: 'plain_text',

--- a/test/index.tsx
+++ b/test/index.tsx
@@ -6,6 +6,7 @@ import {
   SectionBlock,
   StaticSelect,
   Option as SlackOption,
+  FileBlock,
 } from '@slack/types'
 import JSXSlack, {
   Actions,
@@ -20,6 +21,7 @@ import JSXSlack, {
   Escape,
   ExternalSelect,
   Field,
+  File,
   Fragment,
   Image,
   Optgroup,
@@ -830,6 +832,33 @@ describe('jsx-slack', () => {
             </Blocks>
           )
         ).toThrow())
+    })
+
+    describe('<File>', () => {
+      const file: FileBlock = {
+        block_id: 'file',
+        external_id: 'ABCD1',
+        source: 'remote',
+        type: 'file',
+      }
+
+      it('outputs file block', () =>
+        expect(
+          JSXSlack(
+            <Blocks>
+              <File blockId="file" externalId="ABCD1" />
+            </Blocks>
+          )
+        ).toStrictEqual([file]))
+
+      it('allows overriding source prop for future use', () =>
+        expect(
+          JSXSlack(
+            <Blocks>
+              <File id="file" externalId="ABCD1" source="local" />
+            </Blocks>
+          )
+        ).toStrictEqual([{ ...file, source: 'local' }]))
     })
   })
 

--- a/test/index.tsx
+++ b/test/index.tsx
@@ -2,11 +2,11 @@
 import {
   ActionsBlock,
   DividerBlock,
+  FileBlock,
   ImageBlock,
   SectionBlock,
   StaticSelect,
   Option as SlackOption,
-  FileBlock,
 } from '@slack/types'
 import JSXSlack, {
   Actions,

--- a/yarn.lock
+++ b/yarn.lock
@@ -932,10 +932,10 @@
     "@parcel/utils" "^1.11.0"
     physical-cpu-count "^2.0.0"
 
-"@slack/types@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@slack/types/-/types-1.0.0.tgz#1dc7a63b293c4911e474197585c3feda012df17a"
-  integrity sha512-IktC4uD/CHfLQcSitKSmjmRu4a6+Nf/KzfS6dTgUlDzENhh26l8aESKAuIpvYD5VOOE6NxDDIAdPJOXBvUGxlg==
+"@slack/types@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@slack/types/-/types-1.1.0.tgz#64465b6c7e2db66498f335934335da81c15812e7"
+  integrity sha512-uak4Jbi8nlX8xmElkPt1ixxVQXMKdBRbzBayn5bRzZ9Yx3bQGlyJdFs6GjEKI+fvFP0ZTiGWKOzlJTH3Tm/9fg==
 
 "@types/babel__core@^7.1.0":
   version "7.1.2"


### PR DESCRIPTION
Resolves #34.

We are using the updated `@slack/types` v1.1.0 that has `FileBlock` type.

### ToDo

- [x] Update README.md