### PR TITLE
Update htm to v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Update `htm` to [v2.2.0](https://github.com/developit/htm/releases/tag/2.2.0) ([#38](https://github.com/speee/jsx-slack/pull/38))
+
 ## v0.7.0 - 2019-07-29
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
   },
   "dependencies": {
     "@slack/types": "^1.1.0",
-    "htm": "^2.1.1",
+    "htm": "^2.2.0",
     "lodash.flatten": "^4.4.0",
     "turndown": "^5.0.3"
   }

--- a/test/tag.tsx
+++ b/test/tag.tsx
@@ -15,6 +15,7 @@ describe('Tagged template', () => {
     const count = 2
     const template = jsxslack`
       <Blocks>
+        <!-- jsx-slack template literal tag can use as like as JSX. -->
         <Section>
           <Image src="https://example.com/example.jpg" alt="example" />
           <b>Tagged template</b><br />
@@ -22,7 +23,7 @@ describe('Tagged template', () => {
         </Section>
         <Divider />
         <Actions>
-          <Button actionId="clap">:clap: ${count}</Button>
+          <Button actionId="clap${count}">:clap: ${count}</Button>
         </Actions>
       </Blocks>
     `
@@ -30,6 +31,7 @@ describe('Tagged template', () => {
     expect(template).toStrictEqual(
       JSXSlack(
         <Blocks>
+          {/* jsx-slack template literal tag can use as like as JSX. */}
           <Section>
             <Image src="https://example.com/example.jpg" alt="example" />
             <b>Tagged template</b>
@@ -39,7 +41,7 @@ describe('Tagged template', () => {
           </Section>
           <Divider />
           <Actions>
-            <Button actionId="clap">:clap: {count}</Button>
+            <Button actionId={`clap${count}`}>:clap: {count}</Button>
           </Actions>
         </Blocks>
       )

--- a/yarn.lock
+++ b/yarn.lock
@@ -3280,10 +3280,10 @@ hsla-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/hsla-regex/-/hsla-regex-1.0.0.tgz#c1ce7a3168c8c6614033a4b5f7877f3b225f9c38"
   integrity sha1-wc56MWjIxmFAM6S194d/OyJfnDg=
 
-htm@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/htm/-/htm-2.1.1.tgz#5a53e5f2845c3181b1672f95c9bffaf3d621bb0e"
-  integrity sha512-jgvB9nvlOE5xpI1W+juW8DPCe+Pn7mRDNaE4EOQNFqROm0O3l5deOvefK8C8hUaL1OHIX45mDEBSj7BMt+22VQ==
+htm@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/htm/-/htm-2.2.0.tgz#d771e8dc0b8dfafdc07062ad4fa8d88aa6a283b8"
+  integrity sha512-WQy5+JWqSByDWpMM0xj8kIY3KHiCpBfayeuFisTQyxG+7oQgJLVmF50K8A1ezYH57q36Z4EsRDj6jbXLHAMBGA==
 
 html-comment-regex@^1.1.0:
   version "1.1.2"


### PR DESCRIPTION
[HTM v2.2](https://github.com/developit/htm/releases/tag/2.2.0) has nice improvements as like as below:

- String interpolation in attribute had not allowed in HTM <= v2.1. This behavior was a little counterintuitive. And now, it came back in HTM v2.2!
- HTM 2.2 can include HTML comment `<!-- comment -->`. I think it has better looks rather than using JSX-style interpolation `${/* comment */}`.

`jsxslack` template literal tag would benefit from updated HTM.