### PR TITLE
Fix regression of not preserved <pre> whitespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix regression of not preserved `<pre>` whitespaces ([#48](https://github.com/speee/jsx-slack/issues/48), [#49](https://github.com/speee/jsx-slack/pull/49))
+
 ## v0.9.0 - 2019-08-15
 
 ### Breaking

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "preversion": "npm-run-all --npm-path yarn -p check:* lint test:coverage",
     "test": "jest",
     "test:coverage": "jest --coverage",
+    "test:debug": "node --inspect ./node_modules/.bin/jest -i",
     "types": "rimraf types && tsc --declaration --emitDeclarationOnly --outDir types",
     "version": "node version.js && git add -A CHANGELOG.md"
   },

--- a/src/turndown.ts
+++ b/src/turndown.ts
@@ -108,10 +108,11 @@ const turndownService = () => {
 
       replacement: (_, node, opts) => {
         const singleLine = node.parentNode && node.parentNode.nodeName === 'A'
-        const pre = originalTurndown
-          .call(td, node.firstChild.innerHTML.replace(/\n/g, '<br />'))
-          .replace(/<br \/>/g, '')
 
+        const target = node.ownerDocument.createElement('pre')
+        target.innerHTML = node.firstChild.innerHTML
+
+        const pre = originalTurndown.call(td, target).replace(/<br \/>/g, '')
         opts[preSymbol].push(pre)
 
         return `\n${`<<pre:${opts[preSymbol].length - 1}${

--- a/test/html.tsx
+++ b/test/html.tsx
@@ -444,6 +444,11 @@ describe('HTML parser for mrkdwn', () => {
       ).toBe('foo\n\n```\npre\nformatted\ntext\n```\n\nbar')
     })
 
+    it('preserves whitespaces for indent', () => {
+      const preformatted = '{\n  hello\n}'
+      expect(html(<pre>{preformatted}</pre>)).toBe('```\n{\n  hello\n}```')
+    })
+
     it('allows wrapping by text format character', () =>
       expect(
         html(

--- a/test/html.tsx
+++ b/test/html.tsx
@@ -446,7 +446,7 @@ describe('HTML parser for mrkdwn', () => {
 
     it('preserves whitespaces for indent', () => {
       const preformatted = '{\n  hello\n}'
-      expect(html(<pre>{preformatted}</pre>)).toBe('```\n{\n  hello\n}```')
+      expect(html(<pre>{preformatted}</pre>)).toBe('```\n{\n  hello\n}\n```')
     })
 
     it('allows wrapping by text format character', () =>

--- a/test/html.tsx
+++ b/test/html.tsx
@@ -447,6 +447,17 @@ describe('HTML parser for mrkdwn', () => {
     it('preserves whitespaces for indent', () => {
       const preformatted = '{\n  hello\n}'
       expect(html(<pre>{preformatted}</pre>)).toBe('```\n{\n  hello\n}\n```')
+
+      // with <a> link
+      expect(
+        html(
+          <pre>
+            {'{\n  '}
+            <a href="https://example.com/">hello</a>
+            {'\n}'}
+          </pre>
+        )
+      ).toBe('```\n{\n  <https://example.com/|hello>\n}\n```')
     })
 
     it('allows wrapping by text format character', () =>


### PR DESCRIPTION
Resolves #48.

The content of `<pre>` tag will be parsed with `turndown` parser (by #46), but it will collapse whitespaces when passed a string or element except `<pre>`. So we created `<pre>` node for passing to turndown.