### PR TITLE
Coerce number-expected prop to integer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Coerce number-expected prop to integer ([#44](https://github.com/speee/jsx-slack/pull/44))
+
 ## v0.8.0 - 2019-08-06
 
 ### Added

--- a/src/block-kit/interactive/Select.tsx
+++ b/src/block-kit/interactive/Select.tsx
@@ -10,7 +10,7 @@ import {
 import flatten from 'lodash.flatten'
 import { ConfirmProps } from '../composition/Confirm'
 import { JSXSlack } from '../../jsx'
-import { ObjectOutput, PlainText } from '../../utils'
+import { ObjectOutput, PlainText, coerceToInteger } from '../../utils'
 
 export interface SelectPropsBase {
   actionId?: string
@@ -200,7 +200,7 @@ export const ExternalSelect: JSXSlack.FC<ExternalSelectProps> = props => {
       type="external_select"
       {...baseProps(props)}
       initial_option={initial}
-      min_query_length={props.minQueryLength}
+      min_query_length={coerceToInteger(props.minQueryLength)}
     />
   )
 }

--- a/src/dialog/Input.tsx
+++ b/src/dialog/Input.tsx
@@ -1,6 +1,6 @@
 /** @jsx JSXSlack.h */
 import { JSXSlack } from '../jsx'
-import { ObjectOutput } from '../utils'
+import { ObjectOutput, coerceToInteger } from '../utils'
 import { Text, TextProps } from './Text'
 
 interface InputPropsBase {
@@ -79,8 +79,8 @@ export const Input: JSXSlack.FC<InputProps> = props => {
         <Text
           hint={props.hint}
           label={props.label}
-          maxLength={props.maxLength}
-          minLength={props.minLength}
+          maxLength={coerceToInteger(props.maxLength)}
+          minLength={coerceToInteger(props.minLength)}
           name={props.name}
           optional={!props.required}
           placeholder={props.placeholder}

--- a/src/dialog/Select.tsx
+++ b/src/dialog/Select.tsx
@@ -7,7 +7,7 @@ import {
   OptionInternal,
 } from '../block-kit/interactive/Select'
 import { JSXSlack } from '../jsx'
-import { ObjectOutput } from '../utils'
+import { ObjectOutput, coerceToInteger } from '../utils'
 import { validateElement } from './Dialog'
 import { DialogValidationError } from './error'
 
@@ -219,7 +219,7 @@ export const ExternalSelect: JSXSlack.FC<ExternalSelectProps> = props => {
     <ObjectOutput<ExternalSelectElement>
       {...baseProps(props)}
       data_source="external"
-      min_query_length={props.minQueryLength}
+      min_query_length={coerceToInteger(props.minQueryLength)}
       selected_options={initial ? [initial] : undefined}
     />
   )

--- a/src/dialog/Textarea.tsx
+++ b/src/dialog/Textarea.tsx
@@ -35,28 +35,30 @@ export type TextareaElement = Pick<
 
 export const Textarea: JSXSlack.FC<TextareaProps> = props => {
   const validated = validateElement(props)
+  const maxLength = coerceToInteger(props.maxLength)
+  const minLength = coerceToInteger(props.minLength)
 
-  if (typeof props.maxLength === 'number') {
-    if (props.maxLength <= 0)
+  if (typeof maxLength === 'number') {
+    if (maxLength <= 0)
       throw new DialogValidationError(
-        `Maximum length of textarea must be greater than zero but maxLength=${props.maxLength} was passed.`
+        `Maximum length of textarea must be greater than zero but maxLength=${maxLength} was passed.`
       )
 
-    if (props.maxLength > 3000)
+    if (maxLength > 3000)
       throw new DialogValidationError(
-        `Maximum length of textarea must be up to 3000 but maxLength=${props.maxLength} was passed.`
+        `Maximum length of textarea must be up to 3000 but maxLength=${maxLength} was passed.`
       )
   }
 
-  if (typeof props.minLength === 'number') {
-    if (props.minLength < 0)
+  if (typeof minLength === 'number') {
+    if (minLength < 0)
       throw new DialogValidationError(
-        `Minimum length of textarea must be greater than or equal to zero but minLength=${props.minLength} was passed.`
+        `Minimum length of textarea must be greater than or equal to zero but minLength=${minLength} was passed.`
       )
 
-    if (props.minLength > 3000)
+    if (minLength > 3000)
       throw new DialogValidationError(
-        `Minimum length of textarea must be up to 3000 but minLength=${props.minLength} was passed.`
+        `Minimum length of textarea must be up to 3000 but minLength=${minLength} was passed.`
       )
   }
 
@@ -74,8 +76,8 @@ export const Textarea: JSXSlack.FC<TextareaProps> = props => {
     <ObjectOutput<TextareaElement>
       hint={validated.hint}
       label={props.label}
-      max_length={coerceToInteger(props.maxLength)}
-      min_length={coerceToInteger(props.minLength)}
+      max_length={maxLength}
+      min_length={minLength}
       name={props.name}
       optional={!props.required}
       placeholder={props.placeholder}

--- a/src/dialog/Textarea.tsx
+++ b/src/dialog/Textarea.tsx
@@ -1,7 +1,7 @@
 /** @jsx JSXSlack.h */
 import { Dialog } from '@slack/types'
 import { JSXSlack } from '../jsx'
-import { ObjectOutput } from '../utils'
+import { ObjectOutput, coerceToInteger } from '../utils'
 import { validateElement } from './Dialog'
 import { DialogValidationError } from './error'
 
@@ -74,8 +74,8 @@ export const Textarea: JSXSlack.FC<TextareaProps> = props => {
     <ObjectOutput<TextareaElement>
       hint={validated.hint}
       label={props.label}
-      max_length={props.maxLength}
-      min_length={props.minLength}
+      max_length={coerceToInteger(props.maxLength)}
+      min_length={coerceToInteger(props.minLength)}
       name={props.name}
       optional={!props.required}
       placeholder={props.placeholder}

--- a/src/turndown.ts
+++ b/src/turndown.ts
@@ -1,7 +1,7 @@
 import TurndownService from 'turndown'
 import { JSXSlack } from './jsx'
 import { escapeEntity } from './html'
-import { detectSpecialLink, SpecialLink } from './utils'
+import { SpecialLink, coerceToInteger, detectSpecialLink } from './utils'
 
 const preSymbol = Symbol('pre')
 const uniqIdSymbol = Symbol('uniqId')
@@ -126,7 +126,7 @@ const turndownService = () => {
 
         if (parent && parent.nodeName === 'OL') {
           // Get the number of order
-          const start = parent.getAttribute('start') || 1
+          const start = coerceToInteger(parent.getAttribute('start') || 1)
           const index = Array.prototype.indexOf.call(
             Array.prototype.filter.call(
               parent.children,

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -49,3 +49,9 @@ export function detectSpecialLink(href: string): SpecialLink | undefined {
 
   return undefined
 }
+
+export function coerceToInteger(
+  num: number | string | undefined
+): number | undefined {
+  return num !== undefined ? Number.parseInt(num.toString(), 10) : undefined
+}

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -53,5 +53,10 @@ export function detectSpecialLink(href: string): SpecialLink | undefined {
 export function coerceToInteger(
   num: number | string | undefined
 ): number | undefined {
-  return (num !== undefined && Number.parseInt(num.toString(), 10)) || undefined
+  if (num === undefined) return undefined
+
+  const coerced = Number.parseInt(num.toString(), 10)
+  if (Number.isNaN(coerced)) return undefined
+
+  return coerced
 }

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -53,5 +53,5 @@ export function detectSpecialLink(href: string): SpecialLink | undefined {
 export function coerceToInteger(
   num: number | string | undefined
 ): number | undefined {
-  return num !== undefined ? Number.parseInt(num.toString(), 10) : undefined
+  return (num !== undefined && Number.parseInt(num.toString(), 10)) || undefined
 }

--- a/test/html.tsx
+++ b/test/html.tsx
@@ -505,6 +505,21 @@ describe('HTML parser for mrkdwn', () => {
           </ol>
         )
       ).toBe('\u20079. Change\n10. Start\n\u2007\u2007  number') // aligned number
+
+      // Coerce to integer
+      expect(
+        html(
+          <ol start={3.5}>
+            <li>test</li>
+          </ol>
+        )
+      ).toBe(
+        html(
+          <ol start={3}>
+            <li>test</li>
+          </ol>
+        )
+      )
     })
 
     it('allows sub list', () => {


### PR DESCRIPTION
We've added `coerceToInteger` utility function. We will coerce number-expected prop to integer by calling `Number.parseInt()`.

It resolves some edge cases:

- `<ol start={1.5}><li>xxx</li></ol>` outputs internal tag wrongly: `<<list-number:1:1.5>>xxx`

<img width="729" src="https://user-images.githubusercontent.com/3993388/62597794-1ee71c80-b922-11e9-9be2-19dac3e33e1d.png">

- HTML-style number in template literal may output invalid JSON.

<img width="834" src="https://user-images.githubusercontent.com/3993388/62597803-273f5780-b922-11e9-89a3-5fdf33719d35.png">
