### PR TITLE
Update similar projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -896,6 +896,7 @@ You can deal workaround via `SlackJSX.exactMode(true)`. It can enable formatting
 ## Similar projects
 
 - [slack-jsx](https://github.com/zcei/slack-jsx) - Compose Slack messages from JSX Components instead of writing JSON.
+- [react-chat-renderer](https://github.com/asynchronous-dev/react-chat-renderer) - React renderer implementation for building rich Slack messages using JSX.
 
 ## Author
 


### PR DESCRIPTION
We added a new similar project: [react-chat-renderer](https://github.com/asynchronous-dev/react-chat-renderer).

Our module just provides React-like syntax and components for converting to JSON for Slack, and user cannot use React component to compose message. [react-chat-renderer](https://github.com/asynchronous-dev/react-chat-renderer) can use *the real React* by providing custom React renderer and [reconciler](https://reactjs.org/docs/codebase-overview.html#reconcilers).