### PR TITLE
Don't prevent generating <SelectFragment> with no options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Don't prevent generating `<SelectFragment>` with no options ([#41](https://github.com/speee/jsx-slack/pull/41))
+
 ### Changed
 
 - Update `htm` to [v2.2.0](https://github.com/developit/htm/releases/tag/2.2.0) ([#38](https://github.com/speee/jsx-slack/pull/38))

--- a/test/index.tsx
+++ b/test/index.tsx
@@ -1106,5 +1106,15 @@ describe('jsx-slack', () => {
         )
       ).toStrictEqual(expectedOptgroups)
     })
+
+    it('allows no options to return empty result', () => {
+      expect(JSXSlack(<SelectFragment />)).toStrictEqual({
+        options: [],
+      })
+
+      expect(JSXSlack(<SelectFragment>{}</SelectFragment>)).toStrictEqual({
+        options: [],
+      })
+    })
   })
 })


### PR DESCRIPTION
Currently `<SelectFragment>` throws an error when it has not contained any options.

```javascript
console.log(JSXSlack(<SelectFragment />))
// Error: Component for selection must include least of one <Option> or <Optgroup>.
```

However, the empty option is allowed in the external data source to make an empty result do clear. jsx-slack should rather return an empty value to show user correct result than prevent response to Slack by raising an error.

```javascript
console.log(JSXSlack(<SelectFragment />))
// {
//   "options": []
// }
```

`<Select>` that is using `<SelectFragment>` internally must keep throwing an error when any options are not contained.

```javascript
console.log(JSXSlack(<Blocks><Actions><Select /></Actions></Blocks>))
// Error: Component for selection must include least of one <Option> or <Optgroup>.
```