### PR TITLE
Allow links in the inside of code and pre element (again)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Changed
 
 - Improve html entity decoding in JSX and template literal tag ([#33](https://github.com/speee/jsx-slack/pull/33), [#45](https://github.com/speee/jsx-slack/issues/45))
+- Allow links in the inside of `<code>` and `<pre>` element ([#46](https://github.com/speee/jsx-slack/pull/46))
 
 ## v0.8.1 - 2019-08-07
 

--- a/src/turndown.ts
+++ b/src/turndown.ts
@@ -106,17 +106,12 @@ const turndownService = () => {
         node.firstChild &&
         node.firstChild.nodeName === 'CODE',
 
-      replacement: (_, node: HTMLElement, opts) => {
-        const pre = node.firstChild
-          ? originalTurndown
-              .call(
-                td,
-                (node.firstChild as any).innerHTML.replace(/\n/g, '<br />')
-              )
-              .replace(/<br \/>/g, '')
-          : ''
-
+      replacement: (_, node, opts) => {
         const singleLine = node.parentNode && node.parentNode.nodeName === 'A'
+        const pre = originalTurndown
+          .call(td, node.firstChild.innerHTML.replace(/\n/g, '<br />'))
+          .replace(/<br \/>/g, '')
+
         opts[preSymbol].push(pre)
 
         return `\n${`<<pre:${opts[preSymbol].length - 1}${

--- a/test/html.tsx
+++ b/test/html.tsx
@@ -805,6 +805,15 @@ describe('HTML parser for mrkdwn', () => {
       expect(html(<time datetime={1552212000}>{'{time_secs}'}</time>)).toBe(
         '<!date^1552212000^{time_secs}|10:00:00 AM>'
       )
+
+      // HTML entities
+      expect(
+        html(<time datetime={1552212000}>&lt;{'{date_num}'}&gt;</time>)
+      ).toBe('<!date^1552212000^&lt;{date_num}&gt;|&lt;2019-03-10&gt;>')
+
+      expect(
+        html(<time datetime={1552212000}>&#123;date_num&#125; &hearts;</time>)
+      ).toBe('<!date^1552212000^{date_num} \u2665|2019-03-10 \u2665>')
     })
 
     test.each`

--- a/test/html.tsx
+++ b/test/html.tsx
@@ -262,6 +262,32 @@ describe('HTML parser for mrkdwn', () => {
       ).toBe('`foo`\n\n`bar`')
     })
 
+    it('allows containing link', () => {
+      expect(
+        html(
+          <Fragment>
+            <code>
+              <a href="https://example.com/">{'<example>'}</a>
+            </code>
+            <br />
+            <code>
+              <a href="@channel" />
+            </code>
+          </Fragment>
+        )
+      ).toBe('`<https://example.com/|&lt;example&gt;>`\n`<!channel|channel>`')
+    })
+
+    it('allows containing time tag for localization', () => {
+      expect(
+        html(
+          <code>
+            <time datetime="1552212000">{'{date_num}'}</time>
+          </code>
+        )
+      ).toBe('`<!date^1552212000^{date_num}|2019-03-10>`')
+    })
+
     it('inserts invisible spaces around markup chars when rendered in exact mode', () => {
       JSXSlack.exactMode(true)
       expect(html(<code>code</code>)).toBe('\u200b`\u200bcode\u200b`\u200b')
@@ -428,6 +454,29 @@ describe('HTML parser for mrkdwn', () => {
           </s>
         )
       ).toBe('&gt; ~strikethrough and~\n&gt; ```\nquoted\ntext\n```\n&gt;'))
+
+    it('allows containing link', () => {
+      expect(
+        html(
+          <pre>
+            <a href="https://example.com/">example</a>
+          </pre>
+        )
+      ).toBe('```\n<https://example.com/|example>\n```')
+
+      // with format
+      expect(
+        html(
+          <pre>
+            <a href="https://example.com/">
+              <b>Bold</b> link
+            </a>
+            <br />
+            {'and plain\ntext'}
+          </pre>
+        )
+      ).toBe('```\n<https://example.com/|*Bold* link>\nand plain\ntext\n```')
+    })
   })
 
   describe('List', () => {
@@ -833,6 +882,16 @@ describe('HTML parser for mrkdwn', () => {
           </a>
         )
       ).toBe('<!date^1552212000^{date_num}^https://example.com/|2019-03-10>')
+    })
+
+    it('escapes brackets in contents and fallback', () => {
+      expect(
+        html(
+          <time datetime={1552212000} fallback="<2019-03-10>">
+            {'<{date_num}>'}
+          </time>
+        )
+      ).toBe('<!date^1552212000^&lt;{date_num}&gt;|&lt;2019-03-10&gt;>')
     })
 
     it('escapes divider in contents and fallback', () => {


### PR DESCRIPTION
> This PR is re-implementation of #16.

Until now, `<a>` tag in the inside of `<code>` and `<pre>` won't recognize as link. It is the correct behavior in regular Markdown's backtick(s), but not in Slack mrkdwn format and regular HTML. It allows link format `<xxx|xxx>` in the inside of inline code and fence.

For consistent HTML element support, we would require to change that children of `<code>` and `<pre>` allow `<a>` tag and `<time>` tag.

```jsx
<code><a href="https://example.com/">example</a></code>
<pre><a href="https://example.com/">example</a></pre>
```

<img width="677" src="https://user-images.githubusercontent.com/3993388/56725542-021a4500-6788-11e9-85e6-b5b2acb00c8c.png">