### PR TITLE
Dialog support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- [Dialog support](docs/jsx-components-for-dialog.md) ([#19](https://github.com/speee/jsx-slack/issues/19), [#39](https://github.com/speee/jsx-slack/pull/39))
+
 ### Fixed
 
 - Don't prevent generating `<SelectFragment>` with no options ([#41](https://github.com/speee/jsx-slack/pull/41))

--- a/README.md
+++ b/README.md
@@ -9,11 +9,12 @@
 [npm]: https://www.npmjs.com/package/@speee-js/jsx-slack
 [license]: ./LICENSE
 
-Build JSON object for [Slack][slack] [block kit] from readable [JSX].
+Build JSON object for [Slack][slack] [Block Kit] and [dialog] from readable [JSX].
 
 [slack]: https://slack.com
 [jsx]: https://reactjs.org/docs/introducing-jsx.html
 [block kit]: https://api.slack.com/block-kit
+[dialog]: https://api.slack.com/dialogs
 [block kit builder]: https://api.slack.com/tools/block-kit-builder
 
 <p align="center">
@@ -25,8 +26,9 @@ Build JSON object for [Slack][slack] [block kit] from readable [JSX].
 
 ### Features
 
-- **[Block Kit as component](#block-kit-as-component)** - Building your blocks as component.
-- **[HTML-like formatting](#html-like-formatting)** - Keep a readability by using well-known elements.
+- **[Block Kit as components](docs/jsx-components-for-block-kit.md)** - Build your message by block components.
+- **[HTML-like formatting](docs/html-like-formatting.md)** - Keep a readability by using well-known elements.
+- **[Build dialog with HTML form style](docs/jsx-components-for-dialog.md)** - Create Dialog JSON through HTML form style JSX.
 
 ## Motivation
 
@@ -36,9 +38,9 @@ Slack has shipped [Block Kit] and [Block Kit Builder], and efforts to develop ap
 
 ## Project goal
 
-A project goal is creating an interface to build a maintainable Slack message with confidence via readable [JSX].
+A project goal is creating an interface to build a maintainable Slack message and interactive contents with confidence via readable [JSX].
 
-jsx-slack would allow building message blocks with predictable HTML-like markup. It helps in understanding the structure of the complex message.
+jsx-slack would allow building message blocks and dialogs with predictable HTML-like markup. It helps in understanding the structure of complex messages and interactions.
 
 ## Install
 
@@ -54,17 +56,35 @@ npm install --save @speee-js/jsx-slack
 yarn add @speee-js/jsx-slack
 ```
 
-## Block Kit as component
+## Usage
 
-Slack has recommended to use **[Block Kit]** for building tempting message. By using jsx-slack, you can build a template with piling up Block Kit blocks by JSX. It is feeling like using components in React or Vue.
+### Quick start: Template literal
 
-### Usage
+Do you hate troublesome setting up for JSX? All right. We provide **`jsxslack`** tagged template literal to build blocks _right out of the box_.
 
-#### JSX Transpiler
+It allows the template syntax almost same as JSX, powered by [HTM (Hyperscript Tagged Markup)](https://github.com/developit/htm). Setting for transpiler and importing built-in components are not required.
 
-When you want to use jsx-slack with JSX transpiler (Babel / TypeScript), you have to setting to use imported our parser `JSXSlack.h`. Typically, we recommend to use pragma comment `/** @jsx JSXSlack.h */`.
+This is a simple example of the template function just to say hello to someone.
 
-This is a simple block example `example.jsx` just to say hello to someone. Wrap JSX by `JSXSlack()` function.
+```javascript
+import { jsxslack } from '@speee-js/jsx-slack'
+
+export default function exampleBlock({ name }) {
+  return jsxslack`
+    <Blocks>
+      <Section>
+        Hello, <b>${name}</b>!
+      </Section>
+    </Blocks>
+  `
+}
+```
+
+### JSX Transpiler
+
+When you want to use jsx-slack with JSX transpiler (Babel / TypeScript), you have to set up to use imported our parser `JSXSlack.h`. Typically, we recommend to use pragma comment `/** @jsx JSXSlack.h */`.
+
+To create JSON from JSX, please wrap JSX by `JSXSlack()` function.
 
 ```jsx
 /** @jsx JSXSlack.h */
@@ -83,31 +103,7 @@ export default function exampleBlock({ name }) {
 
 A prgama would work in Babel ([@babel/plugin-transform-react-jsx](https://babeljs.io/docs/en/babel-plugin-transform-react-jsx)) and [TypeScript with `--jsx react`](https://www.typescriptlang.org/docs/handbook/jsx.html#factory-functions). You can use jsx-slack in either one.
 
-> :bulb: In Babel, you can set [an extra pragma comment for using fragment syntax](#short-syntax-for-babel-transpiler) too.
-
-#### Template literal
-
-A much simpler way to build blocks is using **`jsxslack`** tagged template literal.
-
-It allows the template syntax almost same as JSX, powered by [htm (Hyperscript Tagged Markup)](https://github.com/developit/htm). The troublesome transpiler setup and importing built-in components are not required.
-
-```javascript
-import { jsxslack } from '@speee-js/jsx-slack'
-
-export default function exampleBlock({ name }) {
-  return jsxslack`
-    <Blocks>
-      <Section>
-        Hello, <b>${name}</b>!
-      </Section>
-    </Blocks>
-  `
-}
-```
-
-> :bulb: We also provide `jsxslack.fragment` tag for defining higher-order component (HOC) and custom block.
-
-#### Use template in Slack API
+### Use template in Slack API
 
 After than, just use created template in Slack API. We are using the official Node SDK [`@slack/client`](https://github.com/slackapi/node-slack-sdk) in this example. [See also Slack guide.](https://slackapi.github.io/node-slack-sdk/web_api)
 
@@ -134,460 +130,72 @@ It would post a simple Slack message like this:
 
 [block-kit-builder-example]: https://api.slack.com/tools/block-kit-builder?blocks=%5B%7B%22type%22%3A%22section%22%2C%22text%22%3A%7B%22text%22%3A%22Hello%2C%20*Yuki%20Hattori*!%22%2C%22type%22%3A%22mrkdwn%22%2C%22verbatim%22%3Atrue%7D%7D%5D
 
-## JSX component
+## Block Kit as components
 
-### Blocks
-
-#### `<Blocks>`
-
-A container component to use Block Kit. You should wrap Block Kit elements by `<Blocks>`.
-
-#### [`<Section>`: Section Block](https://api.slack.com/reference/messaging/blocks#section)
-
-Display a simple text message. You have to specify the content as children. It allows [formatting with HTML-like elements](#html-like-formatting).
-
-`<section>` intrinsic HTML element works as well.
-
-```jsx
-<Blocks>
-  <Section>Hello, world!</Section>
-</Blocks>
-```
-
-[<img src="https://raw.githubusercontent.com/speee/jsx-slack/master/docs/preview-btn.svg?sanitize=true" width="240" />](https://api.slack.com/tools/block-kit-builder?blocks=%5B%7B%22type%22%3A%22section%22%2C%22text%22%3A%7B%22text%22%3A%22Hello%2C%20world!%22%2C%22type%22%3A%22mrkdwn%22%2C%22verbatim%22%3Atrue%7D%7D%5D)
-
-##### Props
-
-- `id` / `blockId` (optional): A string of unique identifier of block.
-
-##### Accessory
-
-The content of `<Section>` may include one of an accessory component. A defined element will show in side-by-side of text.
+Slack has recommended to use **[Block Kit]** for building tempting message. By using jsx-slack, you can build a template with piling up Block Kit blocks by JSX. It is feeling like using components in React or Vue.
 
 ```jsx
 <Blocks>
   <Section>
-    You can add an image next to text in this block. :point_right:
-    <Image src="https://placekitten.com/256/256" alt="Accessory image" />
-  </Section>
-</Blocks>
-```
-
-[<img src="https://raw.githubusercontent.com/speee/jsx-slack/master/docs/preview-btn.svg?sanitize=true" width="240" />](https://api.slack.com/tools/block-kit-builder?blocks=%5B%7B%22type%22%3A%22section%22%2C%22text%22%3A%7B%22text%22%3A%22You%20can%20add%20an%20image%20next%20to%20text%20in%20this%20block.%20%3Apoint_right%3A%22%2C%22type%22%3A%22mrkdwn%22%2C%22verbatim%22%3Atrue%7D%2C%22accessory%22%3A%0A%7B%22type%22%3A%22image%22%2C%22alt_text%22%3A%22Accessory%20image%22%2C%22image_url%22%3A%22https%3A%2F%2Fplacekitten.com%2F256%2F256%22%7D%7D%5D)
-
-###### Accessory components
-
-- [`<Image>` / `<img>`](#image-image-block)
-- [`<Button>`](#button-button-element)
-- [`<Select>`](#select-select-menu-with-static-options)
-- [`<ExternalSelect>`](#externalselect-select-menu-with-external-data-source)
-- [`<UsersSelect>`](#usersselect-select-menu-with-user-list)
-- [`<ConversationsSelect>`](#conversationsselect-select-menu-with-conversations-list)
-- [`<ChannelsSelect>`](#channelsselect-select-menu-with-channel-list)
-- [`<Overflow>`](#overflow-overflow-menu)
-- [`<DatePicker>`](#datepicker-select-date-from-calendar)
-
-##### `<Field>`: Fields for section block
-
-In addition the text content, the section block also can use 2 columns texts called fields. In jsx-slack, you can define field by `<Field>` component in `<Section>` block.
-
-```jsx
-<Blocks>
-  <Section>
-    About this repository:
-    <Field>
-      <b>Name</b>
+    <p>Enjoy building blocks!</p>
+    <blockquote>
+      <b>
+        <a href="https://github.com/speee/jsx-slack">@speee-js/jsx-slack</a>
+      </b>
       <br />
-      speee/jsx-slack
-    </Field>
-    <Field>
-      <b>Maintainer</b>
-      <br />
-      Yuki Hattori
-    </Field>
-    <Field>
-      <b>Organization</b>
-      <br />
-      Speee, Inc.
-    </Field>
+      <i>Build JSON for Slack Block Kit from JSX</i>
+    </blockquote>
     <Image src="https://github.com/speee.png" alt="Speee, Inc." />
   </Section>
-</Blocks>
-```
-
-[<img src="https://raw.githubusercontent.com/speee/jsx-slack/master/docs/preview-btn.svg?sanitize=true" width="240" />](https://api.slack.com/tools/block-kit-builder?blocks=%5B%7B%22type%22%3A%22section%22%2C%22text%22%3A%7B%22text%22%3A%22About%20this%20repository%3A%22%2C%22type%22%3A%22mrkdwn%22%2C%22verbatim%22%3Atrue%7D%2C%22accessory%22%3A%7B%22type%22%3A%22image%22%2C%22alt_text%22%3A%22Speee%2C%20Inc.%22%2C%22image_url%22%3A%22https%3A%2F%2Fgithub.com%2Fspeee.png%22%7D%2C%22fields%22%3A%5B%7B%22type%22%3A%22mrkdwn%22%2C%22text%22%3A%22*Name*%5Cnspeee%2Fjsx-slack%22%2C%22verbatim%22%3Atrue%7D%2C%7B%22type%22%3A%22mrkdwn%22%2C%22text%22%3A%22*Maintainer*%5CnYuki%20Hattori%22%2C%22verbatim%22%3Atrue%7D%2C%7B%22type%22%3A%22mrkdwn%22%2C%22text%22%3A%22*Organization*%5CnSpeee%2C%20Inc.%22%2C%22verbatim%22%3Atrue%7D%5D%7D%5D)
-
-> Contents of `<Field>` would be placed after the main text contents even if placed them anywhere.
-
-#### [`<Divider>`: Divider Block](https://api.slack.com/reference/messaging/blocks#divider)
-
-Just a divider. `<hr>` intrinsic HTML element works as well.
-
-```jsx
-<Blocks>
+  <Context>
+    Maintained by <a href="https://github.com/yhatt">Yuki Hattori</a>
+    <img src="https://github.com/yhatt.png" alt="yhatt" />
+  </Context>
   <Divider />
-</Blocks>
-```
-
-[<img src="https://raw.githubusercontent.com/speee/jsx-slack/master/docs/preview-btn.svg?sanitize=true" width="240" />](https://api.slack.com/tools/block-kit-builder?blocks=%5B%7B%22type%22%3A%22divider%22%7D%5D)
-
-##### Props
-
-- `id` / `blockId` (optional): A string of unique identifier of block.
-
-#### [`<Image>`: Image Block](https://api.slack.com/reference/messaging/blocks#image)
-
-Display an image block. It has well-known props like `<img>` HTML element. In fact, `<img>` intrinsic HTML element works as well.
-
-```jsx
-<Blocks>
-  <Image src="https://placekitten.com/500/500" alt="So cute kitten." />
-</Blocks>
-```
-
-[<img src="https://raw.githubusercontent.com/speee/jsx-slack/master/docs/preview-btn.svg?sanitize=true" width="240" />](https://api.slack.com/tools/block-kit-builder?blocks=%5B%7B%22type%22%3A%22image%22%2C%22alt_text%22%3A%22So%20cute%20kitten.%22%2C%22image_url%22%3A%22https%3A%2F%2Fplacekitten.com%2F500%2F500%22%7D%5D)
-
-##### Props
-
-- `src` (**required**): The URL of the image.
-- `alt` (**required**): A plain-text summary of the image.
-- `title` (optional): An optional title for the image.
-- `id` / `blockId` (optional): A string of unique identifier of block.
-
-#### [`<Actions>`: Actions Block](https://api.slack.com/reference/messaging/blocks#actions)
-
-A block to hold [interactive elements](#interactive-elements). Slack allows a maximum of 25 interactive elements in `<Actions>` (But recommends to place up to 5 elements).
-
-##### Props
-
-- `id` / `blockId` (optional): A string of unique identifier of block.
-
-#### [`<Context>`: Context Block](https://api.slack.com/reference/messaging/blocks#context)
-
-Display message context. It allows mixed contents consisted of texts and `<Image>` components / `<img>` tags.
-
-```jsx
-<Blocks>
-  <Context>
-    <img src="https://placekitten.com/100/100" alt="Kitten" />
-    A kitten and
-    <img src="https://placekitten.com/100/100" alt="Kitten" />
-    more kitten.
-  </Context>
-</Blocks>
-```
-
-[<img src="https://raw.githubusercontent.com/speee/jsx-slack/master/docs/preview-btn.svg?sanitize=true" width="240" />](https://api.slack.com/tools/block-kit-builder?blocks=%5B%7B%22type%22%3A%22context%22%2C%22elements%22%3A%5B%7B%22type%22%3A%22image%22%2C%22image_url%22%3A%22https%3A%2F%2Fplacekitten.com%2F100%2F100%22%2C%22alt_text%22%3A%22Kitten%22%7D%2C%7B%22type%22%3A%22mrkdwn%22%2C%22text%22%3A%22A%20kitten%20and%22%2C%22verbatim%22%3Atrue%7D%2C%7B%22type%22%3A%22image%22%2C%22image_url%22%3A%22https%3A%2F%2Fplacekitten.com%2F100%2F100%22%2C%22alt_text%22%3A%22Kitten%22%7D%2C%7B%22type%22%3A%22mrkdwn%22%2C%22text%22%3A%22more%20kitten.%22%2C%22verbatim%22%3Atrue%7D%5D%7D%5D)
-
-Text contents will merge in pertinent mrkdwn elements automatically, but they also may divide clearly by using `<span>` HTML intrinsic element.
-
-```jsx
-<Blocks>
-  <Context>
-    <span>
-      ◤<br />◤<br />◤
-    </span>
-    <span>
-      ◤<br />◤
-    </span>
-    <span>◤</span>
-    multiple mrkdwns
-  </Context>
-</Blocks>
-```
-
-[<img src="https://raw.githubusercontent.com/speee/jsx-slack/master/docs/preview-btn.svg?sanitize=true" width="240" />](https://api.slack.com/tools/block-kit-builder?blocks=%5B%7B%22type%22%3A%22context%22%2C%22elements%22%3A%5B%7B%22type%22%3A%22mrkdwn%22%2C%22text%22%3A%22%E2%97%A4%5Cn%E2%97%A4%5Cn%E2%97%A4%22%2C%22verbatim%22%3Atrue%7D%2C%7B%22type%22%3A%22mrkdwn%22%2C%22text%22%3A%22%E2%97%A4%5Cn%E2%97%A4%22%2C%22verbatim%22%3Atrue%7D%2C%7B%22type%22%3A%22mrkdwn%22%2C%22text%22%3A%22%E2%97%A4%22%2C%22verbatim%22%3Atrue%7D%2C%7B%22type%22%3A%22mrkdwn%22%2C%22text%22%3A%22multiple%20mrkdwns%22%2C%22verbatim%22%3Atrue%7D%5D%7D%5D)
-
-> :warning: Slack restricts the number of elements consisted of text contents and images up to 10. jsx-slack throws an error if the number of generated elements is going over the limit.
-
-##### Props
-
-- `id` / `blockId` (optional): A string of unique identifier of block.
-
-#### [`<File>`: File Block](https://api.slack.com/reference/messaging/blocks#file)
-
-Display a remote file that was added to Slack workspace. [Learn about adding remote files in the document of Slack API.](https://api.slack.com/messaging/files/remote)
-
-```jsx
-<Blocks>
-  <File externalId="ABCD1" />
-</Blocks>
-```
-
-##### Props
-
-- `externalId` (**required**): A string of unique ID for the file to show.
-- `id` / `blockId` (optional): A string of unique identifier of block.
-- `source` (optional): Override `source` field. At the moment, you should not take care this because only the default value `remote` is available.
-
-### Interactive elements
-
-Some blocks may include the interactive component to exchange info with Slack app.
-
-#### [`<Button>`: Button element](https://api.slack.com/reference/messaging/block-elements#button)
-
-A simple button to send action to registered Slack App, or open external URL.
-
-```jsx
-<Blocks>
   <Actions>
-    <Button actionId="action" value="value" style="primary">
-      Action button
-    </Button>
-    <Button url="https://example.com/">Link to URL</Button>
+    <Button url="https://github.com/speee/jsx-slack">GitHub</Button>
+    <Button url="https://www.npmjs.com/package/@speee-js/jsx-slack">npm</Button>
   </Actions>
 </Blocks>
 ```
 
-[<img src="https://raw.githubusercontent.com/speee/jsx-slack/master/docs/preview-btn.svg?sanitize=true" width="240" />](https://api.slack.com/tools/block-kit-builder?blocks=%5B%7B%22type%22%3A%22actions%22%2C%22elements%22%3A%5B%7B%22type%22%3A%22button%22%2C%22text%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Action%20button%22%2C%22emoji%22%3Atrue%7D%2C%22action_id%22%3A%22action%22%2C%22style%22%3A%22primary%22%2C%22value%22%3A%22value%22%7D%2C%7B%22type%22%3A%22button%22%2C%22text%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Link%20to%20URL%22%2C%22emoji%22%3Atrue%7D%2C%22url%22%3A%22https%3A%2F%2Fexample.com%2F%22%7D%5D%7D%5D)
+### References
 
-##### Props
+- **[JSX components for Block Kit](docs/jsx-components-for-block-kit.md)**
+- **[HTML-like formatting](docs/html-like-formatting.md)**
+- **[About escape and exact mode](docs/about-escape-and-exact-mode.md)**
 
-- `actionId` (optional): An identifier for the action.
-- `value` (optional): A string value to send to Slack App when clicked button.
-- `url` (optional): URL to load when clicked button.
-- `style` (optional): Select the colored button decoration from `primary` and `danger`.
-- `confirm` (optional): [`<Confirm>` element](#confirm-confirmation-dialog) to show confirmation dialog.
+## Dialog as components
 
-#### [`<Select>`: Select menu with static options](https://api.slack.com/reference/messaging/block-elements#static-select)
-
-A menu element with static options passed by `<Option>` or `<Optgroup>`. It has a interface similar to `<select>` HTML element.
+We also provide `@speee-js/jsx-slack/dialog` to allow building Dialog JSON with same feeling. You can create Dialog JSON for `dialog` argument in [`dialog.open` Slack API](https://api.slack.com/methods/dialog.open), with familiar HTML form style.
 
 ```jsx
-<Blocks>
-  <Actions>
-    <Select actionId="rating" placeholder="Rate it!">
-      <Option value="5">5 :star::star::star::star::star:</Option>
-      <Option value="4">4 :star::star::star::star:</Option>
-      <Option value="3">3 :star::star::star:</Option>
-      <Option value="2">2 :star::star:</Option>
-      <Option value="1">1 :star:</Option>
-    </Select>
-  </Actions>
-</Blocks>
+/** @jsx JSXSlack.h */
+import JSXSlack from '@speee-js/jsx-slack'
+import { Dialog, Input, Textarea } from '@speee-js/jsx-slack/dialog'
+
+export default function exampleDialog(data) {
+  return JSXSlack(
+    <Dialog callbackId="create" title="Create">
+      <Input name="name" label="Name" value={data.name} required />
+      <Textarea name="desc" label="Description" value={data.desc} />
+
+      <Input type="hidden" name="userId" value={data.userId} />
+      <Input type="submit" value="Create" />
+    </Dialog>
+  )
+}
 ```
 
-[<img src="https://raw.githubusercontent.com/speee/jsx-slack/master/docs/preview-btn.svg?sanitize=true" width="240" />](https://api.slack.com/tools/block-kit-builder?blocks=%5B%7B%22type%22%3A%22actions%22%2C%22elements%22%3A%5B%7B%22type%22%3A%22static_select%22%2C%22placeholder%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Rate%20it!%22%2C%22emoji%22%3Atrue%7D%2C%22action_id%22%3A%22rating%22%2C%22options%22%3A%5B%7B%22value%22%3A%225%22%2C%22text%22%3A%7B%22text%22%3A%225%20%3Astar%3A%3Astar%3A%3Astar%3A%3Astar%3A%3Astar%3A%22%2C%22type%22%3A%22plain_text%22%2C%22emoji%22%3Atrue%7D%7D%2C%7B%22value%22%3A%224%22%2C%22text%22%3A%7B%22text%22%3A%224%20%3Astar%3A%3Astar%3A%3Astar%3A%3Astar%3A%22%2C%22type%22%3A%22plain_text%22%2C%22emoji%22%3Atrue%7D%7D%2C%7B%22value%22%3A%223%22%2C%22text%22%3A%7B%22text%22%3A%223%20%3Astar%3A%3Astar%3A%3Astar%3A%22%2C%22type%22%3A%22plain_text%22%2C%22emoji%22%3Atrue%7D%7D%2C%7B%22value%22%3A%222%22%2C%22text%22%3A%7B%22text%22%3A%222%20%3Astar%3A%3Astar%3A%22%2C%22type%22%3A%22plain_text%22%2C%22emoji%22%3Atrue%7D%7D%2C%7B%22value%22%3A%221%22%2C%22text%22%3A%7B%22text%22%3A%221%20%3Astar%3A%22%2C%22type%22%3A%22plain_text%22%2C%22emoji%22%3Atrue%7D%7D%5D%7D%5D%7D%5D)
+> :warning: Currently it's only available in JSX transpiler. You cannot build dialog JSON with template literal.
 
-##### Props
+### References
 
-- `actionId` (optional): An identifier for the action.
-- `placeholder` (optional): A plain text to be shown at first.
-- `value` (optional): A value of item to show initially. It must choose value from defined `<Option>` elements in children.
-- `confirm` (optional): [`<Confirm>` element](#confirm-confirmation-dialog) to show confirmation dialog.
+- **[JSX components for dialog](docs/jsx-components-for-dialog.md)**
 
-##### `<Option>`: Menu item
+## Fragments
 
-###### Props
-
-- `value` (**required**): A string value to send to Slack App when choose item.
-
-##### `<Optgroup>`: Group of menu items
-
-```jsx
-<Blocks>
-  <Actions>
-    <Select actionId="action" placeholder="Action...">
-      <Optgroup label="Search with">
-        <Option value="search_google">Google</Option>
-        <Option value="search_bing">Bing</Option>
-        <Option value="search_duckduckgo">DuckDuckGo</Option>
-      </Optgroup>
-      <Optgroup label="Share to">
-        <Option value="share_facebook">Facebook</Option>
-        <Option value="share_twitter">Twitter</Option>
-      </Optgroup>
-    </Select>
-  </Actions>
-</Blocks>
-```
-
-[<img src="https://raw.githubusercontent.com/speee/jsx-slack/master/docs/preview-btn.svg?sanitize=true" width="240" />](https://api.slack.com/tools/block-kit-builder?blocks=%5B%7B%22type%22%3A%22actions%22%2C%22elements%22%3A%5B%7B%22type%22%3A%22static_select%22%2C%22placeholder%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Action...%22%2C%22emoji%22%3Atrue%7D%2C%22action_id%22%3A%22action%22%2C%22option_groups%22%3A%5B%7B%22label%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Search%20with%22%2C%22emoji%22%3Atrue%7D%2C%22options%22%3A%5B%7B%22value%22%3A%22search_google%22%2C%22text%22%3A%7B%22text%22%3A%22Google%22%2C%22type%22%3A%22plain_text%22%2C%22emoji%22%3Atrue%7D%7D%2C%7B%22value%22%3A%22search_bing%22%2C%22text%22%3A%7B%22text%22%3A%22Bing%22%2C%22type%22%3A%22plain_text%22%2C%22emoji%22%3Atrue%7D%7D%2C%7B%22value%22%3A%22search_duckduckgo%22%2C%22text%22%3A%7B%22text%22%3A%22DuckDuckGo%22%2C%22type%22%3A%22plain_text%22%2C%22emoji%22%3Atrue%7D%7D%5D%7D%2C%7B%22label%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Share%20to%22%2C%22emoji%22%3Atrue%7D%2C%22options%22%3A%5B%7B%22value%22%3A%22share_facebook%22%2C%22text%22%3A%7B%22text%22%3A%22Facebook%22%2C%22type%22%3A%22plain_text%22%2C%22emoji%22%3Atrue%7D%7D%2C%7B%22value%22%3A%22share_twitter%22%2C%22text%22%3A%7B%22text%22%3A%22Twitter%22%2C%22type%22%3A%22plain_text%22%2C%22emoji%22%3Atrue%7D%7D%5D%7D%5D%7D%5D%7D%5D)
-
-###### Props
-
-- `label` (**required**): A plain text to be shown as a group name.
-
-#### [`<ExternalSelect>`: Select menu with external data source](https://api.slack.com/reference/messaging/block-elements#external-select)
-
-You should use `<ExternalSelect>` if you want to provide the dynamic list from external source.
-
-It requires setup JSON entry URL in your Slack app. [Learn about external source in Slack documentation.](https://api.slack.com/reference/messaging/block-elements#external-select)
-
-```jsx
-<Blocks>
-  <Actions>
-    <ExternalSelect
-      actionId="category"
-      placeholder="Select category..."
-      minQueryLength={2}
-    />
-  </Actions>
-</Blocks>
-```
-
-[<img src="https://raw.githubusercontent.com/speee/jsx-slack/master/docs/preview-btn.svg?sanitize=true" width="240" />](https://api.slack.com/tools/block-kit-builder?blocks=%5B%7B%22type%22%3A%22actions%22%2C%22elements%22%3A%5B%7B%22type%22%3A%22external_select%22%2C%22placeholder%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Select%20category...%22%2C%22emoji%22%3Atrue%7D%2C%22action_id%22%3A%22category%22%2C%22min_query_length%22%3A2%7D%5D%7D%5D)
-
-##### Props
-
-- `actionId` (optional): An identifier for the action.
-- `placeholder` (optional): A plain text to be shown at first.
-- `initialOption` (optional): An initial option exactly matched to provided options from external source. It allows raw JSON object or `<Option>`.
-- `minQueryLength` (optional): A length of typed characters to begin JSON request.
-- `confirm` (optional): [`<Confirm>` element](#confirm-confirmation-dialog) to show confirmation dialog.
-
-##### `<SelectFragment>`: Generate options for external source
-
-You would want to build not only the message but also the data source by jsx-slack. `<SelectFragment>` component can create JSON object for external data source usable in `<ExternalSelect>`.
-
-A following is a simple example to serve JSON for external select via [express](https://expressjs.com/). It is using [`jsxslack` tagged template literal](#template-literal).
-
-```javascript
-import { jsxslack } from '@speee-js/jsx-slack'
-import express from 'express'
-
-const app = express()
-
-app.get('/external-data-source', (req, res) => {
-  res.json(jsxslack`
-    <SelectFragment>
-      <Option value="item-a">Item A</Option>
-      <Option value="item-b">Item B</Option>
-      <Option value="item-c">Item C</Option>
-    </SelectFragment>
-  `)
-})
-
-app.listen(80)
-```
-
-#### [`<UsersSelect>`: Select menu with user list](https://api.slack.com/reference/messaging/block-elements#users-select)
-
-A select menu with options consisted of users in the current workspace.
-
-##### Props
-
-- `actionId` (optional): An identifier for the action.
-- `placeholder` (optional): A plain text to be shown at first.
-- `initialUser` (optional): The initial user ID.
-- `confirm` (optional): [`<Confirm>` element](#confirm-confirmation-dialog) to show confirmation dialog.
-
-#### [`<ConversationsSelect>`: Select menu with conversations list](https://api.slack.com/reference/messaging/block-elements#conversation-select)
-
-A select menu with options consisted of any type of conversations in the current workspace.
-
-##### Props
-
-- `actionId` (optional): An identifier for the action.
-- `placeholder` (optional): A plain text to be shown at first.
-- `initialConversation` (optional): The initial conversation ID.
-- `confirm` (optional): [`<Confirm>` element](#confirm-confirmation-dialog) to show confirmation dialog.
-
-#### [`<ChannelsSelect>`: Select menu with channel list](https://api.slack.com/reference/messaging/block-elements#channel-select)
-
-A select menu with options consisted of public channels in the current workspace.
-
-##### Props
-
-- `actionId` (optional): An identifier for the action.
-- `placeholder` (optional): A plain text to be shown at first.
-- `initialChannel` (optional): The initial channel ID.
-- `confirm` (optional): [`<Confirm>` element](#confirm-confirmation-dialog) to show confirmation dialog.
-
-#### [`<Overflow>`: Overflow menu](https://api.slack.com/reference/messaging/block-elements#overflow)
-
-An overflow menu displayed as `...` can access to some hidden menu items by many actions. _It must contain least of 2 `<OverflowItem>` components._
-
-```jsx
-<Blocks>
-  <Actions>
-    <Overflow actionId="overflow_menu">
-      <OverflowItem value="share">Share</OverflowItem>
-      <OverflowItem value="reply">Reply message</OverflowItem>
-      <OverflowItem url="https://example.com/">Open in browser</OverflowItem>
-    </Overflow>
-  </Actions>
-</Blocks>
-```
-
-[<img src="https://raw.githubusercontent.com/speee/jsx-slack/master/docs/preview-btn.svg?sanitize=true" width="240" />](https://api.slack.com/tools/block-kit-builder?blocks=%5B%7B%22type%22%3A%22actions%22%2C%22elements%22%3A%5B%7B%22type%22%3A%22overflow%22%2C%22action_id%22%3A%22overflow_menu%22%2C%22options%22%3A%5B%7B%22text%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Share%22%2C%22emoji%22%3Atrue%7D%2C%22value%22%3A%22share%22%7D%2C%7B%22text%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Reply%20message%22%2C%22emoji%22%3Atrue%7D%2C%22value%22%3A%22reply%22%7D%2C%7B%22text%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Open%20in%20browser%22%2C%22emoji%22%3Atrue%7D%2C%22url%22%3A%22https%3A%2F%2Fexample.com%2F%22%7D%5D%7D%5D%7D%5D)
-
-##### Props
-
-- `actionId` (optional): An identifier for the action.
-- `confirm` (optional): [`<Confirm>` element](#confirm-confirmation-dialog) to show confirmation dialog when clicked menu item.
-
-##### `<OverflowItem>`: Menu item in overflow menu
-
-###### Props
-
-- `value` (optional): A string value to send to Slack App when choose item.
-- `url` (optional): URL to load when clicked button.
-
-#### [`<DatePicker>`: Select date from calendar](https://api.slack.com/reference/messaging/block-elements#datepicker)
-
-An easy way to let the user selecting any date is using `<DatePicker>` component.
-
-```jsx
-<Blocks>
-  <Actions>
-    <DatePicker actionId="date_picker" initialDate={new Date()} />
-  </Actions>
-</Blocks>
-```
-
-[<img src="https://raw.githubusercontent.com/speee/jsx-slack/master/docs/preview-btn.svg?sanitize=true" width="240" />](https://api.slack.com/tools/block-kit-builder?blocks=%5B%7B%22type%22%3A%22actions%22%2C%22elements%22%3A%5B%7B%22type%22%3A%22datepicker%22%2C%22action_id%22%3A%22date_picker%22%2C%22initial_date%22%3A%222019-02-22%22%7D%5D%7D%5D)
-
-##### Props
-
-- `actionId` (optional): An identifier for the action.
-- `placeholder` (optional): A plain text to be shown at first.
-- `initialDate` (optional): An initially selected date. It allows `YYYY-MM-DD` formatted string, UNIX timestamp in millisecond, and JavaScript [`Date`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date) instance.
-- `confirm` (optional): [`<Confirm>` element](#confirm-confirmation-dialog) to show confirmation dialog.
-
-### Components for [composition objects](https://api.slack.com/reference/messaging/composition-objects)
-
-#### [`<Confirm>`: Confirmation dialog](https://api.slack.com/reference/messaging/composition-objects#confirm)
-
-Define confirmation dialog. Some interactive elements can open confirmation dialog when selected, by passing `<Confirm>` to `confirm` prop.
-
-```jsx
-<Blocks>
-  <Actions>
-    <Button
-      actionId="commit"
-      value="value"
-      confirm={
-        <Confirm title="Commit your action" confirm="Yes, please" deny="Cancel">
-          <b>Are you sure?</b> Please confirm your action again.
-        </Confirm>
-      }
-    >
-      Commit
-    </Button>
-  </Actions>
-</Blocks>
-```
-
-[<img src="https://raw.githubusercontent.com/speee/jsx-slack/master/docs/confirmation.png" width="500" />][confirmation]
-
-[<img src="https://raw.githubusercontent.com/speee/jsx-slack/master/docs/preview-btn.svg?sanitize=true" width="240" />][confirmation]
-
-[confirmation]: https://api.slack.com/tools/block-kit-builder?blocks=%5B%7B%22type%22%3A%22actions%22%2C%22elements%22%3A%5B%7B%22type%22%3A%22button%22%2C%22text%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Commit%22%2C%22emoji%22%3Atrue%7D%2C%22action_id%22%3A%22commit%22%2C%22confirm%22%3A%7B%22title%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Commit%20your%20action%22%2C%22emoji%22%3Atrue%7D%2C%22text%22%3A%7B%22type%22%3A%22mrkdwn%22%2C%22text%22%3A%22*Are%20you%20sure%3F*%20Please%20confirm%20your%20action%20again.%22%2C%22verbatim%22%3Atrue%7D%2C%22confirm%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Yes%2C%20please%22%2C%22emoji%22%3Atrue%7D%2C%22deny%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Cancel%22%2C%22emoji%22%3Atrue%7D%7D%2C%22value%22%3A%22value%22%7D%5D%7D%5D
-
-> :information_source: You can use [HTML-like formatting](#html-like-formatting) to the content of confirmation dialog. However, you have to be careful that Slack ignores any line breaks and the content will render just in a line.
-
-##### Props
-
-- `title` (**required**): The title of confirmation dialog.
-- `confirm` (**required**): A text content of the button to confirm.
-- `deny` (**required**): A text content of the button to cancel.
-
-### Fragments
-
-#### `<Fragment>`: Group a list of blocks or elements
-
-[As like as React](https://reactjs.org/docs/fragments.html), jsx-slack also provides `<Fragment>` (`<JSXSlack.Fragment>`) component for higher-order component (HOC) consited of multiple blocks or elements.
+[As like as React](https://reactjs.org/docs/fragments.html), jsx-slack provides `<Fragment>` (`<JSXSlack.Fragment>`) component for higher-order component (HOC) consited of multiple blocks or elements.
 
 For example, you can define the custom block by grouping some blocks with `<Fragment>` if you were using JSX transpiler.
 
@@ -624,7 +232,7 @@ Now the defined block can use in `<Blocks>` as like as the other blocks:
 
 [custom-header-block]: https://api.slack.com/tools/block-kit-builder?blocks=%5B%7B%22type%22%3A%22section%22%2C%22text%22%3A%7B%22text%22%3A%22*_jsx-slack%20custom%20block_%20%3Asunglasses%3A*%22%2C%22type%22%3A%22mrkdwn%22%2C%22verbatim%22%3Atrue%7D%7D%2C%7B%22type%22%3A%22divider%22%7D%2C%7B%22type%22%3A%22section%22%2C%22text%22%3A%7B%22text%22%3A%22Let%27s%20build%20your%20block.%22%2C%22type%22%3A%22mrkdwn%22%2C%22verbatim%22%3Atrue%7D%7D%5D
 
-#### Short syntax for Babel transpiler
+### Short syntax for Babel transpiler
 
 If you want to use [the short syntax `<></>` for fragments](https://reactjs.org/docs/fragments.html#short-syntax) in Babel transpiler, we recommend to set [an extra pragma command `/** @jsxFrag JSXSlack.Fragment */`](https://babeljs.io/docs/en/babel-plugin-transform-react-jsx#custom-1).
 
@@ -645,9 +253,9 @@ const Header = ({ children }) => (
 
 > :warning: TypeScript cannot customize the factory method for fragment syntax. ([Microsoft/TypeScript#20469](https://github.com/Microsoft/TypeScript/issues/20469)) Please use `<Fragment>` component as usual.
 
-#### `jsxslack.fragment` template literal tag
+### `jsxslack.fragment` template literal tag
 
-You should use `jsxslack.fragment` template literal tag instead of `jsxslack` when you want to create HOC or custom block with prefering template literal to JSX transpiler.
+You should use **`jsxslack.fragment`** template literal tag instead of `jsxslack` when you want to create HOC or custom block with prefering template literal to JSX transpiler.
 
 ```javascript
 // Header.js
@@ -681,217 +289,6 @@ console.log(jsxslack`
 ```
 
 Please notice to a usage of component that has a bit different syntax from JSX.
-
-## HTML-like formatting
-
-Slack can format message by very rational short syntaxes called "mrkdwn". On the other hand, someone might yearn for a template engine with clear tag definition like HTML, especially when building a complex message.
-
-jsx-slack has HTML-compatible JSX elements to format messages. It might be verbose as a text, but would give readablity by well-known HTML elements.
-
-You may also use a regular mrkdwn syntax to format if necessary.
-
-### Format text style
-
-- `<i>`, `<em>`: _Italic text_
-- `<b>`, `<strong>`: **Bold text**
-- `<s>`, `<strike>`, `<del>`: ~~Strikethrough text~~
-- `<code>`: `Inline code`
-
-### Line breaks
-
-As same as HTML, line breaks in JSX will be ignored, and replace to a single whitespace. You shoud use `<br />` tag in this case.
-
-### HTML block contents
-
-- `<p>` tag just makes a blank line around contents. Slack would render it as like as paragraph.
-- `<blockquote>` adds `>` character to the first of each lines for highlighting as quote.
-- `<pre>` tag will recognize the content as formatted-text, and wrapped content by ` ``` ` .
-
-#### List simulation
-
-We can simulate the list provided from `<ul>` and `<ol>` tag by using mimicked text.
-
-```html
-<ul>
-  <li>Item A</li>
-  <li>
-    Item B
-    <ul>
-      <li>Sub item 1</li>
-      <li>
-        Sub item 2
-        <ul>
-          <li>and more...</li>
-        </ul>
-      </li>
-    </ul>
-  </li>
-  <li>
-    Item C
-    <ol>
-      <li>Ordered item 1</li>
-      <li>Ordered item 2</li>
-    </ol>
-  </li>
-</ul>
-```
-
-The above would be replaced to just a plain text like this:
-
-```
-• Item A
-• Item B
-  ◦ Sub item 1
-  ◦ Sub item 2
-    ▪︎ and more...
-• Item C
-  1. Ordered item 1
-  2. Ordered item 2
-```
-
-### Links
-
-jsx-slack will not recognize URL-like string as hyperlink. You should use `<a href="">` if you want using a link.
-
-For example, `<a href="https://example.com/">Link</a>` will be converted to `<https://example.com/|Link>`, and rendered as like as "[Link](https://example.com)".
-
-#### To Slack channel
-
-`<a href="#C024BE7LR" />` means a link to Slack channel. You have to set **_PUBLIC_ channel's ID, not channel name,** as an anchor. [Refer details to documentation by Slack](https://api.slack.com/messaging/composing/formatting#linking-channels) for more details.
-
-If defined what except URL as `href` attribute, _you cannot use a custom content because Slack would fill the content automatically._ Unlike HTML specification, `<a>` tag allows to use as void element `<a />`.
-
-#### Mention to user and user group
-
-As like as channel link, `<a href="@U024BE7LH" />` (and `<a href="@W41S032FC" />` for [Enterprise Grid](https://api.slack.com/enterprise-grid#user_ids)) means a mention to specified user.
-
-jsx-slack can mention to user groups with a same syntax `<a href="@SAZ94GDB8" />` by detecting user group ID prefixed `S`.
-
-Of course, we also support special mentions like `@here`, `@channel`, and `@everyone`.
-
-### Date formatting
-
-[Slack supports date formatting for localization by timezone.](https://api.slack.com/messaging/composing/formatting#date-formatting) jsx-slack also support it by HTML5 `<time>` tag.
-
-```jsx
-<time datetime="1392734382">{'Posted {date_num} {time_secs}'}</time>
-// => "<!date^1392734382^Posted {date_num} {time_secs}|Posted 2014-02-18 14:39:42 PM>"
-
-<time datetime="1392734382">{'{date} at {time}'}</time>
-// => "<!date^1392734382^{date} at {time}|February 18th, 2014 at 14:39 PM>"
-
-<a href="https://example.com/">
-  <time datetime="1392734382" fallback="Feb 18, 2014 PST">
-    {'{date_short}'}
-  </time>
-</a>
-// => "<!date^1392734382^{date_short}^https://example.com/|Feb 18, 2014 PST>"
-```
-
-An optional fallback text may specify via additional `fallback` attribute. If it is not defined, jsx-slack will generate the fallback text in UTC from template string.
-
-### Correspondence table
-
-#### Basics
-
-|            jsx-slack             |       Slack mrkdwn        |
-| :------------------------------: | :-----------------------: |
-|         `<i>Italic</i>`          |        `_Italic_`         |
-|        `<em>Italic</em>`         |        `_Italic_`         |
-|          `<b>Bold</b>`           |         `*Bold*`          |
-|     `<strong>Bold</strong>`      |         `*Bold*`          |
-|         `<s>Strike</s>`          |        `~Strike~`         |
-|       `<del>Strike</del>`        |        `~Strike~`         |
-|        `Line<br />break`         |       `Line\nbreak`       |
-|      `<p>foo</p><p>bar</p>`      |       `foo\n\nbar`        |
-| `<blockquote>quote</blockquote>` |       `&gt; quote`        |
-|       `<code>code</code>`        |       `` `code` ``        |
-|   `<pre>{'code\nblock'}</pre>`   | ` ```\ncode\nblock\n``` ` |
-|     `<ul><li>List</li></ul>`     |         `• List`          |
-
-#### Links
-
-|                  jsx-slack                   |            Slack mrkdwn            |
-| :------------------------------------------: | :--------------------------------: |
-|  `<a href="https://example.com/">Link</a>`   |   `<https://example.com/\|Link>`   |
-| `<a href="mailto:mail@example.com">Mail</a>` | `<mailto:mail@example.com/\|Mail>` |
-|          `<a href="#C024BE7LR" />`           |           `<#C024BE7LR>`           |
-|          `<a href="@U024BE7LH" />`           |           `<@U024BE7LH>`           |
-|          `<a href="@SAZ94GDB8" />`           |       `<!subteam^SAZ94GDB8>`       |
-|             `<a href="@here" />`             |          `<!here\|here>`           |
-|           `<a href="@channel" />`            |       `<!channel\|channel>`        |
-|           `<a href="@everyone" />`           |      `<!everyone\|everyone>`       |
-
-## About escape
-
-jsx-slack are making effort to be focusable only to contents of your message. Nevertheless, we may require you to consider escaping contents.
-
-### Special characters
-
-We think that anyone never wants to care about special characters for Slack mrkdwn while using jsx-slack. But unfortunately, Slack does not provide how to escape special characters for formatting text. :thinking:
-
-The content would break when JSX contents may have mrkdwn special characters like `*` `_` `~` `` ` `` `>`.
-
-#### `<Escape>`: Escape special characters
-
-To battle against breaking message, we provide `<Escape>` component to replace special characters into another similar character.
-
-```jsx
-<Blocks>
-  <Section>&gt; *bold* _italic_ ~strikethrough~ `code`</Section>
-  <Section>
-    <Escape>&gt; *bold* _italic_ ~strikethrough~ `code`</Escape>
-  </Section>
-</Blocks>
-```
-
-[<img src="https://raw.githubusercontent.com/speee/jsx-slack/master/docs/preview-btn.svg?sanitize=true" width="240" />](https://bit.ly/2SSNLtz)
-
-**By using `<Escape>`, please notice that it may change characters in contents.** jsx-slack will leave mrkdwn by default to avoid unintended contents interpolation via escape. _We recommend using `<Escape>` only to unpredictable contents like made by users._
-
-##### Details
-
-`>` (`&gt;`) and `＞` (`U+FF1E`) would recognize as blockquote only when it has coming to the beginning of line. If it was found, we will add normally invisible soft hyphen (`U+00AD`) to the beginning.
-
-Other special chars will replace to another Unicode character whose similar shape.
-
-- `*` :arrow_right: `∗` (Asterisk operator: `U+2217`)
-- `＊` :arrow_right: `﹡` (Small asterisk: `U+FF0A`)
-- `_` :arrow_right: `ˍ` (Modifier letter low macron: `U+02CD`)
-- `＿` :arrow_right: `⸏` (Paragraphos: `U+2E0F`)
-- `` ` `` :arrow_right: `ˋ` (Modifier letter grave accent: `U+02CB`)
-- `｀` :arrow_right: `ˋ` (Modifier letter grave accent: `U+02CB`)
-- `~` :arrow_right: `∼` (Tilde operator: `U+223C`)
-
-These replacements also will trigger by using corresponded HTML tag. (e.g. `*` and `＊` in the contents of `<b>` tag)
-
-### Exact mode
-
-Some special characters will work only in breaks of words. Take a look this example:
-
-```jsx
-<Blocks>
-  <Section>
-    Super<i>cali</i>fragilistic<b>expiali</b>docious
-  </Section>
-</Blocks>
-```
-
-We expect showing the post as follow:
-
-> Super*cali*fragilistic**expiali**docious
-
-However, Slack renders as:
-
-> Super_cali_fragilistic\*expiali\*docious
-
-[<img src="https://raw.githubusercontent.com/speee/jsx-slack/master/docs/preview-btn.svg?sanitize=true" width="240" />](https://api.slack.com/tools/block-kit-builder?blocks=%5B%7B%22type%22%3A%22section%22%2C%22text%22%3A%7B%22text%22%3A%22Super_cali_fragilistic*expiali*docious%22%2C%22type%22%3A%22mrkdwn%22%2C%22verbatim%22%3Atrue%7D%7D%5D)
-
-You can deal workaround via `SlackJSX.exactMode(true)`. It can enable formatting forcibly by inserting zero-width space around special chars.
-
-[<img src="https://raw.githubusercontent.com/speee/jsx-slack/master/docs/preview-btn.svg?sanitize=true" width="240" />](https://api.slack.com/tools/block-kit-builder?blocks=%5B%7B%22type%22%3A%22section%22%2C%22text%22%3A%7B%22text%22%3A%22Super%E2%80%8B_%E2%80%8Bcali%E2%80%8B_%E2%80%8Bfragilistic%E2%80%8B*%E2%80%8Bexpiali%E2%80%8B*%E2%80%8Bdocious%22%2C%22type%22%3A%22mrkdwn%22%2C%22verbatim%22%3Atrue%7D%7D%5D)
-
-**Exact mode is a last resort.** _We recommend dealing with incorrect rendering by such as inserting spaces around markup elements._
 
 ## Similar projects
 

--- a/README.md
+++ b/README.md
@@ -187,11 +187,27 @@ export default function exampleDialog(data) {
 }
 ```
 
-> :warning: Currently it's only available in JSX transpiler. You cannot build dialog JSON with template literal.
-
 ### References
 
 - **[JSX components for dialog](docs/jsx-components-for-dialog.md)**
+
+> :information_source: Currently dialog components in `jsxslack` template literal have to use imported components from `@speee-js/jsx-slack/dialog`.
+>
+> ```javascript
+> import { jsxslack } from '@speee-js/jsx-slack'
+> import { Dialog, Input, Textarea } from '@speee-js/jsx-slack/dialog'
+>
+> const exampleDialog = data => jsxslack`
+>   <${Dialog} callbackId="create" title="Create">
+>     <${Input} name="name" label="Name" value=${data.name} required />
+>     <${Textarea} name="desc" label="Description" value=${data.desc} />
+> 
+>     <${Input} type="hidden" name="userId" value=${data.userId} />
+>     <${Input} type="submit" value="Create" />
+>   <//>
+> `
+> export default exampleDialog
+> ```
 
 ## Fragments
 

--- a/dialog.d.ts
+++ b/dialog.d.ts
@@ -1,0 +1,1 @@
+export * from './types/dialog/index'

--- a/dialog.js
+++ b/dialog.js
@@ -1,0 +1,1 @@
+module.exports = require('./lib/dialog/index')

--- a/docs/about-escape-and-exact-mode.md
+++ b/docs/about-escape-and-exact-mode.md
@@ -1,0 +1,70 @@
+# About escape and exact mode
+
+jsx-slack are making effort to be focusable only to contents of your message. Nevertheless, we may require you to consider escaping contents.
+
+## Special characters
+
+We think that anyone never wants to care about special characters for Slack mrkdwn while using jsx-slack. But unfortunately, Slack does not provide how to escape special characters for formatting text. :thinking:
+
+The content would break when JSX contents may have mrkdwn special characters like `*`, `_`, `~`, `` ` ``, and `>`.
+
+### `<Escape>`: Escape special characters
+
+To battle against breaking message, we provide `<Escape>` component to replace special characters into another similar character.
+
+```jsx
+<Blocks>
+  <Section>&gt; *bold* _italic_ ~strikethrough~ `code`</Section>
+  <Section>
+    <Escape>&gt; *bold* _italic_ ~strikethrough~ `code`</Escape>
+  </Section>
+</Blocks>
+```
+
+[<img src="https://raw.githubusercontent.com/speee/jsx-slack/master/docs/preview-btn.svg?sanitize=true" width="240" />](https://bit.ly/2SSNLtz)
+
+**By using `<Escape>`, please notice that it may change characters in contents.** jsx-slack will leave mrkdwn by default to avoid unintended contents interpolation via escape. _We recommend using `<Escape>` only to unpredictable contents like made by users._
+
+#### Details
+
+`>` (`&gt;`) and `＞` (`U+FF1E`) would recognize as blockquote only when it has coming to the beginning of line. If it was found, we will add normally invisible soft hyphen (`U+00AD`) to the beginning.
+
+Other special chars will replace to another Unicode character whose similar shape.
+
+- `*` :arrow_right: `∗` (Asterisk operator: `U+2217`)
+- `＊` :arrow_right: `﹡` (Small asterisk: `U+FF0A`)
+- `_` :arrow_right: `ˍ` (Modifier letter low macron: `U+02CD`)
+- `＿` :arrow_right: `⸏` (Paragraphos: `U+2E0F`)
+- `` ` `` :arrow_right: `ˋ` (Modifier letter grave accent: `U+02CB`)
+- `｀` :arrow_right: `ˋ` (Modifier letter grave accent: `U+02CB`)
+- `~` :arrow_right: `∼` (Tilde operator: `U+223C`)
+
+These replacements also will trigger by using corresponded HTML tag. (e.g. `*` and `＊` in the contents of `<b>` tag)
+
+## Exact mode
+
+Some special characters will work only in breaks of words. Take a look this example:
+
+```jsx
+<Blocks>
+  <Section>
+    Super<i>cali</i>fragilistic<b>expiali</b>docious
+  </Section>
+</Blocks>
+```
+
+We expect showing the post as follow:
+
+> Super*cali*fragilistic**expiali**docious
+
+However, Slack renders as:
+
+> Super_cali_fragilistic\*expiali\*docious
+
+[<img src="https://raw.githubusercontent.com/speee/jsx-slack/master/docs/preview-btn.svg?sanitize=true" width="240" />](https://api.slack.com/tools/block-kit-builder?blocks=%5B%7B%22type%22%3A%22section%22%2C%22text%22%3A%7B%22text%22%3A%22Super_cali_fragilistic*expiali*docious%22%2C%22type%22%3A%22mrkdwn%22%2C%22verbatim%22%3Atrue%7D%7D%5D)
+
+You can deal workaround via `SlackJSX.exactMode(true)`. It can enable formatting forcibly by inserting zero-width space around special chars.
+
+[<img src="https://raw.githubusercontent.com/speee/jsx-slack/master/docs/preview-btn.svg?sanitize=true" width="240" />](https://api.slack.com/tools/block-kit-builder?blocks=%5B%7B%22type%22%3A%22section%22%2C%22text%22%3A%7B%22text%22%3A%22Super%E2%80%8B_%E2%80%8Bcali%E2%80%8B_%E2%80%8Bfragilistic%E2%80%8B*%E2%80%8Bexpiali%E2%80%8B*%E2%80%8Bdocious%22%2C%22type%22%3A%22mrkdwn%22%2C%22verbatim%22%3Atrue%7D%7D%5D)
+
+**Exact mode is a last resort.** _We recommend dealing with incorrect rendering by such as inserting spaces around markup elements._

--- a/docs/html-like-formatting.md
+++ b/docs/html-like-formatting.md
@@ -1,0 +1,141 @@
+# HTML-like formatting
+
+Slack can format message by very rational short syntaxes called [mrkdwn]. On the other hand, someone might yearn for a template engine with clear tag definition like HTML, especially when building a complex message.
+
+jsx-slack has HTML-compatible JSX elements to format messages. It might be verbose as a text, but would give readablity by well-known HTML elements.
+
+_Using HTML elements is not mandatory. You may also use [a regular mrkdwn syntax][mrkdwn] to format if necessary._
+
+[mrkdwn]: https://api.slack.com/docs/message-formatting
+
+## Format text style
+
+- `<i>`, `<em>`: _Italic text_
+- `<b>`, `<strong>`: **Bold text**
+- `<s>`, `<strike>`, `<del>`: ~~Strikethrough text~~
+- `<code>`: `Inline code`
+
+## Line breaks
+
+As same as HTML, line breaks in JSX will be ignored, and replace to a single whitespace. You shoud use `<br />` tag in this case.
+
+## HTML block contents
+
+- `<p>` tag just makes a blank line around contents. Slack would render it as like as paragraph.
+- `<blockquote>` adds `>` character to the first of each lines for highlighting as quote.
+- `<pre>` tag will recognize the content as formatted-text, and wrapped content by ` ``` ` .
+
+## List simulation
+
+We can simulate the list provided from `<ul>` and `<ol>` tag by using mimicked text.
+
+```html
+<ul>
+  <li>Item A</li>
+  <li>
+    Item B
+    <ul>
+      <li>Sub item 1</li>
+      <li>
+        Sub item 2
+        <ul>
+          <li>and more...</li>
+        </ul>
+      </li>
+    </ul>
+  </li>
+  <li>
+    Item C
+    <ol>
+      <li>Ordered item 1</li>
+      <li>Ordered item 2</li>
+    </ol>
+  </li>
+</ul>
+```
+
+The above would be replaced to just a plain text like this:
+
+```
+• Item A
+• Item B
+  ◦ Sub item 1
+  ◦ Sub item 2
+    ▪︎ and more...
+• Item C
+  1. Ordered item 1
+  2. Ordered item 2
+```
+
+## Links
+
+jsx-slack will not recognize URL-like string as hyperlink. You should use `<a href="">` whenever you want to use a link.
+
+For example, `<a href="https://example.com/">Link</a>` will be converted to `<https://example.com/|Link>`, and rendered as like as "[Link](https://example.com)".
+
+### To Slack channel
+
+`<a href="#C024BE7LR" />` means a link to Slack channel. You have to set **_PUBLIC_ channel's ID, not channel name,** as an anchor. [Refer details to documentation by Slack](https://api.slack.com/messaging/composing/formatting#linking-channels) for more details.
+
+If defined what except URL as `href` attribute, _you cannot use a custom content because Slack would fill the content automatically._ Unlike HTML specification, `<a>` tag allows to use as void element `<a />`.
+
+### Mention to user and user group
+
+As like as channel link, `<a href="@U024BE7LH" />` (and `<a href="@W41S032FC" />` for [Enterprise Grid](https://api.slack.com/enterprise-grid#user_ids)) means a mention to specified user.
+
+jsx-slack can mention to user groups with a same syntax `<a href="@SAZ94GDB8" />` by detecting user group ID prefixed `S`.
+
+Of course, we also support special mentions like `@here`, `@channel`, and `@everyone`.
+
+## Date formatting
+
+[Slack supports date formatting for localization by timezone.](https://api.slack.com/messaging/composing/formatting#date-formatting) jsx-slack also supports it by HTML5 `<time>` tag.
+
+```jsx
+<time datetime="1392734382">{'Posted {date_num} {time_secs}'}</time>
+// => "<!date^1392734382^Posted {date_num} {time_secs}|Posted 2014-02-18 14:39:42 PM>"
+
+<time datetime="1392734382">{'{date} at {time}'}</time>
+// => "<!date^1392734382^{date} at {time}|February 18th, 2014 at 14:39 PM>"
+
+<a href="https://example.com/">
+  <time datetime="1392734382" fallback="Feb 18, 2014 PST">
+    {'{date_short}'}
+  </time>
+</a>
+// => "<!date^1392734382^{date_short}^https://example.com/|Feb 18, 2014 PST>"
+```
+
+An optional fallback text may specify via additional `fallback` attribute. If it is not defined, jsx-slack will generate the fallback text in UTC from template string.
+
+## Correspondence table
+
+### Basics
+
+|            jsx-slack             |       Slack mrkdwn        |
+| :------------------------------: | :-----------------------: |
+|         `<i>Italic</i>`          |        `_Italic_`         |
+|        `<em>Italic</em>`         |        `_Italic_`         |
+|          `<b>Bold</b>`           |         `*Bold*`          |
+|     `<strong>Bold</strong>`      |         `*Bold*`          |
+|         `<s>Strike</s>`          |        `~Strike~`         |
+|       `<del>Strike</del>`        |        `~Strike~`         |
+|        `Line<br />break`         |       `Line\nbreak`       |
+|      `<p>foo</p><p>bar</p>`      |       `foo\n\nbar`        |
+| `<blockquote>quote</blockquote>` |       `&gt; quote`        |
+|       `<code>code</code>`        |       `` `code` ``        |
+|   `<pre>{'code\nblock'}</pre>`   | ` ```\ncode\nblock\n``` ` |
+|     `<ul><li>List</li></ul>`     |         `• List`          |
+
+### Links
+
+|                  jsx-slack                   |            Slack mrkdwn            |
+| :------------------------------------------: | :--------------------------------: |
+|  `<a href="https://example.com/">Link</a>`   |   `<https://example.com/\|Link>`   |
+| `<a href="mailto:mail@example.com">Mail</a>` | `<mailto:mail@example.com/\|Mail>` |
+|          `<a href="#C024BE7LR" />`           |           `<#C024BE7LR>`           |
+|          `<a href="@U024BE7LH" />`           |           `<@U024BE7LH>`           |
+|          `<a href="@SAZ94GDB8" />`           |       `<!subteam^SAZ94GDB8>`       |
+|             `<a href="@here" />`             |          `<!here\|here>`           |
+|           `<a href="@channel" />`            |       `<!channel\|channel>`        |
+|           `<a href="@everyone" />`           |      `<!everyone\|everyone>`       |

--- a/docs/jsx-components-for-block-kit.md
+++ b/docs/jsx-components-for-block-kit.md
@@ -1,0 +1,448 @@
+# JSX components for Block Kit
+
+## Blocks
+
+### `<Blocks>`
+
+A container component to use Block Kit. You should wrap Block Kit elements by `<Blocks>`.
+
+### [`<Section>`: Section Block](https://api.slack.com/reference/messaging/blocks#section)
+
+Display a simple text message. You have to specify the content as children. It allows [formatting with HTML-like elements](#html-like-formatting).
+
+`<section>` intrinsic HTML element works as well.
+
+```jsx
+<Blocks>
+  <Section>Hello, world!</Section>
+</Blocks>
+```
+
+[<img src="https://raw.githubusercontent.com/speee/jsx-slack/master/docs/preview-btn.svg?sanitize=true" width="240" />](https://api.slack.com/tools/block-kit-builder?blocks=%5B%7B%22type%22%3A%22section%22%2C%22text%22%3A%7B%22text%22%3A%22Hello%2C%20world!%22%2C%22type%22%3A%22mrkdwn%22%2C%22verbatim%22%3Atrue%7D%7D%5D)
+
+#### Props
+
+- `id` / `blockId` (optional): A string of unique identifier of block.
+
+#### Accessory
+
+The content of `<Section>` may include one of an accessory component. A defined element will show in side-by-side of text.
+
+```jsx
+<Blocks>
+  <Section>
+    You can add an image next to text in this block. :point_right:
+    <Image src="https://placekitten.com/256/256" alt="Accessory image" />
+  </Section>
+</Blocks>
+```
+
+[<img src="https://raw.githubusercontent.com/speee/jsx-slack/master/docs/preview-btn.svg?sanitize=true" width="240" />](https://api.slack.com/tools/block-kit-builder?blocks=%5B%7B%22type%22%3A%22section%22%2C%22text%22%3A%7B%22text%22%3A%22You%20can%20add%20an%20image%20next%20to%20text%20in%20this%20block.%20%3Apoint_right%3A%22%2C%22type%22%3A%22mrkdwn%22%2C%22verbatim%22%3Atrue%7D%2C%22accessory%22%3A%0A%7B%22type%22%3A%22image%22%2C%22alt_text%22%3A%22Accessory%20image%22%2C%22image_url%22%3A%22https%3A%2F%2Fplacekitten.com%2F256%2F256%22%7D%7D%5D)
+
+##### Accessory components
+
+- [`<Image>` / `<img>`](#image-image-block)
+- [`<Button>`](#button-button-element)
+- [`<Select>`](#select-select-menu-with-static-options)
+- [`<ExternalSelect>`](#externalselect-select-menu-with-external-data-source)
+- [`<UsersSelect>`](#usersselect-select-menu-with-user-list)
+- [`<ConversationsSelect>`](#conversationsselect-select-menu-with-conversations-list)
+- [`<ChannelsSelect>`](#channelsselect-select-menu-with-channel-list)
+- [`<Overflow>`](#overflow-overflow-menu)
+- [`<DatePicker>`](#datepicker-select-date-from-calendar)
+
+#### `<Field>`: Fields for section block
+
+In addition the text content, the section block also can use 2 columns texts called fields. In jsx-slack, you can define field by `<Field>` component in `<Section>` block.
+
+```jsx
+<Blocks>
+  <Section>
+    About this repository:
+    <Field>
+      <b>Name</b>
+      <br />
+      speee/jsx-slack
+    </Field>
+    <Field>
+      <b>Maintainer</b>
+      <br />
+      Yuki Hattori
+    </Field>
+    <Field>
+      <b>Organization</b>
+      <br />
+      Speee, Inc.
+    </Field>
+    <Image src="https://github.com/speee.png" alt="Speee, Inc." />
+  </Section>
+</Blocks>
+```
+
+[<img src="https://raw.githubusercontent.com/speee/jsx-slack/master/docs/preview-btn.svg?sanitize=true" width="240" />](https://api.slack.com/tools/block-kit-builder?blocks=%5B%7B%22type%22%3A%22section%22%2C%22text%22%3A%7B%22text%22%3A%22About%20this%20repository%3A%22%2C%22type%22%3A%22mrkdwn%22%2C%22verbatim%22%3Atrue%7D%2C%22accessory%22%3A%7B%22type%22%3A%22image%22%2C%22alt_text%22%3A%22Speee%2C%20Inc.%22%2C%22image_url%22%3A%22https%3A%2F%2Fgithub.com%2Fspeee.png%22%7D%2C%22fields%22%3A%5B%7B%22type%22%3A%22mrkdwn%22%2C%22text%22%3A%22*Name*%5Cnspeee%2Fjsx-slack%22%2C%22verbatim%22%3Atrue%7D%2C%7B%22type%22%3A%22mrkdwn%22%2C%22text%22%3A%22*Maintainer*%5CnYuki%20Hattori%22%2C%22verbatim%22%3Atrue%7D%2C%7B%22type%22%3A%22mrkdwn%22%2C%22text%22%3A%22*Organization*%5CnSpeee%2C%20Inc.%22%2C%22verbatim%22%3Atrue%7D%5D%7D%5D)
+
+> Contents of `<Field>` would be placed after the main text contents even if placed them anywhere.
+
+### [`<Divider>`: Divider Block](https://api.slack.com/reference/messaging/blocks#divider)
+
+Just a divider. `<hr>` intrinsic HTML element works as well.
+
+```jsx
+<Blocks>
+  <Divider />
+</Blocks>
+```
+
+[<img src="https://raw.githubusercontent.com/speee/jsx-slack/master/docs/preview-btn.svg?sanitize=true" width="240" />](https://api.slack.com/tools/block-kit-builder?blocks=%5B%7B%22type%22%3A%22divider%22%7D%5D)
+
+#### Props
+
+- `id` / `blockId` (optional): A string of unique identifier of block.
+
+### [`<Image>`: Image Block](https://api.slack.com/reference/messaging/blocks#image)
+
+Display an image block. It has well-known props like `<img>` HTML element. In fact, `<img>` intrinsic HTML element works as well.
+
+```jsx
+<Blocks>
+  <Image src="https://placekitten.com/500/500" alt="So cute kitten." />
+</Blocks>
+```
+
+[<img src="https://raw.githubusercontent.com/speee/jsx-slack/master/docs/preview-btn.svg?sanitize=true" width="240" />](https://api.slack.com/tools/block-kit-builder?blocks=%5B%7B%22type%22%3A%22image%22%2C%22alt_text%22%3A%22So%20cute%20kitten.%22%2C%22image_url%22%3A%22https%3A%2F%2Fplacekitten.com%2F500%2F500%22%7D%5D)
+
+#### Props
+
+- `src` (**required**): The URL of the image.
+- `alt` (**required**): A plain-text summary of the image.
+- `title` (optional): An optional title for the image.
+- `id` / `blockId` (optional): A string of unique identifier of block.
+
+### [`<Actions>`: Actions Block](https://api.slack.com/reference/messaging/blocks#actions)
+
+A block to hold [interactive elements](#interactive-elements). Slack allows a maximum of 25 interactive elements in `<Actions>` (But recommends to place up to 5 elements).
+
+#### Props
+
+- `id` / `blockId` (optional): A string of unique identifier of block.
+
+### [`<Context>`: Context Block](https://api.slack.com/reference/messaging/blocks#context)
+
+Display message context. It allows mixed contents consisted of texts and `<Image>` components / `<img>` tags.
+
+```jsx
+<Blocks>
+  <Context>
+    <img src="https://placekitten.com/100/100" alt="Kitten" />
+    A kitten and
+    <img src="https://placekitten.com/100/100" alt="Kitten" />
+    more kitten.
+  </Context>
+</Blocks>
+```
+
+[<img src="https://raw.githubusercontent.com/speee/jsx-slack/master/docs/preview-btn.svg?sanitize=true" width="240" />](https://api.slack.com/tools/block-kit-builder?blocks=%5B%7B%22type%22%3A%22context%22%2C%22elements%22%3A%5B%7B%22type%22%3A%22image%22%2C%22image_url%22%3A%22https%3A%2F%2Fplacekitten.com%2F100%2F100%22%2C%22alt_text%22%3A%22Kitten%22%7D%2C%7B%22type%22%3A%22mrkdwn%22%2C%22text%22%3A%22A%20kitten%20and%22%2C%22verbatim%22%3Atrue%7D%2C%7B%22type%22%3A%22image%22%2C%22image_url%22%3A%22https%3A%2F%2Fplacekitten.com%2F100%2F100%22%2C%22alt_text%22%3A%22Kitten%22%7D%2C%7B%22type%22%3A%22mrkdwn%22%2C%22text%22%3A%22more%20kitten.%22%2C%22verbatim%22%3Atrue%7D%5D%7D%5D)
+
+Text contents will merge in pertinent mrkdwn elements automatically, but they also may divide clearly by using `<span>` HTML intrinsic element.
+
+```jsx
+<Blocks>
+  <Context>
+    <span>
+      ◤<br />◤<br />◤
+    </span>
+    <span>
+      ◤<br />◤
+    </span>
+    <span>◤</span>
+    multiple mrkdwns
+  </Context>
+</Blocks>
+```
+
+[<img src="https://raw.githubusercontent.com/speee/jsx-slack/master/docs/preview-btn.svg?sanitize=true" width="240" />](https://api.slack.com/tools/block-kit-builder?blocks=%5B%7B%22type%22%3A%22context%22%2C%22elements%22%3A%5B%7B%22type%22%3A%22mrkdwn%22%2C%22text%22%3A%22%E2%97%A4%5Cn%E2%97%A4%5Cn%E2%97%A4%22%2C%22verbatim%22%3Atrue%7D%2C%7B%22type%22%3A%22mrkdwn%22%2C%22text%22%3A%22%E2%97%A4%5Cn%E2%97%A4%22%2C%22verbatim%22%3Atrue%7D%2C%7B%22type%22%3A%22mrkdwn%22%2C%22text%22%3A%22%E2%97%A4%22%2C%22verbatim%22%3Atrue%7D%2C%7B%22type%22%3A%22mrkdwn%22%2C%22text%22%3A%22multiple%20mrkdwns%22%2C%22verbatim%22%3Atrue%7D%5D%7D%5D)
+
+> :warning: Slack restricts the number of elements consisted of text contents and images up to 10. jsx-slack throws an error if the number of generated elements is going over the limit.
+
+#### Props
+
+- `id` / `blockId` (optional): A string of unique identifier of block.
+
+### [`<File>`: File Block](https://api.slack.com/reference/messaging/blocks#file)
+
+Display a remote file that was added to Slack workspace. [Learn about adding remote files in the document of Slack API.](https://api.slack.com/messaging/files/remote)
+
+```jsx
+<Blocks>
+  <File externalId="ABCD1" />
+</Blocks>
+```
+
+#### Props
+
+- `externalId` (**required**): A string of unique ID for the file to show.
+- `id` / `blockId` (optional): A string of unique identifier of block.
+- `source` (optional): Override `source` field. At the moment, you should not take care this because only the default value `remote` is available.
+
+## Interactive elements
+
+Some blocks may include the interactive component to exchange info with Slack app.
+
+### [`<Button>`: Button element](https://api.slack.com/reference/messaging/block-elements#button)
+
+A simple button to send action to registered Slack App, or open external URL.
+
+```jsx
+<Blocks>
+  <Actions>
+    <Button actionId="action" value="value" style="primary">
+      Action button
+    </Button>
+    <Button url="https://example.com/">Link to URL</Button>
+  </Actions>
+</Blocks>
+```
+
+[<img src="https://raw.githubusercontent.com/speee/jsx-slack/master/docs/preview-btn.svg?sanitize=true" width="240" />](https://api.slack.com/tools/block-kit-builder?blocks=%5B%7B%22type%22%3A%22actions%22%2C%22elements%22%3A%5B%7B%22type%22%3A%22button%22%2C%22text%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Action%20button%22%2C%22emoji%22%3Atrue%7D%2C%22action_id%22%3A%22action%22%2C%22style%22%3A%22primary%22%2C%22value%22%3A%22value%22%7D%2C%7B%22type%22%3A%22button%22%2C%22text%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Link%20to%20URL%22%2C%22emoji%22%3Atrue%7D%2C%22url%22%3A%22https%3A%2F%2Fexample.com%2F%22%7D%5D%7D%5D)
+
+#### Props
+
+- `actionId` (optional): An identifier for the action.
+- `value` (optional): A string value to send to Slack App when clicked button.
+- `url` (optional): URL to load when clicked button.
+- `style` (optional): Select the colored button decoration from `primary` and `danger`.
+- `confirm` (optional): [`<Confirm>` element](#confirm-confirmation-dialog) to show confirmation dialog.
+
+### [`<Select>`: Select menu with static options](https://api.slack.com/reference/messaging/block-elements#static-select)
+
+A menu element with static options passed by `<Option>` or `<Optgroup>`. It has a interface similar to `<select>` HTML element.
+
+```jsx
+<Blocks>
+  <Actions>
+    <Select actionId="rating" placeholder="Rate it!">
+      <Option value="5">5 :star::star::star::star::star:</Option>
+      <Option value="4">4 :star::star::star::star:</Option>
+      <Option value="3">3 :star::star::star:</Option>
+      <Option value="2">2 :star::star:</Option>
+      <Option value="1">1 :star:</Option>
+    </Select>
+  </Actions>
+</Blocks>
+```
+
+[<img src="https://raw.githubusercontent.com/speee/jsx-slack/master/docs/preview-btn.svg?sanitize=true" width="240" />](https://api.slack.com/tools/block-kit-builder?blocks=%5B%7B%22type%22%3A%22actions%22%2C%22elements%22%3A%5B%7B%22type%22%3A%22static_select%22%2C%22placeholder%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Rate%20it!%22%2C%22emoji%22%3Atrue%7D%2C%22action_id%22%3A%22rating%22%2C%22options%22%3A%5B%7B%22value%22%3A%225%22%2C%22text%22%3A%7B%22text%22%3A%225%20%3Astar%3A%3Astar%3A%3Astar%3A%3Astar%3A%3Astar%3A%22%2C%22type%22%3A%22plain_text%22%2C%22emoji%22%3Atrue%7D%7D%2C%7B%22value%22%3A%224%22%2C%22text%22%3A%7B%22text%22%3A%224%20%3Astar%3A%3Astar%3A%3Astar%3A%3Astar%3A%22%2C%22type%22%3A%22plain_text%22%2C%22emoji%22%3Atrue%7D%7D%2C%7B%22value%22%3A%223%22%2C%22text%22%3A%7B%22text%22%3A%223%20%3Astar%3A%3Astar%3A%3Astar%3A%22%2C%22type%22%3A%22plain_text%22%2C%22emoji%22%3Atrue%7D%7D%2C%7B%22value%22%3A%222%22%2C%22text%22%3A%7B%22text%22%3A%222%20%3Astar%3A%3Astar%3A%22%2C%22type%22%3A%22plain_text%22%2C%22emoji%22%3Atrue%7D%7D%2C%7B%22value%22%3A%221%22%2C%22text%22%3A%7B%22text%22%3A%221%20%3Astar%3A%22%2C%22type%22%3A%22plain_text%22%2C%22emoji%22%3Atrue%7D%7D%5D%7D%5D%7D%5D)
+
+#### Props
+
+- `actionId` (optional): An identifier for the action.
+- `placeholder` (optional): A plain text to be shown at first.
+- `value` (optional): A value of item to show initially. It must choose value from defined `<Option>` elements in children.
+- `confirm` (optional): [`<Confirm>` element](#confirm-confirmation-dialog) to show confirmation dialog.
+
+#### `<Option>`: Menu item
+
+##### Props
+
+- `value` (**required**): A string value to send to Slack App when choose item.
+
+#### `<Optgroup>`: Group of menu items
+
+```jsx
+<Blocks>
+  <Actions>
+    <Select actionId="action" placeholder="Action...">
+      <Optgroup label="Search with">
+        <Option value="search_google">Google</Option>
+        <Option value="search_bing">Bing</Option>
+        <Option value="search_duckduckgo">DuckDuckGo</Option>
+      </Optgroup>
+      <Optgroup label="Share to">
+        <Option value="share_facebook">Facebook</Option>
+        <Option value="share_twitter">Twitter</Option>
+      </Optgroup>
+    </Select>
+  </Actions>
+</Blocks>
+```
+
+[<img src="https://raw.githubusercontent.com/speee/jsx-slack/master/docs/preview-btn.svg?sanitize=true" width="240" />](https://api.slack.com/tools/block-kit-builder?blocks=%5B%7B%22type%22%3A%22actions%22%2C%22elements%22%3A%5B%7B%22type%22%3A%22static_select%22%2C%22placeholder%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Action...%22%2C%22emoji%22%3Atrue%7D%2C%22action_id%22%3A%22action%22%2C%22option_groups%22%3A%5B%7B%22label%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Search%20with%22%2C%22emoji%22%3Atrue%7D%2C%22options%22%3A%5B%7B%22value%22%3A%22search_google%22%2C%22text%22%3A%7B%22text%22%3A%22Google%22%2C%22type%22%3A%22plain_text%22%2C%22emoji%22%3Atrue%7D%7D%2C%7B%22value%22%3A%22search_bing%22%2C%22text%22%3A%7B%22text%22%3A%22Bing%22%2C%22type%22%3A%22plain_text%22%2C%22emoji%22%3Atrue%7D%7D%2C%7B%22value%22%3A%22search_duckduckgo%22%2C%22text%22%3A%7B%22text%22%3A%22DuckDuckGo%22%2C%22type%22%3A%22plain_text%22%2C%22emoji%22%3Atrue%7D%7D%5D%7D%2C%7B%22label%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Share%20to%22%2C%22emoji%22%3Atrue%7D%2C%22options%22%3A%5B%7B%22value%22%3A%22share_facebook%22%2C%22text%22%3A%7B%22text%22%3A%22Facebook%22%2C%22type%22%3A%22plain_text%22%2C%22emoji%22%3Atrue%7D%7D%2C%7B%22value%22%3A%22share_twitter%22%2C%22text%22%3A%7B%22text%22%3A%22Twitter%22%2C%22type%22%3A%22plain_text%22%2C%22emoji%22%3Atrue%7D%7D%5D%7D%5D%7D%5D%7D%5D)
+
+##### Props
+
+- `label` (**required**): A plain text to be shown as a group name.
+
+### [`<ExternalSelect>`: Select menu with external data source](https://api.slack.com/reference/messaging/block-elements#external-select)
+
+You should use `<ExternalSelect>` if you want to provide the dynamic list from external source.
+
+It requires setup JSON entry URL in your Slack app. [Learn about external source in Slack documentation.](https://api.slack.com/reference/messaging/block-elements#external-select)
+
+```jsx
+<Blocks>
+  <Actions>
+    <ExternalSelect
+      actionId="category"
+      placeholder="Select category..."
+      minQueryLength={2}
+    />
+  </Actions>
+</Blocks>
+```
+
+[<img src="https://raw.githubusercontent.com/speee/jsx-slack/master/docs/preview-btn.svg?sanitize=true" width="240" />](https://api.slack.com/tools/block-kit-builder?blocks=%5B%7B%22type%22%3A%22actions%22%2C%22elements%22%3A%5B%7B%22type%22%3A%22external_select%22%2C%22placeholder%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Select%20category...%22%2C%22emoji%22%3Atrue%7D%2C%22action_id%22%3A%22category%22%2C%22min_query_length%22%3A2%7D%5D%7D%5D)
+
+#### Props
+
+- `actionId` (optional): An identifier for the action.
+- `placeholder` (optional): A plain text to be shown at first.
+- `initialOption` (optional): An initial option exactly matched to provided options from external source. It allows raw JSON object or `<Option>`.
+- `minQueryLength` (optional): A length of typed characters to begin JSON request.
+- `confirm` (optional): [`<Confirm>` element](#confirm-confirmation-dialog) to show confirmation dialog.
+
+#### `<SelectFragment>`: Generate options for external source
+
+You would want to build not only the message but also the data source by jsx-slack. `<SelectFragment>` component can create JSON object for external data source usable in `<ExternalSelect>`.
+
+A following is a simple example to serve JSON for external select via [express](https://expressjs.com/). It is using [`jsxslack` tagged template literal](../README.md#quick-start-template-literal).
+
+```javascript
+import { jsxslack } from '@speee-js/jsx-slack'
+import express from 'express'
+
+const app = express()
+
+app.get('/external-data-source', (req, res) => {
+  res.json(jsxslack`
+    <SelectFragment>
+      <Option value="item-a">Item A</Option>
+      <Option value="item-b">Item B</Option>
+      <Option value="item-c">Item C</Option>
+    </SelectFragment>
+  `)
+})
+
+app.listen(80)
+```
+
+### [`<UsersSelect>`: Select menu with user list](https://api.slack.com/reference/messaging/block-elements#users-select)
+
+A select menu with options consisted of users in the current workspace.
+
+#### Props
+
+- `actionId` (optional): An identifier for the action.
+- `placeholder` (optional): A plain text to be shown at first.
+- `initialUser` (optional): The initial user ID.
+- `confirm` (optional): [`<Confirm>` element](#confirm-confirmation-dialog) to show confirmation dialog.
+
+### [`<ConversationsSelect>`: Select menu with conversations list](https://api.slack.com/reference/messaging/block-elements#conversation-select)
+
+A select menu with options consisted of any type of conversations in the current workspace.
+
+#### Props
+
+- `actionId` (optional): An identifier for the action.
+- `placeholder` (optional): A plain text to be shown at first.
+- `initialConversation` (optional): The initial conversation ID.
+- `confirm` (optional): [`<Confirm>` element](#confirm-confirmation-dialog) to show confirmation dialog.
+
+### [`<ChannelsSelect>`: Select menu with channel list](https://api.slack.com/reference/messaging/block-elements#channel-select)
+
+A select menu with options consisted of public channels in the current workspace.
+
+#### Props
+
+- `actionId` (optional): An identifier for the action.
+- `placeholder` (optional): A plain text to be shown at first.
+- `initialChannel` (optional): The initial channel ID.
+- `confirm` (optional): [`<Confirm>` element](#confirm-confirmation-dialog) to show confirmation dialog.
+
+### [`<Overflow>`: Overflow menu](https://api.slack.com/reference/messaging/block-elements#overflow)
+
+An overflow menu displayed as `...` can access to some hidden menu items by many actions. _It must contain least of 2 `<OverflowItem>` components._
+
+```jsx
+<Blocks>
+  <Actions>
+    <Overflow actionId="overflow_menu">
+      <OverflowItem value="share">Share</OverflowItem>
+      <OverflowItem value="reply">Reply message</OverflowItem>
+      <OverflowItem url="https://example.com/">Open in browser</OverflowItem>
+    </Overflow>
+  </Actions>
+</Blocks>
+```
+
+[<img src="https://raw.githubusercontent.com/speee/jsx-slack/master/docs/preview-btn.svg?sanitize=true" width="240" />](https://api.slack.com/tools/block-kit-builder?blocks=%5B%7B%22type%22%3A%22actions%22%2C%22elements%22%3A%5B%7B%22type%22%3A%22overflow%22%2C%22action_id%22%3A%22overflow_menu%22%2C%22options%22%3A%5B%7B%22text%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Share%22%2C%22emoji%22%3Atrue%7D%2C%22value%22%3A%22share%22%7D%2C%7B%22text%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Reply%20message%22%2C%22emoji%22%3Atrue%7D%2C%22value%22%3A%22reply%22%7D%2C%7B%22text%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Open%20in%20browser%22%2C%22emoji%22%3Atrue%7D%2C%22url%22%3A%22https%3A%2F%2Fexample.com%2F%22%7D%5D%7D%5D%7D%5D)
+
+#### Props
+
+- `actionId` (optional): An identifier for the action.
+- `confirm` (optional): [`<Confirm>` element](#confirm-confirmation-dialog) to show confirmation dialog when clicked menu item.
+
+#### `<OverflowItem>`: Menu item in overflow menu
+
+##### Props
+
+- `value` (optional): A string value to send to Slack App when choose item.
+- `url` (optional): URL to load when clicked button.
+
+### [`<DatePicker>`: Select date from calendar](https://api.slack.com/reference/messaging/block-elements#datepicker)
+
+An easy way to let the user selecting any date is using `<DatePicker>` component.
+
+```jsx
+<Blocks>
+  <Actions>
+    <DatePicker actionId="date_picker" initialDate={new Date()} />
+  </Actions>
+</Blocks>
+```
+
+[<img src="https://raw.githubusercontent.com/speee/jsx-slack/master/docs/preview-btn.svg?sanitize=true" width="240" />](https://api.slack.com/tools/block-kit-builder?blocks=%5B%7B%22type%22%3A%22actions%22%2C%22elements%22%3A%5B%7B%22type%22%3A%22datepicker%22%2C%22action_id%22%3A%22date_picker%22%2C%22initial_date%22%3A%222019-02-22%22%7D%5D%7D%5D)
+
+#### Props
+
+- `actionId` (optional): An identifier for the action.
+- `placeholder` (optional): A plain text to be shown at first.
+- `initialDate` (optional): An initially selected date. It allows `YYYY-MM-DD` formatted string, UNIX timestamp in millisecond, and JavaScript [`Date`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date) instance.
+- `confirm` (optional): [`<Confirm>` element](#confirm-confirmation-dialog) to show confirmation dialog.
+
+## Components for [composition objects](https://api.slack.com/reference/messaging/composition-objects)
+
+### [`<Confirm>`: Confirmation dialog](https://api.slack.com/reference/messaging/composition-objects#confirm)
+
+Define confirmation dialog. Some interactive elements can open confirmation dialog when selected, by passing `<Confirm>` to `confirm` prop.
+
+```jsx
+<Blocks>
+  <Actions>
+    <Button
+      actionId="commit"
+      value="value"
+      confirm={
+        <Confirm title="Commit your action" confirm="Yes, please" deny="Cancel">
+          <b>Are you sure?</b> Please confirm your action again.
+        </Confirm>
+      }
+    >
+      Commit
+    </Button>
+  </Actions>
+</Blocks>
+```
+
+[<img src="https://raw.githubusercontent.com/speee/jsx-slack/master/docs/confirmation.png" width="500" />][confirmation]
+
+[<img src="https://raw.githubusercontent.com/speee/jsx-slack/master/docs/preview-btn.svg?sanitize=true" width="240" />][confirmation]
+
+[confirmation]: https://api.slack.com/tools/block-kit-builder?blocks=%5B%7B%22type%22%3A%22actions%22%2C%22elements%22%3A%5B%7B%22type%22%3A%22button%22%2C%22text%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Commit%22%2C%22emoji%22%3Atrue%7D%2C%22action_id%22%3A%22commit%22%2C%22confirm%22%3A%7B%22title%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Commit%20your%20action%22%2C%22emoji%22%3Atrue%7D%2C%22text%22%3A%7B%22type%22%3A%22mrkdwn%22%2C%22text%22%3A%22*Are%20you%20sure%3F*%20Please%20confirm%20your%20action%20again.%22%2C%22verbatim%22%3Atrue%7D%2C%22confirm%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Yes%2C%20please%22%2C%22emoji%22%3Atrue%7D%2C%22deny%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Cancel%22%2C%22emoji%22%3Atrue%7D%7D%2C%22value%22%3A%22value%22%7D%5D%7D%5D
+
+> :information_source: You can use [HTML-like formatting](./html-like-formatting.md) to the content of confirmation dialog. However, you have to be careful that Slack ignores any line breaks and the content will render just in a line.
+
+#### Props
+
+- `title` (**required**): The title of confirmation dialog.
+- `confirm` (**required**): A text content of the button to confirm.
+- `deny` (**required**): A text content of the button to cancel.

--- a/docs/jsx-components-for-dialog.md
+++ b/docs/jsx-components-for-dialog.md
@@ -43,7 +43,7 @@ export default function exampleDialog(name) {
 }
 ```
 
-## `<Dialog>`: [Create dialog JSON](https://api.slack.com/dialogs#top-level_dialog_attributes)
+## [`<Dialog>`: Create dialog JSON](https://api.slack.com/dialogs#top-level_dialog_attributes)
 
 A container component to build dialog JSON. You should wrap 1-10 dialog element(s) by `<Dialog>`.
 
@@ -73,7 +73,7 @@ Input element is used mainly for adding text field to dialog. It has almost same
 
 The behavior of `<Input>` component varies depending on `type` prop (`text` by default).
 
-### `<Input type="text">`: [Text field](https://api.slack.com/dialogs#text_elements)
+### [`<Input type="text">`: Text field](https://api.slack.com/dialogs#text_elements)
 
 ```jsx
 <Dialog callbackId="example" title="Example">
@@ -90,13 +90,13 @@ The behavior of `<Input>` component varies depending on `type` prop (`text` by d
 
 #### Props
 
-- `name` (**required**): The name of input element. (48 character maximum)
-- `label` (**required**): The label string for input element. (300 character maximum)
+- `name` (**required**): The name of input element. (48 characters maximum)
+- `label` (**required**): The label string for input element. (300 characters maximum)
 - `type` (optional): `text` by default. You can use `text` and [additional HTML5 types](#html5-types), `email`, `number`, `tel`, and `url` as the input element.
-- `placeholder` (optional): Specify a text string appears within the content of input is empty. (150 character maximum)
+- `placeholder` (optional): Specify a text string appears within the content of input is empty. (150 characters maximum)
 - `required` (optional): A boolean prop to specify whether user must fill any value. `false` by default for HTML compatibility, and _it is different from Slack's default._
-- `title` / `hint` (optional): Specify a helpful text appears under the input element. `title` is alias to `hint` prop for keeping HTML compatibility. (150 character maximum)
-- `value` (optional): The default value for this element. (150 character maximum)
+- `title` / `hint` (optional): Specify a helpful text appears under the input element. `title` is alias to `hint` prop for keeping HTML compatibility. (150 characters maximum)
+- `value` (optional): The default value for this element. (150 characters maximum)
 - `maxLength` (optional): The maximum number of characters allowed for the input element. It must up to 150 character.
 - `minLength` (optional): The minimum number of characters allowed for the input element. It must up to 150 character.
 
@@ -181,9 +181,9 @@ As like as `hidden` type, **`submitLabel` prop in `<Dialog>` must not define whe
 - `type` (**required**): Must be `submit`.
 - `value` (**required**): A string of submit button for current dialog. (24 characters maximum)
 
-## `<Textarea>`: [Textarea field](https://api.slack.com/dialogs#textarea_elements)
+## [`<Textarea>`: Textarea field](https://api.slack.com/dialogs#textarea_elements)
 
-Put multiline text field as same as `<textarea>` HTML element.
+Puts multiline text field as same as `<textarea>` HTML element.
 
 ```jsx
 <Dialog callbackId="example" title="Example">
@@ -200,25 +200,153 @@ Put multiline text field as same as `<textarea>` HTML element.
 
 #### Props
 
-- `name` (**required**): The name of textarea element. (48 character maximum)
-- `label` (**required**): The label string for textarea element. (300 character maximum)
+- `name` (**required**): The name of textarea element. (48 characters maximum)
+- `label` (**required**): The label string for textarea element. (300 characters maximum)
 - `subtype` (optional): The subtype for textarea element that can choose from `email`, `number`, `tel`, and `url`. [As like as `type` prop in `<Input>`](#html5-types), it's useful for typing with better keyboard in mobile device.
-- `placeholder` (optional): Specify a text string appears within the content of textarea is empty. (150 character maximum)
+- `placeholder` (optional): Specify a text string appears within the content of textarea is empty. (150 characters maximum)
 - `required` (optional): A boolean prop to specify whether user must fill any value. `false` by default.
-- `title` / `hint` (optional): Specify a helpful text appears under the textarea element. `title` is alias to `hint` prop. (150 character maximum)
-- `value` (optional): The default value for this element. (3000 character maximum)
+- `title` / `hint` (optional): Specify a helpful text appears under the textarea element. `title` is alias to `hint` prop. (150 characters maximum)
+- `value` (optional): The default value for this element. (3000 characters maximum)
 - `maxLength` (optional): The maximum number of characters allowed for the textarea element. It must up to 3000 character.
 - `minLength` (optional): The minimum number of characters allowed for the textarea element. It must up to 3000 character.
 
-## `<Select>`
+## [`<Select>`: Select field with static options](https://api.slack.com/dialogs#select_elements)
 
-### `<Option>`
+> :information_source: `<Select>` and similar components are provided to [Block Kit](./jsx-components-for-block-kit.md##select-select-menu-with-static-options) too. There is a difference in the specification of input props and output JSON between Block Kit and dialog. So you must exactly use components imported from `@speee-js/jsx-slack/dialog`, not `@speee-js/jsx-slack`.
 
-### `<Optgroup>`
+Provides select field to pick single one from multiple static options passed by `<Option>` or `<Optgroup>`. It has a interface similar to `<select>` HTML element.
 
-## `<ExternalSelect>`
+```jsx
+<Dialog callbackId="example" title="Example">
+  <Select name="rating" label="Rating" required>
+    <Option value="5">5 {':star:'.repeat(5)}</Option>
+    <Option value="4">4 {':star:'.repeat(4)}</Option>
+    <Option value="3">3 {':star:'.repeat(3)}</Option>
+    <Option value="2">2 {':star:'.repeat(2)}</Option>
+    <Option value="1">1 {':star:'.repeat(1)}</Option>
+  </Select>
+</Dialog>
+```
+
+`<Select>` allows containing up to 100 options.
+
+#### Props
+
+- `name` (**required**): The name of select element. (48 characters maximum)
+- `label` (**required**): The label string for select element. (300 characters maximum)
+- `placeholder` (optional): Specify a text string appears when the option is not selected. (150 characters maximum)
+- `required` (optional): A boolean prop to specify whether user must select any option. `false` by default.
+- `title` / `hint` (optional): Specify a helpful text appears under the select element. `title` is alias to `hint` prop. (150 characters maximum)
+- `value` (optional): The default value for this element. (75 characters maximum)
+
+### `<Option>`: Option item
+
+Define an option item for `<Select>` and `<Optgroup>`. The text content of element will be used as the label of item. (75 characters maximum)
+
+#### Props
+
+- `value` (**required**): A string value for this option. (75 characters maximum)
+
+### `<Optgroup>`: Group of options
+
+```jsx
+<Dialog callbackId="example" title="Example">
+  <Select name="favorite_pet" label="Favorite pet">
+    <Optgroup label="Dog">
+      <Option value="labrador">Labrador</Option>
+      <Option value="german_shepherd">German Shepherd</Option>
+      <Option value="golden_retriver">Golden Retriever</Option>
+      <Option value="bulldog">Bulldog</Option>
+    </Optgroup>
+    <Optgroup label="Cat">
+      <Option value="scottish_fold">Scottish Fold</Option>
+      <Option value="american_shorthair">American Shorthair</Option>
+      <Option value="munchkin">Munchkin</Option>
+      <Option value="russian_blue">Russian Blue</Option>
+    </Optgroup>
+  </Select>
+</Dialog>
+```
+
+#### Props
+
+- `label` (**required**): The label string for the group of options. (75 characters maximum)
+
+## [`<ExternalSelect>`: Select field with external data source](https://api.slack.com/dialogs#dynamic_select_elements_external)
+
+```jsx
+<Dialog callbackId="example" title="Example">
+  <ExternalSelect
+    name="category"
+    label="Category"
+    placeholder="Select category..."
+    minQueryLength={2}
+  />
+</Dialog>
+```
 
 ### `<SelectFragment>`
+
+#### Example
+
+This is a practical example providing external source with selection narrowing through [Slack Bolt](https://slack.dev/bolt).
+
+```javascript
+/** @jsx JSXSlack.h */
+import { App } from '@slack/bolt'
+import JSXSlack from '@speee-js/jsx-slack'
+import { SelectFragment, Option } from '@speee-js/jsx-slack/dialog'
+
+const codenames = {
+  cupcake: 'Cupcake',
+  donut: 'Donut',
+  eclair: 'Eclair',
+  froyo: 'Froyo',
+  gingerbread: 'Gingerbread',
+  honeycomb: 'Honeycomb',
+  iceCreamSandwich: 'Ice Cream Sandwich',
+  JellyBean: 'Jelly Bean',
+  kitKat: 'KitKat',
+  lollipop: 'Lollipop',
+  marshmallow: 'Marshmallow',
+  nougat: 'Nougat',
+  oreo: 'Oreo',
+  pie: 'Pie',
+}
+
+const app = new App({
+  token: process.env.SLACK_BOT_TOKEN,
+  signingSecret: process.env.SLACK_SIGNING_SECRET,
+})
+
+// React to external select in <Dialog callbackId="android">
+app.options({ callback_id: 'android' }, ({ options, ack }) => {
+  const query = options.value.toLowerCase()
+
+  ack(
+    JSXSlack(
+      <SelectFragment>
+        {Object.keys(codenames).map(
+          code =>
+            codenames[code].toLowerCase().startsWith(query) && (
+              <Option value={code}>{codenames[code]}</Option>
+            )
+        )}
+      </SelectFragment>
+    )
+  )
+})
+
+// Start Bolt server
+;(async () => {
+  const port = process.env.PORT || 8080
+
+  await app.start(port)
+  consolt.log(`Bolt server is running on port ${port}.`)
+})()
+```
+
+You have to set up _"Options Load URL"_ in [your app](https://api.slack.com/apps) :arrow_forward: `Interactive Components` :arrow_forward: `Message Menus` to `https://your-hosted-app.url/slack/events`. (e.g. [ngrok](https://ngrok.com/) URL + `/slack/events` for testing on local)
 
 ## `<UsersSelect>`
 

--- a/docs/jsx-components-for-dialog.md
+++ b/docs/jsx-components-for-dialog.md
@@ -1,0 +1,3 @@
+# JSX components for dialog
+
+Under construction.

--- a/docs/jsx-components-for-dialog.md
+++ b/docs/jsx-components-for-dialog.md
@@ -149,6 +149,12 @@ And please take care that the maximum length validation will still apply for str
 
 [As Slack recommends](https://api.slack.com/dialogs#state), the best practice is only storing the value of a pointer to reference data stored elsewhere. _Don't store sensitive data as state and hidden value directly._
 
+#### Props
+
+- `type` (**required**): Must be `hidden`.
+- `name` (**required**): The name of hidden value.
+- `value` (**required**): A hidden value to store as the dialog state. It must be [a serializable value to JSON](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#Description).
+
 ### `<Input type="submit">`: Set the label of submit button
 
 `<Input type="submit">` can set the label of submit button for current dialog. It is meaning just an alias to `submitLabel` prop of `<Dialog>`, but JSX looks like more natural HTML form.
@@ -169,6 +175,11 @@ As you guessed, it is same as below:
 ```
 
 As like as `hidden` type, **`submitLabel` prop in `<Dialog>` must not define when using `<Input type="submit">`.** The dialog component prefers props defined directly.
+
+#### Props
+
+- `type` (**required**): Must be `submit`.
+- `value` (**required**): A string of submit button for current dialog. (24 characters maximum)
 
 ## `<Textarea>`
 

--- a/docs/jsx-components-for-dialog.md
+++ b/docs/jsx-components-for-dialog.md
@@ -43,7 +43,7 @@ export default function exampleDialog(name) {
 }
 ```
 
-## `<Dialog>`: Create dialog JSON
+## `<Dialog>`: [Create dialog JSON](https://api.slack.com/dialogs#top-level_dialog_attributes)
 
 A container component to build dialog JSON. You should wrap 1-10 dialog element(s) by `<Dialog>`.
 
@@ -59,7 +59,7 @@ A container component to build dialog JSON. You should wrap 1-10 dialog element(
 </Dialog>
 ```
 
-### Props
+#### Props
 
 - `callbackId` (**required**): A string of identifier for dialog. (255 characters maximum)
 - `title` (**required**): An user-facing title of dialog. (24 characters maximum)
@@ -73,7 +73,7 @@ Input element is used mainly for adding text field to dialog. It has almost same
 
 The behavior of `<Input>` component varies depending on `type` prop (`text` by default).
 
-### `<Input type="text">`: Text field
+### `<Input type="text">`: [Text field](https://api.slack.com/dialogs#text_elements)
 
 ```jsx
 <Dialog callbackId="example" title="Example">
@@ -145,7 +145,7 @@ You can use hidden values by parsing JSON stored in callbacked `state` prop.
 
 **`state` prop in parent `<Dialog>` must not define when using `<Input type="hidden">`.** The parent dialog prefers `state` prop than `<Input type="hidden">` whenever it has any value in `state` prop.
 
-And please take care that the maximum length validation will still apply for stringified JSON. The value like string and array that cannot predict the length might exceed the limit of JSON string length easily (3000 characters).
+And please take care that the maximum length validation will still apply for stringified JSON. The value like string and array that cannot predict the length might over the limit of JSON string length easily (3000 characters).
 
 [As Slack recommends](https://api.slack.com/dialogs#state), the best practice is only storing the value of a pointer to reference data stored elsewhere. _Don't store sensitive data as state and hidden value directly._
 
@@ -181,7 +181,34 @@ As like as `hidden` type, **`submitLabel` prop in `<Dialog>` must not define whe
 - `type` (**required**): Must be `submit`.
 - `value` (**required**): A string of submit button for current dialog. (24 characters maximum)
 
-## `<Textarea>`
+## `<Textarea>`: [Textarea field](https://api.slack.com/dialogs#textarea_elements)
+
+Put multiline text field as same as `<textarea>` HTML element.
+
+```jsx
+<Dialog callbackId="example" title="Example">
+  <Textarea name="content" label="Content" required />
+  <Textarea
+    name="tweet"
+    label="Tweet"
+    placeholder="Optional..."
+    title="You can tweet about published content."
+    maxLength={140}
+  />
+</Dialog>
+```
+
+#### Props
+
+- `name` (**required**): The name of textarea element. (48 character maximum)
+- `label` (**required**): The label string for textarea element. (300 character maximum)
+- `subtype` (optional): The subtype for textarea element that can choose from `email`, `number`, `tel`, and `url`. [As like as `type` prop in `<Input>`](#html5-types), it's useful for typing with better keyboard in mobile device.
+- `placeholder` (optional): Specify a text string appears within the content of textarea is empty. (150 character maximum)
+- `required` (optional): A boolean prop to specify whether user must fill any value. `false` by default.
+- `title` / `hint` (optional): Specify a helpful text appears under the textarea element. `title` is alias to `hint` prop. (150 character maximum)
+- `value` (optional): The default value for this element. (3000 character maximum)
+- `maxLength` (optional): The maximum number of characters allowed for the textarea element. It must up to 3000 character.
+- `minLength` (optional): The minimum number of characters allowed for the textarea element. It must up to 3000 character.
 
 ## `<Select>`
 

--- a/docs/jsx-components-for-dialog.md
+++ b/docs/jsx-components-for-dialog.md
@@ -1,3 +1,101 @@
 # JSX components for dialog
 
-Under construction.
+Dialog components provide from another entry point **`@speee-js/jsx-slack/dialog`** because the specification is different from Block Kit.
+
+Thus, you have to import `JSXSlack` and dialog components from 2 entries normally.
+
+```javascript
+/** @jsx JSXSlack.h */
+import JSXSlack from '@speee-js/jsx-slack'
+import { Dialog, Input, Textarea } from '@speee-js/jsx-slack/dialog'
+```
+
+## `<Dialog>`: Create dialog JSON
+
+A container component to build dialog JSON. You should wrap 1-10 dialog element(s) by `<Dialog>`.
+
+```jsx
+<Dialog
+  callbackId="createAccount"
+  title="Create account"
+  state="id:1"
+  submitLabel="Create"
+  notifyOnCancel={true}
+>
+  ...
+</Dialog>
+```
+
+### Props
+
+- `callbackId` (**required**): A string of identifier for dialog. (255 characters maximum)
+- `title` (**required**): An user-facing title of dialog. (24 characters maximum)
+- `state` (optional): An optional string that will be echoed back to Slack app after interacting with dialog. The value specified in this prop is preferred than `<Input type="hidden">`. (3000 characters maximum)
+- `submitLabel` (optional): A string of submit button for dialog. The value specified in this prop is preferred than `<Input type="submit">`. (24 characters maximum)
+- `notifyOnCancel` (optional): A boolean attribute whether notify to Slack app on canceling dialog interaction by user. `false` by default.
+
+## `<Input>`
+
+Input element is used mainly for adding text field to dialog. It has almost same interface with `<input>` HTML element.
+
+In fact, a behavior of `<Input>` component varies depending on `type` prop. The default type is `text`.
+
+### `<Input type="text">`: Text field
+
+```jsx
+<Dialog callbackId="example" title="Example">
+  <Input type="text" name="name" label="Name" required />
+  <Input
+    name="id"
+    label="Your ID"
+    placeholder="Optional (Generate automatically if empty)"
+    title="Up to 16 characters."
+    maxLength={16}
+  />
+</Dialog>
+```
+
+#### Props
+
+- `name` (**required**):
+- `label` (**required**):
+- `type` (optional): `text` by default. You can use `text` and [additional HTML5 types](#html5-types), `email`, `number`, `tel`, and `url`.
+- `placeholder` (optional):
+- `required` (optional):
+- `title` / `hint` (optional):
+- `value` (optional):
+- `maxLength` (optional):
+- `minLength` (optional):
+
+#### HTML5 types
+
+- `<Input type="email">`
+- `<Input type="number">`
+- `<Input type="tel">`
+- `<Input type="url">`
+
+These types are same as `type="text"` except the appropriate subtype will be passed to Slack. These types allow using a suitable on-screen keyboard in mobile device.
+
+> :warning: Slack never validate the input value. `type` prop is using only for selecting the best keyboard to input.
+
+### `<Input type="hidden">`: Pass JSON state
+
+### `<Input type="submit">`: Set the label of submit button
+
+## `<Textarea>`
+
+## `<Select>`
+
+### `<Option>`
+
+### `<Optgroup>`
+
+## `<ExternalSelect>`
+
+### `<SelectFragment>`
+
+## `<UsersSelect>`
+
+## `<ConversationsSelect>`
+
+## `<ChannelsSelect>`

--- a/docs/jsx-components-for-dialog.md
+++ b/docs/jsx-components-for-dialog.md
@@ -274,20 +274,45 @@ Define an option item for `<Select>` and `<Optgroup>`. The text content of eleme
 
 ## [`<ExternalSelect>`: Select field with external data source](https://api.slack.com/dialogs#dynamic_select_elements_external)
 
+You should use `<ExternalSelect>` if you want to provide options from external source dynamically.
+
+It requires setting up URL for external source in your Slack app. [Learn about an external source in Slack documentation.](https://api.slack.com/dialogs#dynamic_select_elements_external)
+
 ```jsx
 <Dialog callbackId="example" title="Example">
   <ExternalSelect
     name="category"
     label="Category"
     placeholder="Select category..."
+    initialOption={<Option value="unknown">Unknown</Option>}
     minQueryLength={2}
+    required
   />
 </Dialog>
 ```
 
-### `<SelectFragment>`
+#### Props
 
-#### Example
+- `name` (**required**): The name of select element. (48 characters maximum)
+- `label` (**required**): The label string for select element. (300 characters maximum)
+- `placeholder` (optional): Specify a text string appears when the option is not selected. (150 characters maximum)
+- `required` (optional): A boolean prop to specify whether user must select any option. `false` by default.
+- `title` / `hint` (optional): Specify a helpful text appears under the select element. `title` is alias to `hint` prop. (150 characters maximum)
+- `initialOption` (optional): An initial option exactly matched to provided options from external source. It allows raw JSON object or `<Option>`.
+- `minQueryLength` (optional): A length of typed characters to begin JSON request.
+
+### `<SelectFragment>`: Generate options for external source
+
+`<SelectFragment>` can create JSON object for external data source usable in `<ExternalSelect>`. As same as `<Select>`, please include static options by using `<Option>` or `<Optgroup>`.
+
+```jsx
+<SelectFragment>
+  <Option value="foo">Foo</Option>
+  <Option value="bar">Bar</Option>
+</SelectFragment>
+```
+
+### Example: Serve external source with [Slack bolt](https://slack.dev/bolt)
 
 This is a practical example providing external source with selection narrowing through [Slack Bolt](https://slack.dev/bolt).
 
@@ -346,10 +371,37 @@ app.options({ callback_id: 'android' }, ({ options, ack }) => {
 })()
 ```
 
-You have to set up _"Options Load URL"_ in [your app](https://api.slack.com/apps) :arrow_forward: `Interactive Components` :arrow_forward: `Message Menus` to `https://your-hosted-app.url/slack/events`. (e.g. [ngrok](https://ngrok.com/) URL + `/slack/events` for testing on local)
+Please set up "Options Load URL" in [your app](https://api.slack.com/apps) :arrow_forward: `Interactive Components` :arrow_forward: `Message Menus` to `https://your-hosted-app.url/slack/events`. (e.g. [ngrok](https://ngrok.com/) URL + `/slack/events` for testing on local)
 
-## `<UsersSelect>`
+## [`<UsersSelect>`: Select field with user list](https://api.slack.com/dialogs#dynamic_select_elements_users)
 
-## `<ConversationsSelect>`
+#### Props
 
-## `<ChannelsSelect>`
+- `name` (**required**): The name of select element. (48 characters maximum)
+- `label` (**required**): The label string for select element. (300 characters maximum)
+- `placeholder` (optional): Specify a text string appears when user is not selected. (150 characters maximum)
+- `required` (optional): A boolean prop to specify whether it must be selected any user. `false` by default.
+- `title` / `hint` (optional): Specify a helpful text appears under the select element. `title` is alias to `hint` prop. (150 characters maximum)
+- `initialUser` (optional): The initial user ID.
+
+## [`<ConversationsSelect>`: Select field with conversations](https://api.slack.com/dialogs#dynamic_select_elements_channels_conversations)
+
+#### Props
+
+- `name` (**required**): The name of select element. (48 characters maximum)
+- `label` (**required**): The label string for select element. (300 characters maximum)
+- `placeholder` (optional): Specify a text string appears when conversation is not selected. (150 characters maximum)
+- `required` (optional): A boolean prop to specify whether it must be selected any conversation. `false` by default.
+- `title` / `hint` (optional): Specify a helpful text appears under the select element. `title` is alias to `hint` prop. (150 characters maximum)
+- `initialConversation` (optional): The initial conversation ID.
+
+## [`<ChannelsSelect>`: Select field with channels](https://api.slack.com/dialogs#dynamic_select_elements_channels_conversations)
+
+#### Props
+
+- `name` (**required**): The name of select element. (48 characters maximum)
+- `label` (**required**): The label string for select element. (300 characters maximum)
+- `placeholder` (optional): Specify a text string appears when channel is not selected. (150 characters maximum)
+- `required` (optional): A boolean prop to specify whether it must be selected any channel. `false` by default.
+- `title` / `hint` (optional): Specify a helpful text appears under the select element. `title` is alias to `hint` prop. (150 characters maximum)
+- `initialChannel` (optional): The initial channel ID.

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   "types": "types/index.js",
   "files": [
     "lib/",
-    "types/"
+    "types/",
+    "dialog.js"
   ],
   "scripts": {
     "build": "rimraf lib && tsc",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   "files": [
     "lib/",
     "types/",
-    "dialog.js"
+    "dialog.js",
+    "dialog.d.ts"
   ],
   "scripts": {
     "build": "rimraf lib && tsc",

--- a/src/block-kit/interactive/Select.tsx
+++ b/src/block-kit/interactive/Select.tsx
@@ -57,12 +57,12 @@ interface OptgroupProps {
   children: JSXSlack.Children<OptionInternal>
 }
 
-interface OptionInternal extends OptionProps {
+export interface OptionInternal extends OptionProps {
   type: 'option'
   text: string
 }
 
-interface OptgroupInternal extends OptgroupProps {
+export interface OptgroupInternal extends OptgroupProps {
   type: 'optgroup'
 }
 

--- a/src/dialog/.eslintrc.yml
+++ b/src/dialog/.eslintrc.yml
@@ -1,0 +1,2 @@
+rules:
+  import/prefer-default-export: off

--- a/src/dialog/Dialog.tsx
+++ b/src/dialog/Dialog.tsx
@@ -16,12 +16,12 @@ export interface DialogProps {
 export const validateElement = (props: { name: string; label: string }) => {
   if (props.label.length > 48)
     throw new DialogValidationError(
-      `The label of text field must be up to 48 characters but a string with ${props.label.length} characters was passed.`
+      `The label of element must be up to 48 characters but a string with ${props.label.length} characters was passed.`
     )
 
   if (props.name.length > 300)
     throw new DialogValidationError(
-      `The name of text field must be up to 300 characters but a string with ${props.name.length} characters was passed.`
+      `The name of element must be up to 300 characters but a string with ${props.name.length} characters was passed.`
     )
 }
 

--- a/src/dialog/Dialog.tsx
+++ b/src/dialog/Dialog.tsx
@@ -21,7 +21,7 @@ export const Dialog: JSXSlack.FC<DialogProps> = props => {
   const parsed: any[] = JSXSlack(<ArrayOutput>{props.children}</ArrayOutput>)
 
   parsed.forEach(obj => {
-    if (!obj) return
+    if (typeof obj !== 'object') return
 
     switch (obj.type) {
       case 'text':

--- a/src/dialog/Dialog.tsx
+++ b/src/dialog/Dialog.tsx
@@ -2,6 +2,7 @@
 import { Dialog as SlackDialog } from '@slack/types'
 import { JSXSlack } from '../jsx'
 import { ArrayOutput, ObjectOutput } from '../utils'
+import { DialogValidationError } from './error'
 
 export interface DialogProps {
   callbackId: string
@@ -10,6 +11,18 @@ export interface DialogProps {
   submitLabel?: string
   title: string
   notifyOnCancel?: boolean
+}
+
+export const validateElement = (props: { name: string; label: string }) => {
+  if (props.label.length > 48)
+    throw new DialogValidationError(
+      `The label of text field must be up to 48 characters but a string with ${props.label.length} characters was passed.`
+    )
+
+  if (props.name.length > 300)
+    throw new DialogValidationError(
+      `The name of text field must be up to 300 characters but a string with ${props.name.length} characters was passed.`
+    )
 }
 
 export const Dialog: JSXSlack.FC<DialogProps> = props => {
@@ -41,12 +54,41 @@ export const Dialog: JSXSlack.FC<DialogProps> = props => {
     }
   })
 
+  const state =
+    props.state || (stateJSON ? JSON.stringify(stateJSON) : undefined)
+
+  // Validation
+  if (props.title.length > 24)
+    throw new DialogValidationError(
+      `The title of dialog must be up to 24 characters but a string with ${props.title.length} characters was passed.`
+    )
+
+  if (props.callbackId.length > 255)
+    throw new DialogValidationError(
+      `The callback ID of dialog must be up to 255 characters but a string with ${props.callbackId.length} characters was passed.`
+    )
+
+  if (elements.length > 10)
+    throw new DialogValidationError(
+      `Up to 10 form elements are allowed in dialog but ${elements.length} elements were passed.`
+    )
+
+  if (state && state.length > 3000)
+    throw new DialogValidationError(
+      `A state string of dialog must be up to 3000 characters but a string with ${state.length} characters was passed.`
+    )
+
+  if (submitLabel && submitLabel.length > 24)
+    throw new DialogValidationError(
+      `The label of submit button must be up to 24 characters but a string with ${submitLabel.length} characters was passed.`
+    )
+
   return (
     <ObjectOutput<SlackDialog>
       title={props.title}
       callback_id={props.callbackId}
       elements={elements}
-      state={props.state || (stateJSON ? JSON.stringify(stateJSON) : undefined)}
+      state={state}
       submit_label={submitLabel}
       notify_on_cancel={props.notifyOnCancel}
     />

--- a/src/dialog/Dialog.tsx
+++ b/src/dialog/Dialog.tsx
@@ -13,7 +13,14 @@ export interface DialogProps {
   notifyOnCancel?: boolean
 }
 
-export const validateElement = (props: { name: string; label: string }) => {
+interface DialogElementProps {
+  hint?: string
+  label: string
+  name: string
+  title?: string
+}
+
+export const validateElement = (props: DialogElementProps) => {
   if (props.label.length > 48)
     throw new DialogValidationError(
       `The label of element must be up to 48 characters but a string with ${props.label.length} characters was passed.`
@@ -23,6 +30,21 @@ export const validateElement = (props: { name: string; label: string }) => {
     throw new DialogValidationError(
       `The name of element must be up to 300 characters but a string with ${props.name.length} characters was passed.`
     )
+
+  // `title` prop is an alias to `hint` for HTML compatibility.
+  const hint = props.hint || props.title
+
+  if (hint && hint.length > 150) {
+    throw new DialogValidationError(
+      `A ${
+        props.hint ? 'hint' : 'title'
+      } string of element must be up to 150 characters but a string with ${
+        hint.length
+      } characters was passed.`
+    )
+  }
+
+  return { hint }
 }
 
 export const Dialog: JSXSlack.FC<DialogProps> = props => {

--- a/src/dialog/Dialog.tsx
+++ b/src/dialog/Dialog.tsx
@@ -1,0 +1,54 @@
+/** @jsx JSXSlack.h */
+import { Dialog as SlackDialog } from '@slack/types'
+import { JSXSlack } from '../jsx'
+import { ArrayOutput, ObjectOutput } from '../utils'
+
+export interface DialogProps {
+  callbackId: string
+  children: JSXSlack.Children<{}>
+  state?: string
+  submitLabel?: string
+  title: string
+  notifyOnCancel?: boolean
+}
+
+export const Dialog: JSXSlack.FC<DialogProps> = props => {
+  let { submitLabel } = props
+  let stateJSON
+
+  // Parse elements
+  const elements: SlackDialog['elements'] = []
+  const parsed: any[] = JSXSlack(<ArrayOutput>{props.children}</ArrayOutput>)
+
+  parsed.forEach(obj => {
+    if (!obj) return
+
+    switch (obj.type) {
+      case 'text':
+      case 'textarea':
+      case 'select':
+        elements.push(obj)
+        break
+      case 'submit':
+        submitLabel = submitLabel || obj.value
+        break
+      case 'hidden':
+        stateJSON = stateJSON || {}
+        stateJSON[obj.name] = obj.value
+        break
+      default:
+        throw new Error(`Unknown element type: ${obj.type}`)
+    }
+  })
+
+  return (
+    <ObjectOutput<SlackDialog>
+      title={props.title}
+      callback_id={props.callbackId}
+      elements={elements}
+      state={props.state || (stateJSON ? JSON.stringify(stateJSON) : undefined)}
+      submit_label={submitLabel}
+      notify_on_cancel={props.notifyOnCancel}
+    />
+  )
+}

--- a/src/dialog/Dialog.tsx
+++ b/src/dialog/Dialog.tsx
@@ -34,7 +34,10 @@ export const Dialog: JSXSlack.FC<DialogProps> = props => {
   const parsed: any[] = JSXSlack(<ArrayOutput>{props.children}</ArrayOutput>)
 
   parsed.forEach(obj => {
-    if (typeof obj !== 'object') return
+    if (typeof obj !== 'object')
+      throw new DialogValidationError(
+        '<Dialog> allows only including dialog components.'
+      )
 
     switch (obj.type) {
       case 'text':
@@ -50,7 +53,7 @@ export const Dialog: JSXSlack.FC<DialogProps> = props => {
         stateJSON[obj.name] = obj.value
         break
       default:
-        throw new Error(`Unknown element type: ${obj.type}`)
+        throw new DialogValidationError(`Unknown element type: ${obj.type}`)
     }
   })
 
@@ -66,6 +69,11 @@ export const Dialog: JSXSlack.FC<DialogProps> = props => {
   if (props.callbackId.length > 255)
     throw new DialogValidationError(
       `The callback ID of dialog must be up to 255 characters but a string with ${props.callbackId.length} characters was passed.`
+    )
+
+  if (elements.length === 0)
+    throw new DialogValidationError(
+      'Dialog must have the least of one element.'
     )
 
   if (elements.length > 10)

--- a/src/dialog/Input.tsx
+++ b/src/dialog/Input.tsx
@@ -77,7 +77,7 @@ export const Input: JSXSlack.FC<InputProps> = props => {
     default:
       return (
         <Text
-          hint={props.hint || props.title}
+          hint={props.hint}
           label={props.label}
           maxLength={props.maxLength}
           minLength={props.minLength}
@@ -85,6 +85,7 @@ export const Input: JSXSlack.FC<InputProps> = props => {
           optional={!props.required}
           placeholder={props.placeholder}
           subtype={subtype}
+          title={props.title}
           value={props.value}
         />
       )

--- a/src/dialog/Input.tsx
+++ b/src/dialog/Input.tsx
@@ -12,6 +12,7 @@ interface InputPropsBase {
   name: string
   placeholder?: string
   required?: boolean
+  title?: string
   value?: string
 }
 
@@ -76,7 +77,7 @@ export const Input: JSXSlack.FC<InputProps> = props => {
     default:
       return (
         <Text
-          hint={props.hint}
+          hint={props.hint || props.title}
           label={props.label}
           maxLength={props.maxLength}
           minLength={props.minLength}

--- a/src/dialog/Input.tsx
+++ b/src/dialog/Input.tsx
@@ -1,0 +1,90 @@
+/** @jsx JSXSlack.h */
+import { JSXSlack } from '../jsx'
+import { ObjectOutput } from '../utils'
+import { Text, TextProps } from './Text'
+
+interface InputPropsBase {
+  hint?: string
+  label: string
+  maxLength?: number
+  minLength?: number
+  name: string
+  placeholder?: string
+  required?: boolean
+  value?: string
+}
+
+interface TextInputProps extends InputPropsBase {
+  type?: 'text'
+}
+
+interface EmailInputProps extends InputPropsBase {
+  type: 'email'
+}
+
+interface NumberInputProps extends InputPropsBase {
+  type: 'number'
+}
+
+interface TelInputProps extends InputPropsBase {
+  type: 'tel'
+}
+
+interface UrlInputProps extends InputPropsBase {
+  type: 'url'
+}
+
+interface HiddenInputProps {
+  type: 'hidden'
+  name: string
+  value: any
+}
+
+interface SubmitInputProps {
+  type: 'submit'
+  value: string
+}
+
+type InputProps =
+  | TextInputProps
+  | EmailInputProps
+  | NumberInputProps
+  | TelInputProps
+  | UrlInputProps
+  | HiddenInputProps
+  | SubmitInputProps
+
+type InputElementInternal = HiddenInputProps | SubmitInputProps
+
+// <Input> has an interface to keep compatibility with HTML as possible.
+export const Input: JSXSlack.FC<InputProps> = props => {
+  let subtype: TextProps['subtype'] | undefined
+
+  switch (props.type) {
+    case 'hidden':
+    case 'submit':
+      return <ObjectOutput<InputElementInternal> {...props} />
+
+    case 'email':
+    case 'number':
+    case 'tel':
+    case 'url':
+      subtype = props.type
+
+    // eslint-disable-next-line no-fallthrough
+    default:
+      return (
+        <Text
+          hint={props.hint}
+          label={props.label}
+          maxLength={props.maxLength}
+          minLength={props.minLength}
+          name={props.name}
+          optional={!props.required}
+          placeholder={props.placeholder}
+          subtype={subtype}
+          value={props.value}
+        />
+      )
+  }
+}

--- a/src/dialog/Input.tsx
+++ b/src/dialog/Input.tsx
@@ -4,6 +4,7 @@ import { ObjectOutput } from '../utils'
 import { Text, TextProps } from './Text'
 
 interface InputPropsBase {
+  children?: undefined
   hint?: string
   label: string
   maxLength?: number

--- a/src/dialog/Select.tsx
+++ b/src/dialog/Select.tsx
@@ -142,12 +142,20 @@ export const SelectFragment: JSXSlack.FC<SelectFragmentProps> = props => {
       return <ObjectOutput<SelectFragmentObject<'options'>> options={options} />
     }
     case 'optgroup': {
-      const optGroups = (opts as JSXSlack.Node<OptgroupInternal>[]).map(n => ({
-        label: n.props.label,
-        options: filter(n.props.children).map(o => createOption(o.props)),
-      }))
+      let optsCount = 0
 
-      const optsCount = optGroups.reduce((t, v) => t + v.options.length, 0)
+      const optGroups = (opts as JSXSlack.Node<OptgroupInternal>[]).map(n => {
+        const { children, label } = n.props
+        const options = filter(children).map(o => createOption(o.props))
+
+        if (label.length > 75)
+          throw new DialogValidationError(
+            `A label of the option group for select field must be up to 75 characters but a string with ${label.length} characters was passed.`
+          )
+
+        optsCount += options.length
+        return { label, options }
+      })
 
       if (optsCount > 100)
         throw new DialogValidationError(

--- a/src/dialog/Select.tsx
+++ b/src/dialog/Select.tsx
@@ -1,0 +1,201 @@
+/** @jsx JSXSlack.h */
+import { Dialog, SelectOption } from '@slack/types'
+import {
+  Optgroup,
+  OptgroupInternal,
+  Option,
+  OptionInternal,
+} from '../block-kit/interactive/Select'
+import { JSXSlack } from '../jsx'
+import { ObjectOutput } from '../utils'
+
+interface SelectFragmentProps {
+  children: JSXSlack.Children<any>
+}
+
+interface SelectPropsBase {
+  label: string
+  name: string
+  placeholder?: string
+  required?: boolean
+}
+
+interface SelectProps extends SelectPropsBase {
+  children: JSXSlack.Children<OptionInternal | OptgroupInternal>
+  value?: string
+}
+
+interface ExternalSelectProps extends SelectPropsBase {
+  children?: undefined
+  initialOption?: JSXSlack.Node<OptionInternal> | SelectOption
+  minQueryLength?: number
+}
+
+interface UsersSelectProps extends SelectPropsBase {
+  initialUser?: string
+  children?: undefined
+}
+
+interface ConversationsSelectProps extends SelectPropsBase {
+  initialConversation?: string
+  children?: undefined
+}
+
+interface ChannelsSelectProps extends SelectPropsBase {
+  initialChannel?: string
+  children?: undefined
+}
+
+type DialogElement = Dialog['elements'][0]
+
+type SelectBase = Pick<
+  DialogElement,
+  | 'data_source'
+  | 'label'
+  | 'name'
+  | 'optional'
+  | 'placeholder'
+  | 'type'
+  | 'value'
+> & { type: 'select' }
+
+type SelectFragmentObject<T extends 'options' | 'option_groups'> = Pick<
+  DialogElement,
+  T
+>
+
+type StaticSelectElement = Omit<SelectBase, 'data_source'> &
+  Pick<DialogElement, 'option_groups' | 'options'>
+
+type ExternalSelectElement = Omit<SelectBase, 'value'> &
+  Pick<DialogElement, 'min_query_length' | 'selected_options'> & {
+    data_source: 'external'
+  }
+
+type UsersSelectElement = SelectBase & { data_source: 'users' }
+type ConversationsSelectElement = SelectBase & { data_source: 'conversations' }
+type ChannelsSelectElement = SelectBase & { data_source: 'channels' }
+
+const baseProps = (props: SelectPropsBase) => ({
+  label: props.label,
+  name: props.name,
+  optional: !props.required,
+  placeholder: props.placeholder,
+  type: 'select' as const,
+})
+
+const createOption = ({ value, text }: OptionInternal): SelectOption => ({
+  value,
+  label: text,
+})
+
+const filter = <T extends {}>(children: JSXSlack.Children<T>) =>
+  JSXSlack.normalizeChildren(children).filter(
+    o => typeof o !== 'string'
+  ) as JSXSlack.Node<T>[]
+
+export const SelectFragment: JSXSlack.FC<SelectFragmentProps> = props => {
+  const opts = filter(props.children)
+
+  if (opts.length === 0)
+    throw new Error(
+      'Component for selection must include least of one <Option> or <Optgroup>.'
+    )
+
+  const { type } = opts[0].props
+  if (!opts.every(o => o.props.type === type))
+    throw new Error(
+      'Component for selection must only include either of <Option> and <Optgroup>.'
+    )
+
+  switch (type) {
+    case 'option':
+      return (
+        <ObjectOutput<SelectFragmentObject<'options'>>
+          options={(opts as JSXSlack.Node<OptionInternal>[]).map(n =>
+            createOption(n.props)
+          )}
+        />
+      )
+    case 'optgroup':
+      return (
+        <ObjectOutput<SelectFragmentObject<'option_groups'>>
+          option_groups={(opts as JSXSlack.Node<OptgroupInternal>[]).map(n => ({
+            label: n.props.label,
+            options: filter(n.props.children).map(o => createOption(o.props)),
+          }))}
+        />
+      )
+    default:
+      throw new Error(`Unexpected option type: ${type}`)
+  }
+}
+
+export const Select: JSXSlack.FC<SelectProps> = props => {
+  const fragment: SelectFragmentObject<'options' | 'option_groups'> = JSXSlack(
+    <SelectFragment children={props.children} />
+  )
+
+  return (
+    <ObjectOutput<StaticSelectElement>
+      {...baseProps(props)}
+      value={props.value}
+      {...fragment}
+    />
+  )
+}
+
+export const ExternalSelect: JSXSlack.FC<ExternalSelectProps> = props => {
+  const initial = (() => {
+    if (props.initialOption) {
+      const isNode = (
+        v: ExternalSelectProps['initialOption']
+      ): v is JSXSlack.Node<OptionInternal> =>
+        (v as JSXSlack.Node<OptionInternal>).type !== undefined
+
+      if (isNode(props.initialOption)) {
+        return createOption(props.initialOption.props)
+      }
+
+      return props.initialOption
+    }
+    return undefined
+  })()
+
+  return (
+    <ObjectOutput<ExternalSelectElement>
+      {...baseProps(props)}
+      data_source="external"
+      min_query_length={props.minQueryLength}
+      selected_options={initial ? [initial] : undefined}
+    />
+  )
+}
+
+export const UsersSelect: JSXSlack.FC<UsersSelectProps> = props => (
+  <ObjectOutput<UsersSelectElement>
+    {...baseProps(props)}
+    data_source="users"
+    value={props.initialUser}
+  />
+)
+
+export const ConversationsSelect: JSXSlack.FC<
+  ConversationsSelectProps
+> = props => (
+  <ObjectOutput<ConversationsSelectElement>
+    {...baseProps(props)}
+    data_source="conversations"
+    value={props.initialConversation}
+  />
+)
+
+export const ChannelsSelect: JSXSlack.FC<ChannelsSelectProps> = props => (
+  <ObjectOutput<ChannelsSelectElement>
+    {...baseProps(props)}
+    data_source="channels"
+    value={props.initialChannel}
+  />
+)
+
+export { Option, Optgroup }

--- a/src/dialog/Select.tsx
+++ b/src/dialog/Select.tsx
@@ -12,7 +12,7 @@ import { validateElement } from './Dialog'
 import { DialogValidationError } from './error'
 
 interface SelectFragmentProps {
-  children: JSXSlack.Children<any>
+  children?: JSXSlack.Children<OptionInternal | OptgroupInternal>
 }
 
 interface SelectPropsBase {

--- a/src/dialog/Select.tsx
+++ b/src/dialog/Select.tsx
@@ -16,10 +16,12 @@ interface SelectFragmentProps {
 }
 
 interface SelectPropsBase {
+  hint?: string
   label: string
   name: string
   placeholder?: string
   required?: boolean
+  title?: string
 }
 
 interface SelectProps extends SelectPropsBase {
@@ -53,6 +55,7 @@ type DialogElement = Dialog['elements'][0]
 type SelectBase = Pick<
   DialogElement,
   | 'data_source'
+  | 'hint'
   | 'label'
   | 'name'
   | 'optional'
@@ -79,7 +82,7 @@ type ConversationsSelectElement = SelectBase & { data_source: 'conversations' }
 type ChannelsSelectElement = SelectBase & { data_source: 'channels' }
 
 const baseProps = (props: SelectPropsBase) => {
-  validateElement(props)
+  const validated = validateElement(props)
 
   if (props.placeholder && props.placeholder.length > 150)
     throw new DialogValidationError(
@@ -87,6 +90,7 @@ const baseProps = (props: SelectPropsBase) => {
     )
 
   return {
+    hint: validated.hint,
     label: props.label,
     name: props.name,
     optional: !props.required,

--- a/src/dialog/Select.tsx
+++ b/src/dialog/Select.tsx
@@ -118,13 +118,26 @@ const filter = <T extends {}>(children: JSXSlack.Children<T>) =>
     o => typeof o !== 'string'
   ) as JSXSlack.Node<T>[]
 
+const generateFragment = (
+  children: JSXSlack.Children<OptionInternal | OptgroupInternal>
+): SelectFragmentObject<'options' | 'option_groups'> => {
+  const fragment: SelectFragmentObject<'options' | 'option_groups'> = JSXSlack(
+    <SelectFragment children={children} />
+  )
+
+  if (fragment.options && fragment.options.length === 0)
+    throw new Error(
+      'Component for selection must include least of one <Option> or <Optgroup>.'
+    )
+
+  return fragment
+}
+
 export const SelectFragment: JSXSlack.FC<SelectFragmentProps> = props => {
   const opts = filter(props.children)
 
   if (opts.length === 0)
-    throw new Error(
-      'Component for selection must include least of one <Option> or <Optgroup>.'
-    )
+    return <ObjectOutput<SelectFragmentObject<'options'>> options={[]} />
 
   const { type } = opts[0].props
   if (!opts.every(o => o.props.type === type))
@@ -177,19 +190,13 @@ export const SelectFragment: JSXSlack.FC<SelectFragmentProps> = props => {
   }
 }
 
-export const Select: JSXSlack.FC<SelectProps> = props => {
-  const fragment: SelectFragmentObject<'options' | 'option_groups'> = JSXSlack(
-    <SelectFragment children={props.children} />
-  )
-
-  return (
-    <ObjectOutput<StaticSelectElement>
-      {...baseProps(props)}
-      value={props.value}
-      {...fragment}
-    />
-  )
-}
+export const Select: JSXSlack.FC<SelectProps> = props => (
+  <ObjectOutput<StaticSelectElement>
+    {...baseProps(props)}
+    value={props.value}
+    {...generateFragment(props.children)}
+  />
+)
 
 export const ExternalSelect: JSXSlack.FC<ExternalSelectProps> = props => {
   const initial = (() => {

--- a/src/dialog/Text.tsx
+++ b/src/dialog/Text.tsx
@@ -15,6 +15,7 @@ export interface TextProps {
   optional?: boolean
   placeholder?: string
   subtype?: TextElement['subtype']
+  title?: string
   value?: string
 }
 

--- a/src/dialog/Text.tsx
+++ b/src/dialog/Text.tsx
@@ -1,0 +1,45 @@
+/** @jsx JSXSlack.h */
+import { Dialog } from '@slack/types'
+import { JSXSlack } from '../jsx'
+import { ObjectOutput } from '../utils'
+
+export interface TextProps {
+  hint?: string
+  label: string
+  maxLength?: number
+  minLength?: number
+  name: string
+  optional?: boolean
+  placeholder?: string
+  subtype?: TextElement['subtype']
+  value?: string
+}
+
+export type TextElement = Pick<
+  Dialog['elements'][0],
+  | 'hint'
+  | 'label'
+  | 'max_length'
+  | 'min_length'
+  | 'name'
+  | 'optional'
+  | 'placeholder'
+  | 'subtype'
+  | 'type'
+  | 'value'
+> & { type: 'text' }
+
+export const Text: JSXSlack.FC<TextProps> = props => (
+  <ObjectOutput<TextElement>
+    hint={props.hint}
+    label={props.label}
+    max_length={props.maxLength}
+    min_length={props.minLength}
+    name={props.name}
+    optional={props.optional}
+    placeholder={props.placeholder}
+    subtype={props.subtype}
+    type="text"
+    value={props.value}
+  />
+)

--- a/src/dialog/Text.tsx
+++ b/src/dialog/Text.tsx
@@ -6,6 +6,7 @@ import { validateElement } from './Dialog'
 import { DialogValidationError } from './error'
 
 export interface TextProps {
+  children?: undefined
   hint?: string
   label: string
   maxLength?: number

--- a/src/dialog/Text.tsx
+++ b/src/dialog/Text.tsx
@@ -33,7 +33,7 @@ export type TextElement = Pick<
 > & { type: 'text' }
 
 export const Text: JSXSlack.FC<TextProps> = props => {
-  validateElement(props)
+  const validated = validateElement(props)
 
   if (typeof props.maxLength === 'number') {
     if (props.maxLength <= 0)
@@ -59,11 +59,6 @@ export const Text: JSXSlack.FC<TextProps> = props => {
       )
   }
 
-  if (props.hint && props.hint.length > 150)
-    throw new DialogValidationError(
-      `A hint string of text field must be up to 150 characters but a string with ${props.hint.length} characters was passed.`
-    )
-
   if (props.placeholder && props.placeholder.length > 150)
     throw new DialogValidationError(
       `A placeholder string of text field must be up to 150 characters but a string with ${props.placeholder.length} characters was passed.`
@@ -76,7 +71,7 @@ export const Text: JSXSlack.FC<TextProps> = props => {
 
   return (
     <ObjectOutput<TextElement>
-      hint={props.hint}
+      hint={validated.hint}
       label={props.label}
       max_length={props.maxLength}
       min_length={props.minLength}

--- a/src/dialog/Text.tsx
+++ b/src/dialog/Text.tsx
@@ -2,6 +2,8 @@
 import { Dialog } from '@slack/types'
 import { JSXSlack } from '../jsx'
 import { ObjectOutput } from '../utils'
+import { validateElement } from './Dialog'
+import { DialogValidationError } from './error'
 
 export interface TextProps {
   hint?: string
@@ -29,17 +31,60 @@ export type TextElement = Pick<
   | 'value'
 > & { type: 'text' }
 
-export const Text: JSXSlack.FC<TextProps> = props => (
-  <ObjectOutput<TextElement>
-    hint={props.hint}
-    label={props.label}
-    max_length={props.maxLength}
-    min_length={props.minLength}
-    name={props.name}
-    optional={props.optional}
-    placeholder={props.placeholder}
-    subtype={props.subtype}
-    type="text"
-    value={props.value}
-  />
-)
+export const Text: JSXSlack.FC<TextProps> = props => {
+  validateElement(props)
+
+  if (typeof props.maxLength === 'number') {
+    if (props.maxLength <= 0)
+      throw new DialogValidationError(
+        `Maximum length of text field must be greater than zero but maxLength=${props.maxLength} was passed.`
+      )
+
+    if (props.maxLength > 150)
+      throw new DialogValidationError(
+        `Maximum length of text field must be up to 150 but maxLength=${props.maxLength} was passed.`
+      )
+  }
+
+  if (typeof props.minLength === 'number') {
+    if (props.minLength <= 0)
+      throw new DialogValidationError(
+        `Minimum length of text field must be greater than zero but minLength=${props.minLength} was passed.`
+      )
+
+    if (props.minLength > 150)
+      throw new DialogValidationError(
+        `Minimum length of text field must be up to 150 but minLength=${props.minLength} was passed.`
+      )
+  }
+
+  if (props.hint && props.hint.length > 150)
+    throw new DialogValidationError(
+      `A hint string of text field must be up to 150 characters but a string with ${props.hint.length} characters was passed.`
+    )
+
+  if (props.placeholder && props.placeholder.length > 150)
+    throw new DialogValidationError(
+      `A placeholder string of text field must be up to 150 characters but a string with ${props.placeholder.length} characters was passed.`
+    )
+
+  if (props.value && props.value.length > 150)
+    throw new DialogValidationError(
+      `A default value of text field must be up to 150 characters but a string with ${props.value.length} characters was passed.`
+    )
+
+  return (
+    <ObjectOutput<TextElement>
+      hint={props.hint}
+      label={props.label}
+      max_length={props.maxLength}
+      min_length={props.minLength}
+      name={props.name}
+      optional={props.optional}
+      placeholder={props.placeholder}
+      subtype={props.subtype}
+      type="text"
+      value={props.value}
+    />
+  )
+}

--- a/src/dialog/Textarea.tsx
+++ b/src/dialog/Textarea.tsx
@@ -6,6 +6,7 @@ import { validateElement } from './Dialog'
 import { DialogValidationError } from './error'
 
 export interface TextareaProps {
+  children?: undefined
   hint?: string
   label: string
   maxLength?: number

--- a/src/dialog/Textarea.tsx
+++ b/src/dialog/Textarea.tsx
@@ -1,0 +1,45 @@
+/** @jsx JSXSlack.h */
+import { Dialog } from '@slack/types'
+import { JSXSlack } from '../jsx'
+import { ObjectOutput } from '../utils'
+
+export interface TextareaProps {
+  hint?: string
+  label: string
+  maxLength?: number
+  minLength?: number
+  name: string
+  placeholder?: string
+  required?: boolean // HTML compatible
+  subtype?: TextareaElement['subtype']
+  value?: string
+}
+
+export type TextareaElement = Pick<
+  Dialog['elements'][0],
+  | 'hint'
+  | 'label'
+  | 'max_length'
+  | 'min_length'
+  | 'name'
+  | 'optional'
+  | 'placeholder'
+  | 'subtype'
+  | 'type'
+  | 'value'
+> & { type: 'textarea' }
+
+export const Textarea: JSXSlack.FC<TextareaProps> = props => (
+  <ObjectOutput<TextareaElement>
+    hint={props.hint}
+    label={props.label}
+    max_length={props.maxLength}
+    min_length={props.minLength}
+    name={props.name}
+    optional={!props.required}
+    placeholder={props.placeholder}
+    subtype={props.subtype}
+    type="textarea"
+    value={props.value}
+  />
+)

--- a/src/dialog/Textarea.tsx
+++ b/src/dialog/Textarea.tsx
@@ -2,6 +2,8 @@
 import { Dialog } from '@slack/types'
 import { JSXSlack } from '../jsx'
 import { ObjectOutput } from '../utils'
+import { validateElement } from './Dialog'
+import { DialogValidationError } from './error'
 
 export interface TextareaProps {
   hint?: string
@@ -29,17 +31,60 @@ export type TextareaElement = Pick<
   | 'value'
 > & { type: 'textarea' }
 
-export const Textarea: JSXSlack.FC<TextareaProps> = props => (
-  <ObjectOutput<TextareaElement>
-    hint={props.hint}
-    label={props.label}
-    max_length={props.maxLength}
-    min_length={props.minLength}
-    name={props.name}
-    optional={!props.required}
-    placeholder={props.placeholder}
-    subtype={props.subtype}
-    type="textarea"
-    value={props.value}
-  />
-)
+export const Textarea: JSXSlack.FC<TextareaProps> = props => {
+  validateElement(props)
+
+  if (typeof props.maxLength === 'number') {
+    if (props.maxLength <= 0)
+      throw new DialogValidationError(
+        `Maximum length of textarea must be greater than zero but maxLength=${props.maxLength} was passed.`
+      )
+
+    if (props.maxLength > 3000)
+      throw new DialogValidationError(
+        `Maximum length of textarea must be up to 3000 but maxLength=${props.maxLength} was passed.`
+      )
+  }
+
+  if (typeof props.minLength === 'number') {
+    if (props.minLength < 0)
+      throw new DialogValidationError(
+        `Minimum length of textarea must be greater than or equal to zero but minLength=${props.minLength} was passed.`
+      )
+
+    if (props.minLength > 3000)
+      throw new DialogValidationError(
+        `Minimum length of textarea must be up to 3000 but minLength=${props.minLength} was passed.`
+      )
+  }
+
+  if (props.hint && props.hint.length > 150)
+    throw new DialogValidationError(
+      `A hint string of textarea must be up to 150 characters but a string with ${props.hint.length} characters was passed.`
+    )
+
+  if (props.placeholder && props.placeholder.length > 150)
+    throw new DialogValidationError(
+      `A placeholder string of textarea must be up to 150 characters but a string with ${props.placeholder.length} characters was passed.`
+    )
+
+  if (props.value && props.value.length > 3000)
+    throw new DialogValidationError(
+      `A default value of textarea must be up to 3000 characters but a string with ${props.value.length} characters was passed.`
+    )
+
+  return (
+    <ObjectOutput<TextareaElement>
+      hint={props.hint}
+      label={props.label}
+      max_length={props.maxLength}
+      min_length={props.minLength}
+      name={props.name}
+      optional={!props.required}
+      placeholder={props.placeholder}
+      subtype={props.subtype}
+      type="textarea"
+      value={props.value}
+    />
+  )
+}

--- a/src/dialog/Textarea.tsx
+++ b/src/dialog/Textarea.tsx
@@ -13,8 +13,9 @@ export interface TextareaProps {
   minLength?: number
   name: string
   placeholder?: string
-  required?: boolean // HTML compatible
+  required?: boolean
   subtype?: TextareaElement['subtype']
+  title?: string
   value?: string
 }
 
@@ -33,7 +34,7 @@ export type TextareaElement = Pick<
 > & { type: 'textarea' }
 
 export const Textarea: JSXSlack.FC<TextareaProps> = props => {
-  validateElement(props)
+  const validated = validateElement(props)
 
   if (typeof props.maxLength === 'number') {
     if (props.maxLength <= 0)
@@ -59,11 +60,6 @@ export const Textarea: JSXSlack.FC<TextareaProps> = props => {
       )
   }
 
-  if (props.hint && props.hint.length > 150)
-    throw new DialogValidationError(
-      `A hint string of textarea must be up to 150 characters but a string with ${props.hint.length} characters was passed.`
-    )
-
   if (props.placeholder && props.placeholder.length > 150)
     throw new DialogValidationError(
       `A placeholder string of textarea must be up to 150 characters but a string with ${props.placeholder.length} characters was passed.`
@@ -76,7 +72,7 @@ export const Textarea: JSXSlack.FC<TextareaProps> = props => {
 
   return (
     <ObjectOutput<TextareaElement>
-      hint={props.hint}
+      hint={validated.hint}
       label={props.label}
       max_length={props.maxLength}
       min_length={props.minLength}

--- a/src/dialog/error.ts
+++ b/src/dialog/error.ts
@@ -1,0 +1,6 @@
+export class DialogValidationError extends Error {
+  public constructor(message?: string) {
+    super(message)
+    this.name = 'DialogValidationError'
+  }
+}

--- a/src/dialog/index.ts
+++ b/src/dialog/index.ts
@@ -1,0 +1,9 @@
+// Dialog container
+export { Dialog } from './Dialog'
+
+// Dialog form elements
+export { Text } from './Text'
+export { Textarea } from './Textarea'
+
+// HTML-compatible component
+export { Input } from './Input'

--- a/src/dialog/index.ts
+++ b/src/dialog/index.ts
@@ -2,8 +2,15 @@
 export { Dialog } from './Dialog'
 
 // Dialog form elements
-export { Text } from './Text'
-export { Textarea } from './Textarea'
-
-// HTML-compatible component
 export { Input } from './Input'
+export { Textarea } from './Textarea'
+export {
+  Select,
+  SelectFragment,
+  Option,
+  Optgroup,
+  ExternalSelect,
+  UsersSelect,
+  ConversationsSelect,
+  ChannelsSelect,
+} from './Select'

--- a/src/dialog/index.ts
+++ b/src/dialog/index.ts
@@ -14,3 +14,6 @@ export {
   ConversationsSelect,
   ChannelsSelect,
 } from './Select'
+
+// Error class
+export * from './error'

--- a/src/dialog/index.ts
+++ b/src/dialog/index.ts
@@ -16,4 +16,4 @@ export {
 } from './Select'
 
 // Error class
-export * from './error'
+export { DialogValidationError } from './error'

--- a/test/__snapshots__/tag.tsx.snap
+++ b/test/__snapshots__/tag.tsx.snap
@@ -1,0 +1,44 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Tagged template can use imported dialog components through interpolation 1`] = `
+Object {
+  "callback_id": "callback",
+  "elements": Array [
+    Object {
+      "label": "foo",
+      "name": "foo",
+      "optional": false,
+      "type": "text",
+    },
+    Object {
+      "label": "bar",
+      "name": "bar",
+      "optional": true,
+      "type": "textarea",
+    },
+    Object {
+      "label": "select",
+      "name": "select",
+      "optional": true,
+      "options": Array [
+        Object {
+          "label": "one",
+          "value": "1",
+        },
+        Object {
+          "label": "two",
+          "value": "2",
+        },
+        Object {
+          "label": "three",
+          "value": "3",
+        },
+      ],
+      "type": "select",
+    },
+  ],
+  "state": "{\\"hiddenState\\":[\\"a\\",\\"b\\",\\"c\\"]}",
+  "submit_label": "Submit dialog",
+  "title": "test",
+}
+`;

--- a/test/dialog.tsx
+++ b/test/dialog.tsx
@@ -1,13 +1,19 @@
 /** @jsx JSXSlack.h */
 import { Dialog as SlackDialog } from '@slack/types'
-import JSXSlack, { Select as BlockSelect, Optgroup } from '../src/index'
+import JSXSlack, { Select as BlockSelect } from '../src/index'
 import {
+  ChannelsSelect,
+  ConversationsSelect,
   Dialog,
   DialogValidationError,
+  ExternalSelect,
   Input,
-  Textarea,
-  Select,
+  Optgroup,
   Option,
+  Select,
+  SelectFragment,
+  Textarea,
+  UsersSelect,
 } from '../src/dialog'
 import { DialogProps } from '../src/dialog/Dialog'
 
@@ -194,15 +200,32 @@ describe('Dialog support', () => {
   })
 
   describe('<Input>', () => {
-    it('outputs text field element', () =>
-      expect(element(<Input name="name" label="label" />)).toStrictEqual({
+    it('outputs text field element', () => {
+      const expectedElement: DialogElement = {
         type: 'text',
         name: 'name',
         label: 'label',
         optional: true,
-      }))
+      }
 
-    it('can specify options for text field element', () =>
+      expect(element(<Input name="name" label="label" />)).toStrictEqual(
+        expectedElement
+      )
+    })
+
+    it('can specify options for text field element', () => {
+      const expectedElement: DialogElement = {
+        hint: 'hint',
+        label: 'label',
+        max_length: 30,
+        min_length: 5,
+        name: 'name',
+        optional: false,
+        placeholder: 'placeholder',
+        type: 'text',
+        value: 'default',
+      }
+
       expect(
         element(
           <Input
@@ -217,17 +240,8 @@ describe('Dialog support', () => {
             value="default"
           />
         )
-      ).toStrictEqual({
-        hint: 'hint',
-        label: 'label',
-        max_length: 30,
-        min_length: 5,
-        name: 'name',
-        optional: false,
-        placeholder: 'placeholder',
-        type: 'text',
-        value: 'default',
-      }))
+      ).toStrictEqual(expectedElement)
+    })
 
     it('maps specified type to correct subtype', () => {
       expect(
@@ -384,15 +398,33 @@ describe('Dialog support', () => {
   })
 
   describe('<Textarea>', () => {
-    it('outputs textarea element', () =>
-      expect(element(<Textarea name="name" label="label" />)).toStrictEqual({
+    it('outputs textarea element', () => {
+      const expectedElement: DialogElement = {
         type: 'textarea',
         name: 'name',
         label: 'label',
         optional: true,
-      }))
+      }
 
-    it('can specify options for textarea element', () =>
+      expect(element(<Textarea name="name" label="label" />)).toStrictEqual(
+        expectedElement
+      )
+    })
+
+    it('can specify options for textarea element', () => {
+      const expectedElement: DialogElement = {
+        hint: 'hint',
+        label: 'label',
+        max_length: 140,
+        min_length: 10,
+        name: 'name',
+        optional: false,
+        placeholder: 'placeholder',
+        subtype: 'number',
+        type: 'textarea',
+        value: 'default',
+      }
+
       expect(
         element(
           <Textarea
@@ -407,18 +439,8 @@ describe('Dialog support', () => {
             value="default"
           />
         )
-      ).toStrictEqual({
-        hint: 'hint',
-        label: 'label',
-        max_length: 140,
-        min_length: 10,
-        name: 'name',
-        optional: false,
-        placeholder: 'placeholder',
-        subtype: 'number',
-        type: 'textarea',
-        value: 'default',
-      }))
+      ).toStrictEqual(expectedElement)
+    })
 
     it('throws error when passed invalid name', () => {
       expect(() => <Textarea name={'a'.repeat(300)} label="a" />).not.toThrow()
@@ -498,6 +520,14 @@ describe('Dialog support', () => {
   describe('<Select>', () => {
     it('outputs static select element', () => {
       // w/ <Option>
+      const expectedElementForOption: DialogElement = {
+        type: 'select',
+        name: 'name',
+        label: 'label',
+        optional: true,
+        options: [{ label: 'A', value: 'a' }, { label: 'B', value: 'b' }],
+      }
+
       expect(
         element(
           <Select name="name" label="label">
@@ -505,29 +535,10 @@ describe('Dialog support', () => {
             <Option value="b">B</Option>
           </Select>
         )
-      ).toStrictEqual({
-        type: 'select',
-        name: 'name',
-        label: 'label',
-        optional: true,
-        options: [{ label: 'A', value: 'a' }, { label: 'B', value: 'b' }],
-      })
+      ).toStrictEqual(expectedElementForOption)
 
       // w/ <Optgroup>
-      expect(
-        element(
-          <Select name="name" label="label" required>
-            <Optgroup label="A">
-              <Option value="one">1</Option>
-              <Option value="two">2</Option>
-            </Optgroup>
-            <Optgroup label="B">
-              <Option value="three">3</Option>
-              <Option value="four">4</Option>
-            </Optgroup>
-          </Select>
-        )
-      ).toStrictEqual({
+      const expectedElementForOptgroup: DialogElement = {
         type: 'select',
         name: 'name',
         label: 'label',
@@ -548,7 +559,22 @@ describe('Dialog support', () => {
             ],
           },
         ],
-      })
+      }
+
+      expect(
+        element(
+          <Select name="name" label="label" required>
+            <Optgroup label="A">
+              <Option value="one">1</Option>
+              <Option value="two">2</Option>
+            </Optgroup>
+            <Optgroup label="B">
+              <Option value="three">3</Option>
+              <Option value="four">4</Option>
+            </Optgroup>
+          </Select>
+        )
+      ).toStrictEqual(expectedElementForOptgroup)
     })
 
     it('throws error when <Select> has not contained option elements', () => {
@@ -729,6 +755,124 @@ describe('Dialog support', () => {
           </Optgroup>
         </Select>
       )).toThrow(/value/)
+    })
+  })
+
+  describe('<ExternalSelect>', () => {
+    it('outputs external select element', () => {
+      const expectedElement: DialogElement = {
+        data_source: 'external',
+        label: 'label',
+        name: 'name',
+        optional: true,
+        type: 'select',
+      }
+
+      expect(
+        element(<ExternalSelect name="name" label="label" />)
+      ).toStrictEqual(expectedElement)
+    })
+
+    it('can specify options for external select element', () => {
+      const expectedElement: DialogElement = {
+        data_source: 'external',
+        label: 'label',
+        min_query_length: 2,
+        name: 'name',
+        optional: false,
+        placeholder: 'placeholder',
+        type: 'select',
+        selected_options: [{ label: 'foo', value: 'bar' }],
+      }
+
+      expect(
+        element(
+          <ExternalSelect
+            label="label"
+            name="name"
+            placeholder="placeholder"
+            required
+            initialOption={{ label: 'foo', value: 'bar' }}
+            minQueryLength={2}
+          />
+        )
+      ).toStrictEqual(expectedElement)
+    })
+
+    it('can use <Option> element to set selected option as initial value', () =>
+      expect(
+        element(
+          <ExternalSelect
+            label="label"
+            name="name"
+            initialOption={<Option value="bar">foo</Option>}
+          />
+        ).selected_options
+      ).toStrictEqual([{ label: 'foo', value: 'bar' }]))
+  })
+
+  describe('<UsersSelect>', () => {
+    it('outputs select element with users data source', () => {
+      const expectedElement: DialogElement = {
+        data_source: 'users',
+        label: 'label',
+        name: 'name',
+        optional: true,
+        type: 'select',
+        value: 'U01234567',
+      }
+
+      expect(
+        element(
+          <UsersSelect name="name" label="label" initialUser="U01234567" />
+        )
+      ).toStrictEqual(expectedElement)
+    })
+  })
+
+  describe('<ChannelsSelect>', () => {
+    it('outputs select element with channels data source', () => {
+      const expectedElement: DialogElement = {
+        data_source: 'channels',
+        label: 'label',
+        name: 'name',
+        optional: true,
+        type: 'select',
+        value: 'C01234567',
+      }
+
+      expect(
+        element(
+          <ChannelsSelect
+            name="name"
+            label="label"
+            initialChannel="C01234567"
+          />
+        )
+      ).toStrictEqual(expectedElement)
+    })
+  })
+
+  describe('<ConversationsSelect>', () => {
+    it('outputs select element with conversations data source', () => {
+      const expectedElement: DialogElement = {
+        data_source: 'conversations',
+        label: 'label',
+        name: 'name',
+        optional: true,
+        type: 'select',
+        value: 'D01234567',
+      }
+
+      expect(
+        element(
+          <ConversationsSelect
+            name="name"
+            label="label"
+            initialConversation="D01234567"
+          />
+        )
+      ).toStrictEqual(expectedElement)
     })
   })
 })

--- a/test/dialog.tsx
+++ b/test/dialog.tsx
@@ -380,4 +380,116 @@ describe('Dialog support', () => {
       expect(dialog.state).toBe('customState')
     })
   })
+
+  describe('<Textarea>', () => {
+    it('outputs textarea element', () =>
+      expect(element(<Textarea name="name" label="label" />)).toStrictEqual({
+        type: 'textarea',
+        name: 'name',
+        label: 'label',
+        optional: true,
+      }))
+
+    it('can specify options for textarea element', () =>
+      expect(
+        element(
+          <Textarea
+            hint="hint"
+            label="label"
+            maxLength={140}
+            minLength={10}
+            name="name"
+            placeholder="placeholder"
+            required
+            subtype="number"
+            value="default"
+          />
+        )
+      ).toStrictEqual({
+        hint: 'hint',
+        label: 'label',
+        max_length: 140,
+        min_length: 10,
+        name: 'name',
+        optional: false,
+        placeholder: 'placeholder',
+        subtype: 'number',
+        type: 'textarea',
+        value: 'default',
+      }))
+
+    it('throws error when passed invalid name', () => {
+      expect(() => <Textarea name={'a'.repeat(300)} label="a" />).not.toThrow()
+      expect(() => <Textarea name={'a'.repeat(301)} label="a" />).toThrow(
+        /name/
+      )
+    })
+
+    it('throws error when passed invalid label', () => {
+      expect(() => <Textarea label={'a'.repeat(48)} name="a" />).not.toThrow()
+      expect(() => <Textarea label={'a'.repeat(49)} name="a" />).toThrow(
+        /label/
+      )
+    })
+
+    it('throws error when passed invalid hint', () => {
+      expect(() => (
+        <Textarea hint={'a'.repeat(150)} label="a" name="a" />
+      )).not.toThrow()
+
+      expect(() => (
+        <Textarea hint={'a'.repeat(151)} label="a" name="a" />
+      )).toThrow(/hint/)
+    })
+
+    it('throws error when passed invalid placeholder', () => {
+      expect(() => (
+        <Textarea placeholder={'a'.repeat(150)} label="a" name="a" />
+      )).not.toThrow()
+
+      expect(() => (
+        <Textarea placeholder={'a'.repeat(151)} label="a" name="a" />
+      )).toThrow(/placeholder/)
+    })
+
+    it('throws error when passed invalid value', () => {
+      expect(() => (
+        <Textarea value={'a'.repeat(3000)} label="a" name="a" />
+      )).not.toThrow()
+
+      expect(() => (
+        <Textarea value={'a'.repeat(3001)} label="a" name="a" />
+      )).toThrow(/value/)
+    })
+
+    it('throws error when passed invalid maxLength', () => {
+      expect(() => <Textarea label="a" name="a" maxLength={1} />).not.toThrow()
+      expect(() => <Textarea label="a" name="a" maxLength={0} />).toThrow(
+        /maxLength/
+      )
+
+      expect(() => (
+        <Textarea label="a" name="a" maxLength={3000} />
+      )).not.toThrow()
+
+      expect(() => <Textarea label="a" name="a" maxLength={3001} />).toThrow(
+        /maxLength/
+      )
+    })
+
+    it('throws error when passed invalid minLength', () => {
+      expect(() => <Textarea label="a" name="a" minLength={0} />).not.toThrow()
+      expect(() => <Textarea label="a" name="a" minLength={-1} />).toThrow(
+        /minLength/
+      )
+
+      expect(() => (
+        <Textarea label="a" name="a" minLength={3000} />
+      )).not.toThrow()
+
+      expect(() => <Textarea label="a" name="a" minLength={3001} />).toThrow(
+        /minLength/
+      )
+    })
+  })
 })

--- a/test/dialog.tsx
+++ b/test/dialog.tsx
@@ -1,7 +1,7 @@
 /** @jsx JSXSlack.h */
 import { Dialog as SlackDialog } from '@slack/types'
 import JSXSlack from '../src/index'
-import { Dialog, Input } from '../src/dialog'
+import { Dialog, Input, Textarea, Select, Option } from '../src/dialog'
 
 describe('Dialog support', () => {
   describe('<Dialog>', () => {
@@ -21,10 +21,21 @@ describe('Dialog support', () => {
             optional: false,
           },
           {
-            type: 'text',
+            type: 'textarea',
             name: 'bar',
             label: 'bar',
             optional: true,
+          },
+          {
+            type: 'select',
+            name: 'select',
+            label: 'select',
+            optional: true,
+            options: [
+              { label: 'one', value: '1' },
+              { label: 'two', value: '2' },
+              { label: 'three', value: '3' },
+            ],
           },
         ],
       }
@@ -38,7 +49,12 @@ describe('Dialog support', () => {
             title="test"
           >
             <Input name="foo" label="foo" required={true} />
-            <Input name="bar" label="bar" />
+            <Textarea name="bar" label="bar" />
+            <Select name="select" label="select">
+              <Option value="1">one</Option>
+              <Option value="2">two</Option>
+              <Option value="3">three</Option>
+            </Select>
           </Dialog>
         )
       ).toStrictEqual(expectedDialog)
@@ -49,7 +65,12 @@ describe('Dialog support', () => {
           <Dialog callbackId="callback" title="test">
             <Input type="hidden" name="hiddenState" value={['a', 'b', 'c']} />
             <Input type="text" name="foo" label="foo" required={true} />
-            <Input type="text" name="bar" label="bar" />
+            <Textarea name="bar" label="bar" />
+            <Select name="select" label="select">
+              <Option value="1">one</Option>
+              <Option value="2">two</Option>
+              <Option value="3">three</Option>
+            </Select>
             <Input type="submit" value="Submit dialog" />
           </Dialog>
         )

--- a/test/dialog.tsx
+++ b/test/dialog.tsx
@@ -875,4 +875,62 @@ describe('Dialog support', () => {
       ).toStrictEqual(expectedElement)
     })
   })
+
+  describe('<SelectFragment>', () => {
+    it('outputs fragmented options for external select', () => {
+      const expectedElement: Pick<DialogElement, 'options'> = {
+        options: [
+          { label: 'A', value: 'a' },
+          { label: 'B', value: 'b' },
+          { label: 'C', value: 'c' },
+        ],
+      }
+
+      expect(
+        JSXSlack(
+          <SelectFragment>
+            <Option value="a">A</Option>
+            <Option value="b">B</Option>
+            <Option value="c">C</Option>
+          </SelectFragment>
+        )
+      ).toStrictEqual(expectedElement)
+    })
+
+    it('outputs fragmented option groups for external select', () => {
+      const expectedElement: Pick<DialogElement, 'option_groups'> = {
+        option_groups: [
+          {
+            label: 'Group A',
+            options: [
+              { label: '1', value: 'one' },
+              { label: '2', value: 'two' },
+            ],
+          },
+          {
+            label: 'Group B',
+            options: [
+              { label: '3', value: 'three' },
+              { label: '4', value: 'four' },
+            ],
+          },
+        ],
+      }
+
+      expect(
+        JSXSlack(
+          <SelectFragment>
+            <Optgroup label="Group A">
+              <Option value="one">1</Option>
+              <Option value="two">2</Option>
+            </Optgroup>
+            <Optgroup label="Group B">
+              <Option value="three">3</Option>
+              <Option value="four">4</Option>
+            </Optgroup>
+          </SelectFragment>
+        )
+      ).toStrictEqual(expectedElement)
+    })
+  })
 })

--- a/test/dialog.tsx
+++ b/test/dialog.tsx
@@ -1,0 +1,59 @@
+/** @jsx JSXSlack.h */
+import { Dialog as SlackDialog } from '@slack/types'
+import JSXSlack from '../src/index'
+import { Dialog, Input } from '../src/dialog'
+
+describe('Dialog support', () => {
+  describe('<Dialog>', () => {
+    it('outputs Dialog JSON', () => {
+      const state = JSON.stringify({ hiddenState: ['a', 'b', 'c'] })
+
+      const expectedDialog: SlackDialog = {
+        callback_id: 'callback',
+        title: 'test',
+        submit_label: 'Submit dialog',
+        state,
+        elements: [
+          {
+            type: 'text',
+            name: 'foo',
+            label: 'foo',
+            optional: false,
+          },
+          {
+            type: 'text',
+            name: 'bar',
+            label: 'bar',
+            optional: true,
+          },
+        ],
+      }
+
+      expect(
+        JSXSlack(
+          <Dialog
+            callbackId="callback"
+            state={state}
+            submitLabel="Submit dialog"
+            title="test"
+          >
+            <Input name="foo" label="foo" required={true} />
+            <Input name="bar" label="bar" />
+          </Dialog>
+        )
+      ).toStrictEqual(expectedDialog)
+
+      // HTML compatible style
+      expect(
+        JSXSlack(
+          <Dialog callbackId="callback" title="test">
+            <Input type="hidden" name="hiddenState" value={['a', 'b', 'c']} />
+            <Input type="text" name="foo" label="foo" required={true} />
+            <Input type="text" name="bar" label="bar" />
+            <Input type="submit" value="Submit dialog" />
+          </Dialog>
+        )
+      ).toStrictEqual(expectedDialog)
+    })
+  })
+})

--- a/test/dialog.tsx
+++ b/test/dialog.tsx
@@ -1008,5 +1008,11 @@ describe('Dialog support', () => {
         )
       ).toStrictEqual(expectedElement)
     })
+
+    it('allows no options to return empty result', () => {
+      expect(JSXSlack(<SelectFragment>{}</SelectFragment>)).toStrictEqual({
+        options: [],
+      })
+    })
   })
 })

--- a/test/dialog.tsx
+++ b/test/dialog.tsx
@@ -1010,6 +1010,10 @@ describe('Dialog support', () => {
     })
 
     it('allows no options to return empty result', () => {
+      expect(JSXSlack(<SelectFragment />)).toStrictEqual({
+        options: [],
+      })
+
       expect(JSXSlack(<SelectFragment>{}</SelectFragment>)).toStrictEqual({
         options: [],
       })

--- a/test/dialog.tsx
+++ b/test/dialog.tsx
@@ -1,9 +1,23 @@
 /** @jsx JSXSlack.h */
 import { Dialog as SlackDialog } from '@slack/types'
-import JSXSlack from '../src/index'
-import { Dialog, Input, Textarea, Select, Option } from '../src/dialog'
+import JSXSlack, { Select as BlockSelect } from '../src/index'
+import {
+  Dialog,
+  DialogValidationError,
+  Input,
+  Textarea,
+  Select,
+  Option,
+} from '../src/dialog'
+import { DialogProps } from '../src/dialog/Dialog'
 
 describe('Dialog support', () => {
+  const TestDialog = (props: Partial<DialogProps> = {}) => (
+    <Dialog callbackId="callbackId" title="test" {...props}>
+      {props.children || <Input name="test" label="test" />}
+    </Dialog>
+  )
+
   describe('<Dialog>', () => {
     it('outputs Dialog JSON', () => {
       const state = JSON.stringify({ hiddenState: ['a', 'b', 'c'] })
@@ -75,6 +89,94 @@ describe('Dialog support', () => {
           </Dialog>
         )
       ).toStrictEqual(expectedDialog)
+    })
+
+    it('throws error when passed incompatible elements with dialog', () => {
+      expect(() => (
+        <Dialog callbackId="callback" title="test">
+          <BlockSelect>
+            <Option value="1">one</Option>
+            <Option value="2">two</Option>
+            <Option value="3">three</Option>
+          </BlockSelect>
+        </Dialog>
+      )).toThrow(DialogValidationError)
+
+      expect(() => (
+        <Dialog callbackId="callback" title="test">
+          Text is not allowed
+        </Dialog>
+      )).toThrow(DialogValidationError)
+    })
+
+    it('throws error when the number of passed elements was incorrect', () => {
+      expect(() => (
+        <TestDialog>
+          <Input type="submit" value="test" />
+        </TestDialog>
+      )).toThrow(/element/)
+
+      expect(() => (
+        <TestDialog>
+          {[...Array(11)].map((_, i) => (
+            <Input name={i.toString()} label={i.toString()} />
+          ))}
+        </TestDialog>
+      )).toThrow(/element/)
+    })
+
+    it('throws error when passed invalid title', () => {
+      expect(() => <TestDialog title={'a'.repeat(24)} />).not.toThrow()
+      expect(() => <TestDialog title={'a'.repeat(25)} />).toThrow(/title/)
+    })
+
+    it('throws error when passed invalid callbackId', () => {
+      expect(() => <TestDialog callbackId={'a'.repeat(255)} />).not.toThrow()
+      expect(() => <TestDialog callbackId={'a'.repeat(256)} />).toThrow(
+        /callback/
+      )
+    })
+
+    it('throws error when passed invalid state', () => {
+      expect(() => <TestDialog state={'a'.repeat(3000)} />).not.toThrow()
+      expect(() => <TestDialog state={'a'.repeat(3001)} />).toThrow(/state/)
+
+      // Generated JSON from <Input type="hidden" />
+      expect(() => (
+        <TestDialog>
+          <Input type="hidden" name="a" value={'a'.repeat(2992)} />
+          <Input name="b" label="dummy" />
+        </TestDialog>
+      )).not.toThrow()
+
+      expect(() => (
+        <TestDialog>
+          <Input type="hidden" name="a" value={'a'.repeat(2993)} />
+          <Input name="b" label="dummy" />
+        </TestDialog>
+      )).toThrow(/state/)
+    })
+
+    it('throws error when passed invalid submit label', () => {
+      expect(() => <TestDialog submitLabel={'a'.repeat(24)} />).not.toThrow()
+      expect(() => <TestDialog submitLabel={'a'.repeat(25)} />).toThrow(
+        /submit/
+      )
+
+      // Specified by <Input type="submit" />
+      expect(() => (
+        <TestDialog>
+          <Input type="submit" value={'a'.repeat(24)} />
+          <Input name="b" label="dummy" />
+        </TestDialog>
+      )).not.toThrow()
+
+      expect(() => (
+        <TestDialog>
+          <Input type="submit" value={'a'.repeat(25)} />
+          <Input name="b" label="dummy" />
+        </TestDialog>
+      )).toThrow(/submit/)
     })
   })
 })

--- a/test/dialog.tsx
+++ b/test/dialog.tsx
@@ -48,7 +48,7 @@ describe('Dialog support', () => {
             submitLabel="Submit dialog"
             title="test"
           >
-            <Input name="foo" label="foo" required={true} />
+            <Input name="foo" label="foo" required />
             <Textarea name="bar" label="bar" />
             <Select name="select" label="select">
               <Option value="1">one</Option>
@@ -64,7 +64,7 @@ describe('Dialog support', () => {
         JSXSlack(
           <Dialog callbackId="callback" title="test">
             <Input type="hidden" name="hiddenState" value={['a', 'b', 'c']} />
-            <Input type="text" name="foo" label="foo" required={true} />
+            <Input type="text" name="foo" label="foo" required />
             <Textarea name="bar" label="bar" />
             <Select name="select" label="select">
               <Option value="1">one</Option>

--- a/test/dialog.tsx
+++ b/test/dialog.tsx
@@ -1,6 +1,6 @@
 /** @jsx JSXSlack.h */
 import { Dialog as SlackDialog } from '@slack/types'
-import JSXSlack, { Select as BlockSelect } from '../src/index'
+import JSXSlack, { Select as BlockSelect, Optgroup } from '../src/index'
 import {
   Dialog,
   DialogValidationError,
@@ -11,6 +11,8 @@ import {
 } from '../src/dialog'
 import { DialogProps } from '../src/dialog/Dialog'
 
+type DialogElement = SlackDialog['elements'][0]
+
 describe('Dialog support', () => {
   const TestDialog = (props: Partial<DialogProps> = {}) => (
     <Dialog callbackId="callbackId" title="test" {...props}>
@@ -18,7 +20,7 @@ describe('Dialog support', () => {
     </Dialog>
   )
 
-  const element = (inputJSX: JSXSlack.Node): SlackDialog['elements'][0] =>
+  const element = (inputJSX: JSXSlack.Node): DialogElement =>
     (JSXSlack(<TestDialog>{inputJSX}</TestDialog>) as SlackDialog).elements[0]
 
   describe('<Dialog>', () => {
@@ -490,6 +492,243 @@ describe('Dialog support', () => {
       expect(() => <Textarea label="a" name="a" minLength={3001} />).toThrow(
         /minLength/
       )
+    })
+  })
+
+  describe('<Select>', () => {
+    it('outputs static select element', () => {
+      // w/ <Option>
+      expect(
+        element(
+          <Select name="name" label="label">
+            <Option value="a">A</Option>
+            <Option value="b">B</Option>
+          </Select>
+        )
+      ).toStrictEqual({
+        type: 'select',
+        name: 'name',
+        label: 'label',
+        optional: true,
+        options: [{ label: 'A', value: 'a' }, { label: 'B', value: 'b' }],
+      })
+
+      // w/ <Optgroup>
+      expect(
+        element(
+          <Select name="name" label="label" required>
+            <Optgroup label="A">
+              <Option value="one">1</Option>
+              <Option value="two">2</Option>
+            </Optgroup>
+            <Optgroup label="B">
+              <Option value="three">3</Option>
+              <Option value="four">4</Option>
+            </Optgroup>
+          </Select>
+        )
+      ).toStrictEqual({
+        type: 'select',
+        name: 'name',
+        label: 'label',
+        optional: false,
+        option_groups: [
+          {
+            label: 'A',
+            options: [
+              { label: '1', value: 'one' },
+              { label: '2', value: 'two' },
+            ],
+          },
+          {
+            label: 'B',
+            options: [
+              { label: '3', value: 'three' },
+              { label: '4', value: 'four' },
+            ],
+          },
+        ],
+      })
+    })
+
+    it('throws error when <Select> has not contained option elements', () => {
+      expect(() => (
+        <Select name="a" label="a">
+          {}
+        </Select>
+      )).toThrow(/must include/)
+    })
+
+    it('throws error when <Select> has contained invalid component', () => {
+      expect(() => (
+        <Select name="a" label="a">
+          <Input name="b" label="b" />
+        </Select>
+      )).toThrow(/unexpected/i)
+    })
+
+    it('throws error when <Select> has mixed children', () => {
+      expect(() => (
+        <Select name="a" label="a">
+          <Option value="first">1st</Option>
+          <Optgroup label="A">
+            <Option value="second">2nd</Option>
+            <Option value="third">3rd</Option>
+          </Optgroup>
+        </Select>
+      )).toThrow(/only include either of/)
+    })
+
+    it('throws error when <Select> has over 100 options', () => {
+      expect(() => (
+        <Select name="a" label="a">
+          {[...Array(100)].map((_, i) => (
+            <Option value={i.toString()}>{i}</Option>
+          ))}
+        </Select>
+      )).not.toThrow()
+
+      expect(() => (
+        <Select name="a" label="a">
+          {[...Array(101)].map((_, i) => (
+            <Option value={i.toString()}>{i}</Option>
+          ))}
+        </Select>
+      )).toThrow(/options/)
+
+      // <Optgroup>
+      expect(() => (
+        <Select name="a" label="a">
+          <Optgroup label="A">
+            {[...Array(50)].map((_, i) => (
+              <Option value={`A${i}`}>{i}</Option>
+            ))}
+          </Optgroup>
+          <Optgroup label="B">
+            {[...Array(50)].map((_, i) => (
+              <Option value={`B${i}`}>{i}</Option>
+            ))}
+          </Optgroup>
+        </Select>
+      )).not.toThrow()
+
+      expect(() => (
+        <Select name="a" label="a">
+          <Optgroup label="A">
+            {[...Array(50)].map((_, i) => (
+              <Option value={`A${i}`}>{i}</Option>
+            ))}
+          </Optgroup>
+          <Optgroup label="B">
+            {[...Array(51)].map((_, i) => (
+              <Option value={`B${i}`}>{i}</Option>
+            ))}
+          </Optgroup>
+        </Select>
+      )).toThrow(/options/)
+    })
+
+    it('throws error when passed invalid name', () => {
+      expect(() => (
+        <Select name={'a'.repeat(300)} label="a">
+          <Option value="a">A</Option>
+        </Select>
+      )).not.toThrow()
+
+      expect(() => (
+        <Select name={'a'.repeat(301)} label="a">
+          <Option value="a">A</Option>
+        </Select>
+      )).toThrow(/name/)
+    })
+
+    it('throws error when passed invalid label', () => {
+      expect(() => (
+        <Select label={'a'.repeat(48)} name="a">
+          <Option value="a">A</Option>
+        </Select>
+      )).not.toThrow()
+
+      expect(() => (
+        <Select label={'a'.repeat(49)} name="a">
+          <Option value="a">A</Option>
+        </Select>
+      )).toThrow(/label/)
+
+      // Label of <Option>
+      expect(() => (
+        <Select label="a" name="a">
+          <Option value="a">{'A'.repeat(75)}</Option>
+        </Select>
+      )).not.toThrow()
+
+      expect(() => (
+        <Select label="a" name="a">
+          <Option value="a">{'A'.repeat(76)}</Option>
+        </Select>
+      )).toThrow(/label/)
+
+      // Label of <Optgroup>
+      expect(() => (
+        <Select label="a" name="a">
+          <Optgroup label={'A'.repeat(75)}>
+            <Option value="a">A</Option>
+          </Optgroup>
+        </Select>
+      )).not.toThrow()
+
+      expect(() => (
+        <Select label="a" name="a">
+          <Optgroup label={'A'.repeat(76)}>
+            <Option value="a">A</Option>
+          </Optgroup>
+        </Select>
+      )).toThrow(/label/)
+    })
+
+    it('throws error when passed invalid placeholder', () => {
+      expect(() => (
+        <Select placeholder={'a'.repeat(150)} label="a" name="a">
+          <Option value="a">A</Option>
+        </Select>
+      )).not.toThrow()
+
+      expect(() => (
+        <Select placeholder={'a'.repeat(151)} label="a" name="a">
+          <Option value="a">A</Option>
+        </Select>
+      )).toThrow(/placeholder/)
+    })
+
+    it('throws error when passed option has invalid value', () => {
+      expect(() => (
+        <Select label="a" name="a" value={'A'.repeat(75)}>
+          <Option value={'A'.repeat(75)}>A</Option>
+        </Select>
+      )).not.toThrow()
+
+      expect(() => (
+        <Select label="a" name="a" value={'A'.repeat(76)}>
+          <Option value={'A'.repeat(76)}>A</Option>
+        </Select>
+      )).toThrow(/value/)
+
+      // <Option> in <Optgroup>
+      expect(() => (
+        <Select label="a" name="a" value={'A'.repeat(75)}>
+          <Optgroup label="A">
+            <Option value={'A'.repeat(75)}>A</Option>
+          </Optgroup>
+        </Select>
+      )).not.toThrow()
+
+      expect(() => (
+        <Select label="a" name="a" value={'A'.repeat(76)}>
+          <Optgroup label="A">
+            <Option value={'A'.repeat(76)}>A</Option>
+          </Optgroup>
+        </Select>
+      )).toThrow(/value/)
     })
   })
 })

--- a/test/dialog.tsx
+++ b/test/dialog.tsx
@@ -265,6 +265,17 @@ describe('Dialog support', () => {
       )
     })
 
+    it('can use title prop as an alias to hint prop', () => {
+      expect(element(<Input name="a" label="b" title="TITLE" />)).toStrictEqual(
+        element(<Input name="a" label="b" hint="TITLE" />)
+      )
+
+      // Use hint prop rather than title prop when both defined
+      expect(
+        element(<Input name="a" label="b" hint="hint" title="title" />).hint
+      ).toBe('hint')
+    })
+
     it('throws error when passed invalid name', () => {
       expect(() => <Input name={'a'.repeat(300)} label="a" />).not.toThrow()
       expect(() => <Input name={'a'.repeat(301)} label="a" />).toThrow(/name/)
@@ -283,6 +294,10 @@ describe('Dialog support', () => {
       expect(() => <Input hint={'a'.repeat(151)} label="a" name="a" />).toThrow(
         /hint/
       )
+
+      expect(() => (
+        <Input title={'a'.repeat(151)} label="a" name="a" />
+      )).toThrow(/title/)
     })
 
     it('throws error when passed invalid placeholder', () => {
@@ -442,6 +457,17 @@ describe('Dialog support', () => {
       ).toStrictEqual(expectedElement)
     })
 
+    it('can use title prop as an alias to hint prop', () => {
+      expect(
+        element(<Textarea name="a" label="b" title="TITLE" />)
+      ).toStrictEqual(element(<Textarea name="a" label="b" hint="TITLE" />))
+
+      // Use hint prop rather than title prop when both defined
+      expect(
+        element(<Textarea name="a" label="b" hint="hint" title="title" />).hint
+      ).toBe('hint')
+    })
+
     it('throws error when passed invalid name', () => {
       expect(() => <Textarea name={'a'.repeat(300)} label="a" />).not.toThrow()
       expect(() => <Textarea name={'a'.repeat(301)} label="a" />).toThrow(
@@ -464,6 +490,10 @@ describe('Dialog support', () => {
       expect(() => (
         <Textarea hint={'a'.repeat(151)} label="a" name="a" />
       )).toThrow(/hint/)
+
+      expect(() => (
+        <Textarea title={'a'.repeat(151)} label="a" name="a" />
+      )).toThrow(/title/)
     })
 
     it('throws error when passed invalid placeholder', () => {
@@ -542,6 +572,7 @@ describe('Dialog support', () => {
         type: 'select',
         name: 'name',
         label: 'label',
+        hint: 'hint',
         optional: false,
         option_groups: [
           {
@@ -563,7 +594,7 @@ describe('Dialog support', () => {
 
       expect(
         element(
-          <Select name="name" label="label" required>
+          <Select name="name" label="label" hint="hint" required>
             <Optgroup label="A">
               <Option value="one">1</Option>
               <Option value="two">2</Option>
@@ -575,6 +606,31 @@ describe('Dialog support', () => {
           </Select>
         )
       ).toStrictEqual(expectedElementForOptgroup)
+    })
+
+    it('can use title prop as an alias to hint prop', () => {
+      expect(
+        element(
+          <Select name="a" label="b" title="TITLE">
+            <Option value="a">A</Option>
+          </Select>
+        )
+      ).toStrictEqual(
+        element(
+          <Select name="a" label="b" hint="TITLE">
+            <Option value="a">A</Option>
+          </Select>
+        )
+      )
+
+      // Use hint prop rather than title prop when both defined
+      expect(
+        element(
+          <Select name="a" label="b" hint="hint" title="title">
+            <Option value="a">A</Option>
+          </Select>
+        ).hint
+      ).toBe('hint')
     })
 
     it('throws error when <Select> has not contained option elements', () => {
@@ -724,6 +780,26 @@ describe('Dialog support', () => {
           <Option value="a">A</Option>
         </Select>
       )).toThrow(/placeholder/)
+    })
+
+    it('throws error when passed invalid hint', () => {
+      expect(() => (
+        <Select hint={'a'.repeat(150)} label="a" name="a">
+          <Option value="a">A</Option>
+        </Select>
+      )).not.toThrow()
+
+      expect(() => (
+        <Select hint={'a'.repeat(151)} label="a" name="a">
+          <Option value="a">A</Option>
+        </Select>
+      )).toThrow(/hint/)
+
+      expect(() => (
+        <Select title={'a'.repeat(151)} label="a" name="a">
+          <Option value="a">A</Option>
+        </Select>
+      )).toThrow(/title/)
     })
 
     it('throws error when passed option has invalid value', () => {

--- a/test/tag.tsx
+++ b/test/tag.tsx
@@ -1,4 +1,5 @@
 /** @jsx JSXSlack.h */
+import { Dialog, Input, Option, Select, Textarea } from '../src/dialog'
 import JSXSlack, {
   jsxslack,
   Actions,
@@ -46,6 +47,22 @@ describe('Tagged template', () => {
         </Blocks>
       )
     )
+  })
+
+  it('can use imported dialog components through interpolation', () => {
+    expect(jsxslack`
+      <${Dialog} callbackId="callback" title="test">
+        <${Input} type="hidden" name="hiddenState" value=${['a', 'b', 'c']} />
+        <${Input} type="text" name="foo" label="foo" required />
+        <${Textarea} name="bar" label="bar" />
+        <${Select} name="select" label="select">
+          <${Option} value="1">one<//>
+          <${Option} value="2">two<//>
+          <${Option} value="3">three<//>
+        <//>
+        <${Input} type="submit" value="Submit dialog" />
+      <//>
+    `).toMatchSnapshot()
   })
 
   describe('jsxslack.fragment', () => {


### PR DESCRIPTION
Resolves #19.

Although there are dialog components like `<Select>` whose a similar feature of Block Kit, Dialog JSON has a lot of differences from Block Kit JSON. We must provide as an individual module `@speee-js/jsx-slack/dialog` to avoid confusion.

```javascript
import JSXSlack from '@speee-js/jsx-slack'
import { Dialog, Input } from '@speee-js/jsx-slack/dialog'

console.log(
  JSXSlack(
    <Dialog callbackId="callback" title="test">
      <Input type="text" name="foo" label="foo" required />
      <Input type="text" name="bar" label="bar" />
      <Input type="submit" value="Submit" />
    </Dialog>
  )
)
```

```json
{
  "callback_id": "callback",
  "title": "test",
  "submit_label": "Submit",
  "elements": [
    {
      "type": "text",
      "name": "foo",
      "label": "foo",
      "optional": false
    },
    {
      "type": "text",
      "name": "bar",
      "label": "bar",
      "optional": true
    }
  ]
}
```

## Specification

An important difference of Slack dialog elements from HTML form is required `label` prop to each elements. We had considered the usage like `<label>` HTML5 element at first, but it becomes complex for parsing elements. `label` prop in each component would be very simple and still keeping readability.

For the text field on dialog, we will provide `<Input>` and `<Textarea>` components. These have familiar props like `<input>` and `<textarea>` HTML5 elements. `type` attribute of `<Input>` allows `text` (default), `tel`, `number`, `email`, and `url` (mapping to `subtype` in JSON for Slack). In addition, we also supports `hidden` type for keeping JSON value as a dialog state, and `submit` type to specify the submit label of current dialog.

For the select field, we will provide `<Select>` and family components from `@speee-js/jsx-slack/dialog` as like as already provided to Block Kit. (As described at the first, there is some differences in both of input props and output JSON between Block Kit and Dialog) Input props will fit in with already provided components as possible. Thus, select components from external data sources would use `initialXXX` prop instead of `value` prop.

## ToDo

- [x] Add documentation
