### PR TITLE
Update about-escape-and-exact-mode.md

### DIFF
--- a/docs/about-escape-and-exact-mode.md
+++ b/docs/about-escape-and-exact-mode.md
@@ -65,6 +65,6 @@ However, Slack renders as:
 
 You can deal workaround via `SlackJSX.exactMode(true)`. It can enable formatting forcibly by inserting zero-width space around special chars.
 
-[<img src="https://raw.githubusercontent.com/speee/jsx-slack/master/docs/preview-btn.svg?sanitize=true" width="240" />](https://api.slack.com/tools/block-kit-builder?blocks=%5B%7B%22type%22%3A%22section%22%2C%22text%22%3A%7B%22text%22%3A%22Super%E2%80%8B_%E2%80%8Bcali%E2%80%8B_%E2%80%8Bfragilistic%E2%80%8B*%E2%80%8Bexpiali%E2%80%8B*%E2%80%8Bdocious%22%2C%22type%22%3A%22mrkdwn%22%2C%22verbatim%22%3Atrue%7D%7D%5D)
+[<img src="https://raw.githubusercontent.com/speee/jsx-slack/master/docs/preview-btn.svg?sanitize=true" width="240" />](https://api.slack.com/tools/block-kit-builder?blocks=%5B%7B%22type%22%3A%22section%22%2C%22text%22%3A%7B%22text%22%3A%22Super%5Cu200b_%5Cu200bcali%5Cu200b_%5Cu200bfragilistic%5Cu200b*%5Cu200bexpiali%5Cu200b*%5Cu200bdocious%22%2C%22type%22%3A%22mrkdwn%22%2C%22verbatim%22%3Atrue%7D%7D%5D)
 
 **Exact mode is a last resort.** _We recommend dealing with incorrect rendering by such as inserting spaces around markup elements._


### PR DESCRIPTION
Now URL for exact mode enabled JSON does not work in Block Kit Builder.

We have to use zero-width whitespace as `\u200b` instead of encoded URI components.