### PR TITLE
Use lodash.flattendeep instead of lodash.flatten to normalize nested fragments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Nested fragments fail ([#53](https://github.com/speee/jsx-slack/issues/53), [#54](https://github.com/speee/jsx-slack/pull/54))
+
 ### Changed
 
 - Update dependent packages to the latest version ([#52](https://github.com/speee/jsx-slack/pull/52))

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "@slack/types": "^1.1.0",
     "he": "^1.2.0",
     "htm": "^2.2.1",
-    "lodash.flatten": "^4.4.0",
+    "lodash.flattendeep": "^4.4.0",
     "turndown": "^5.0.3"
   }
 }

--- a/src/block-kit/interactive/Select.tsx
+++ b/src/block-kit/interactive/Select.tsx
@@ -7,7 +7,7 @@ import {
   Option as SlackOption,
   UsersSelect as SlackUsersSelect,
 } from '@slack/types'
-import flatten from 'lodash.flatten'
+import flattenDeep from 'lodash.flattendeep'
 import { ConfirmProps } from '../composition/Confirm'
 import { JSXSlack } from '../../jsx'
 import { ObjectOutput, PlainText, coerceToInteger } from '../../utils'
@@ -163,7 +163,8 @@ export const Select: JSXSlack.FC<SelectProps> = props => {
 
   if (typeof props.value === 'string') {
     const opts: SlackOption[] =
-      fragment.options || flatten(fragment.option_groups.map(og => og.options))
+      fragment.options ||
+      flattenDeep(fragment.option_groups.map(og => og.options))
 
     initialOption = opts.find(o => o.value === props.value)
   }

--- a/src/jsx.ts
+++ b/src/jsx.ts
@@ -1,5 +1,5 @@
 /* eslint-disable import/export, @typescript-eslint/no-namespace, @typescript-eslint/no-empty-interface */
-import flatten from 'lodash.flatten'
+import flattenDeep from 'lodash.flattendeep'
 import { escapeChars, escapeEntity, parse } from './html'
 import turndown from './turndown'
 import { wrap } from './utils'
@@ -135,7 +135,7 @@ export namespace JSXSlack {
 
   // Remove conditional value from children
   export const normalizeChildren = (cr: Children<any>): (Node | string)[] =>
-    flatten(wrap(cr))
+    flattenDeep(wrap(cr))
       .filter(c => c != null && c !== false && c !== true)
       .map(c => (typeof c !== 'object' ? c.toString() : c))
 

--- a/test/index.tsx
+++ b/test/index.tsx
@@ -1029,6 +1029,48 @@ describe('jsx-slack', () => {
         )
       )
     })
+
+    it('allows nested fragments', () => {
+      expect(
+        JSXSlack(
+          <Blocks>
+            <Fragment>
+              <Fragment>
+                <Section>Nested</Section>
+                <Section>fragments</Section>
+              </Fragment>
+              <Fragment>
+                <Section>with</Section>
+                <Section>multiple</Section>
+              </Fragment>
+            </Fragment>
+            <Fragment>
+              <Fragment>
+                <Section>components</Section>
+                <Section>are</Section>
+              </Fragment>
+              <Fragment>
+                <Section>supported</Section>
+                <Section>well</Section>
+              </Fragment>
+            </Fragment>
+          </Blocks>
+        )
+      ).toStrictEqual(
+        JSXSlack(
+          <Blocks>
+            <Section>Nested</Section>
+            <Section>fragments</Section>
+            <Section>with</Section>
+            <Section>multiple</Section>
+            <Section>components</Section>
+            <Section>are</Section>
+            <Section>supported</Section>
+            <Section>well</Section>
+          </Blocks>
+        )
+      )
+    })
   })
 
   describe('<SelectFragment> component', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4425,10 +4425,10 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
 
-lodash.flatten@^4.4.0:
+lodash.flattendeep@^4.4.0:
   version "4.4.0"
-  resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
-  integrity sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=
+  resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
+  integrity sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=
 
 lodash.memoize@^4.1.2:
   version "4.1.2"


### PR DESCRIPTION
jsx-slack <= v0.9.1 had used `lodash.flatten` to flatten JSX elements in array spread by using `<Fragment>`. But it flattens only a single level so nested fragments could not handle correctly in `JSXSlack`.

We will use `lodash.flattendeep` instead of `lodash.flatten` to normalize JSX elements in multiple level array.

Resolves #53.