### PR TITLE
Add multiple attribute for multi-select menus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- [Multi-select menus](https://api.slack.com/reference/block-kit/block-elements#multi_select) ([#56](https://github.com/speee/jsx-slack/issues/56), [#58](https://github.com/speee/jsx-slack/pull/58))
+
 ## v0.9.2 - 2019-08-29
 
 ### Fixed

--- a/docs/jsx-components-for-block-kit.md
+++ b/docs/jsx-components-for-block-kit.md
@@ -233,12 +233,44 @@ A menu element with static options passed by `<Option>` or `<Optgroup>`. It has 
 
 [<img src="https://raw.githubusercontent.com/speee/jsx-slack/master/docs/preview-btn.svg?sanitize=true" width="240" />](https://api.slack.com/tools/block-kit-builder?blocks=%5B%7B%22type%22%3A%22actions%22%2C%22elements%22%3A%5B%7B%22type%22%3A%22static_select%22%2C%22placeholder%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Rate%20it!%22%2C%22emoji%22%3Atrue%7D%2C%22action_id%22%3A%22rating%22%2C%22options%22%3A%5B%7B%22value%22%3A%225%22%2C%22text%22%3A%7B%22text%22%3A%225%20%3Astar%3A%3Astar%3A%3Astar%3A%3Astar%3A%3Astar%3A%22%2C%22type%22%3A%22plain_text%22%2C%22emoji%22%3Atrue%7D%7D%2C%7B%22value%22%3A%224%22%2C%22text%22%3A%7B%22text%22%3A%224%20%3Astar%3A%3Astar%3A%3Astar%3A%3Astar%3A%22%2C%22type%22%3A%22plain_text%22%2C%22emoji%22%3Atrue%7D%7D%2C%7B%22value%22%3A%223%22%2C%22text%22%3A%7B%22text%22%3A%223%20%3Astar%3A%3Astar%3A%3Astar%3A%22%2C%22type%22%3A%22plain_text%22%2C%22emoji%22%3Atrue%7D%7D%2C%7B%22value%22%3A%222%22%2C%22text%22%3A%7B%22text%22%3A%222%20%3Astar%3A%3Astar%3A%22%2C%22type%22%3A%22plain_text%22%2C%22emoji%22%3Atrue%7D%7D%2C%7B%22value%22%3A%221%22%2C%22text%22%3A%7B%22text%22%3A%221%20%3Astar%3A%22%2C%22type%22%3A%22plain_text%22%2C%22emoji%22%3Atrue%7D%7D%5D%7D%5D%7D%5D)
 
+By defining `multiple` attribute, you also can provide [the selectable menu from multiple options][multi-select] with an appearance is similar to button or text input. The same goes for other menu-like components.
+
+[multi-select]: https://api.slack.com/reference/block-kit/block-elements#multi_select
+
+```jsx
+<Blocks>
+  <Section>
+    What kind of dogs do you love? :dog:
+    <Select
+      actionId="dogs"
+      multiple
+      placeholder="Choose favorite dog(s)"
+      value={['labrador', 'golden_retriver']}
+    >
+      <Option value="labrador">Labrador</Option>
+      <Option value="german_shepherd">German Shepherd</Option>
+      <Option value="golden_retriver">Golden Retriever</Option>
+      <Option value="bulldog">Bulldog</Option>
+    </Select>
+  </Section>
+</Blocks>
+```
+
+[<img src="https://raw.githubusercontent.com/speee/jsx-slack/master/docs/preview-btn.svg?sanitize=true" width="240" />](<https://api.slack.com/tools/block-kit-builder?blocks=%5B%7B%22type%22%3A%22section%22%2C%22text%22%3A%7B%22text%22%3A%22What%20kind%20of%20dogs%20do%20you%20love%3F%20%3Adog%3A%22%2C%22type%22%3A%22mrkdwn%22%2C%22verbatim%22%3Atrue%7D%2C%22accessory%22%3A%7B%22type%22%3A%22multi_static_select%22%2C%22action_id%22%3A%22dogs%22%2C%22placeholder%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Choose%20favorite%20dog(s)%22%2C%22emoji%22%3Atrue%7D%2C%22initial_options%22%3A%5B%7B%22value%22%3A%22labrador%22%2C%22text%22%3A%7B%22text%22%3A%22Labrador%22%2C%22type%22%3A%22plain_text%22%2C%22emoji%22%3Atrue%7D%7D%2C%7B%22value%22%3A%22golden_retriver%22%2C%22text%22%3A%7B%22text%22%3A%22Golden%20Retriever%22%2C%22type%22%3A%22plain_text%22%2C%22emoji%22%3Atrue%7D%7D%5D%2C%22options%22%3A%5B%7B%22value%22%3A%22labrador%22%2C%22text%22%3A%7B%22text%22%3A%22Labrador%22%2C%22type%22%3A%22plain_text%22%2C%22emoji%22%3Atrue%7D%7D%2C%7B%22value%22%3A%22german_shepherd%22%2C%22text%22%3A%7B%22text%22%3A%22German%20Shepherd%22%2C%22type%22%3A%22plain_text%22%2C%22emoji%22%3Atrue%7D%7D%2C%7B%22value%22%3A%22golden_retriver%22%2C%22text%22%3A%7B%22text%22%3A%22Golden%20Retriever%22%2C%22type%22%3A%22plain_text%22%2C%22emoji%22%3Atrue%7D%7D%2C%7B%22value%22%3A%22bulldog%22%2C%22text%22%3A%7B%22text%22%3A%22Bulldog%22%2C%22type%22%3A%22plain_text%22%2C%22emoji%22%3Atrue%7D%7D%5D%7D%7D%5D&mode=message>)
+
+> :warning: Slack does not allow to place the multi-select menu in `Actions` block. So jsx-slack throws error if you're trying to use `multiple` attribute in the children of `<Actions>`.
+
 #### Props
 
 - `actionId` (optional): An identifier for the action.
 - `placeholder` (optional): A plain text to be shown at first.
-- `value` (optional): A value of item to show initially. It must choose value from defined `<Option>` elements in children.
+- `value` (optional): A value of item to show initially. It must choose value from defined `<Option>` elements in children. It can pass multiple string values by array when `multiple` is enabled.
 - `confirm` (optional): [`<Confirm>` element](#confirm-confirmation-dialog) to show confirmation dialog.
+
+##### Props for [multi-select] menu
+
+- `multiple` (optional): A boolean value that shows whether multiple options can be selected.
+- `maxSelectedItems` (optional): A maximum number of items to allow selected.
 
 #### `<Option>`: Menu item
 
@@ -296,15 +328,20 @@ It requires setup JSON entry URL in your Slack app. [Learn about external source
 
 - `actionId` (optional): An identifier for the action.
 - `placeholder` (optional): A plain text to be shown at first.
-- `initialOption` (optional): An initial option exactly matched to provided options from external source. It allows raw JSON object or `<Option>`.
+- `initialOption` (optional): An initial option exactly matched to provided options from external source. It allows raw JSON object or `<Option>`. It can pass multiple options by array when `multiple` is enabled.
 - `minQueryLength` (optional): A length of typed characters to begin JSON request.
 - `confirm` (optional): [`<Confirm>` element](#confirm-confirmation-dialog) to show confirmation dialog.
+
+##### Props for [multi-select] menu
+
+- `multiple` (optional): A boolean value that shows whether multiple options can be selected.
+- `maxSelectedItems` (optional): A maximum number of items to allow selected.
 
 #### `<SelectFragment>`: Generate options for external source
 
 You would want to build not only the message but also the data source by jsx-slack. `<SelectFragment>` component can create JSON object for external data source usable in `<ExternalSelect>`.
 
-A following is a simple example to serve JSON for external select via [express](https://expressjs.com/). It is using [`jsxslack` tagged template literal](../README.md#quick-start-template-literal).
+A following is a super simple example to serve JSON for external select via [express](https://expressjs.com/). It is using [`jsxslack` tagged template literal](../README.md#quick-start-template-literal).
 
 ```javascript
 import { jsxslack } from '@speee-js/jsx-slack'
@@ -333,8 +370,13 @@ A select menu with options consisted of users in the current workspace.
 
 - `actionId` (optional): An identifier for the action.
 - `placeholder` (optional): A plain text to be shown at first.
-- `initialUser` (optional): The initial user ID.
+- `initialUser` (optional): The initial user ID. It can pass multiple string values by array when `multiple` is enabled.
 - `confirm` (optional): [`<Confirm>` element](#confirm-confirmation-dialog) to show confirmation dialog.
+
+##### Props for [multi-select] menu
+
+- `multiple` (optional): A boolean value that shows whether multiple options can be selected.
+- `maxSelectedItems` (optional): A maximum number of items to allow selected.
 
 ### [`<ConversationsSelect>`: Select menu with conversations list](https://api.slack.com/reference/messaging/block-elements#conversation-select)
 
@@ -344,8 +386,13 @@ A select menu with options consisted of any type of conversations in the current
 
 - `actionId` (optional): An identifier for the action.
 - `placeholder` (optional): A plain text to be shown at first.
-- `initialConversation` (optional): The initial conversation ID.
+- `initialConversation` (optional): The initial conversation ID. It can pass multiple string values by array when `multiple` is enabled.
 - `confirm` (optional): [`<Confirm>` element](#confirm-confirmation-dialog) to show confirmation dialog.
+
+##### Props for [multi-select] menu
+
+- `multiple` (optional): A boolean value that shows whether multiple options can be selected.
+- `maxSelectedItems` (optional): A maximum number of items to allow selected.
 
 ### [`<ChannelsSelect>`: Select menu with channel list](https://api.slack.com/reference/messaging/block-elements#channel-select)
 
@@ -355,8 +402,13 @@ A select menu with options consisted of public channels in the current workspace
 
 - `actionId` (optional): An identifier for the action.
 - `placeholder` (optional): A plain text to be shown at first.
-- `initialChannel` (optional): The initial channel ID.
+- `initialChannel` (optional): The initial channel ID. It can pass multiple string values by array when `multiple` is enabled.
 - `confirm` (optional): [`<Confirm>` element](#confirm-confirmation-dialog) to show confirmation dialog.
+
+##### Props for [multi-select] menu
+
+- `multiple` (optional): A boolean value that shows whether multiple options can be selected.
+- `maxSelectedItems` (optional): A maximum number of items to allow selected.
 
 ### [`<Overflow>`: Overflow menu](https://api.slack.com/reference/messaging/block-elements#overflow)
 

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "typescript": "^3.5.3"
   },
   "dependencies": {
-    "@slack/types": "^1.1.0",
+    "@slack/types": "^1.2.0",
     "he": "^1.2.0",
     "htm": "^2.2.1",
     "lodash.flattendeep": "^4.4.0",

--- a/src/block-kit/Actions.tsx
+++ b/src/block-kit/Actions.tsx
@@ -4,12 +4,26 @@ import { JSXSlack } from '../jsx'
 import { ArrayOutput, ObjectOutput } from '../utils'
 import { BlockComponentProps } from './Blocks'
 import { ButtonProps } from './interactive/Button'
-import { SelectPropsBase } from './interactive/Select'
+import { SingleSelectPropsBase } from './interactive/Select'
 import { OverflowProps } from './interactive/Overflow'
+import { DatePickerProps } from './interactive/DatePicker'
 
 interface ActionsProps extends BlockComponentProps {
-  children: JSXSlack.Children<ButtonProps | SelectPropsBase | OverflowProps>
+  children: JSXSlack.Children<
+    ButtonProps | SingleSelectPropsBase | OverflowProps | DatePickerProps
+  >
 }
+
+const actionTypes = [
+  'button',
+  'static_select',
+  'external_select',
+  'users_select',
+  'conversations_select',
+  'channels_select',
+  'overflow',
+  'datepicker',
+]
 
 export const Actions: JSXSlack.FC<ActionsProps> = props => {
   const elements = JSXSlack(<ArrayOutput>{props.children}</ArrayOutput>)
@@ -18,6 +32,9 @@ export const Actions: JSXSlack.FC<ActionsProps> = props => {
     throw new Error(
       `The number of passed elements (${elements.length}) is over the limit. <Actions> block allows to include up to 25 elements.`
     )
+
+  if (elements.some(({ type }) => !actionTypes.includes(type)))
+    throw new Error(`<Actions> block has an incompatible element as children.`)
 
   return (
     <ObjectOutput<ActionsBlock>

--- a/src/block-kit/Blocks.tsx
+++ b/src/block-kit/Blocks.tsx
@@ -1,6 +1,6 @@
 /** @jsx JSXSlack.h */
 import { JSXSlack } from '../jsx'
-import { ArrayOutput, wrap } from '../utils'
+import { ArrayOutput, isNode, wrap } from '../utils'
 import { Divider, Image, Section } from './index'
 
 export interface BlocksProps {
@@ -14,22 +14,17 @@ export interface BlockComponentProps {
 
 export const Blocks: JSXSlack.FC<BlocksProps> = props => {
   const normalized = wrap(props.children).map(child => {
-    if (child && typeof child === 'object') {
-      const isNode = (v: object): v is JSXSlack.Node =>
-        typeof (v as JSXSlack.Node).type === 'string'
-
-      if (isNode(child)) {
-        // Aliasing intrinsic elements to Block component
-        switch (child.type) {
-          case 'hr':
-            return <Divider {...child.props}>{...child.children}</Divider>
-          case 'img':
-            return <Image {...child.props}>{...child.children}</Image>
-          case 'section':
-            return <Section {...child.props}>{...child.children}</Section>
-          default:
-            throw new Error('<Blocks> allows only including Block component.')
-        }
+    if (child && isNode(child) && typeof child.type === 'string') {
+      // Aliasing intrinsic elements to Block component
+      switch (child.type) {
+        case 'hr':
+          return <Divider {...child.props}>{...child.children}</Divider>
+        case 'img':
+          return <Image {...child.props}>{...child.children}</Image>
+        case 'section':
+          return <Section {...child.props}>{...child.children}</Section>
+        default:
+          throw new Error('<Blocks> allows only including Block component.')
       }
     }
     return child

--- a/src/block-kit/Section.tsx
+++ b/src/block-kit/Section.tsx
@@ -28,6 +28,11 @@ export const Section: JSXSlack.FC<
           case 'users_select':
           case 'conversations_select':
           case 'channels_select':
+          case 'multi_static_select':
+          case 'multi_external_select':
+          case 'multi_users_select':
+          case 'multi_conversations_select':
+          case 'multi_channels_select':
           case 'overflow':
           case 'datepicker':
             accessory = JSXSlack(child)

--- a/src/block-kit/index.ts
+++ b/src/block-kit/index.ts
@@ -1,4 +1,4 @@
-// Block container
+// Containers for Block Kit
 export { Blocks } from './Blocks'
 
 // Block Kit blocks

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -27,6 +27,9 @@ export const PlainText = (props: { children: JSXSlack.Children<{}> }) =>
 export const Html = (props: { children: JSXSlack.Children<{}> }) =>
   JSXSlack.h(JSXSlack.NodeType.html, props)
 
+export const isNode = <T extends {} = any>(v: any): v is JSXSlack.Node<T> =>
+  typeof v === 'object' && v.type !== undefined
+
 export function wrap<T>(children: T | T[]): T[] {
   if (Array.isArray(children)) return children
   if (children) return [children]

--- a/test/index.tsx
+++ b/test/index.tsx
@@ -37,7 +37,20 @@ import JSXSlack, {
 beforeEach(() => JSXSlack.exactMode(false))
 
 describe('jsx-slack', () => {
-  describe('Block Kit as component', () => {
+  describe('Container components', () => {
+    describe('<Blocks>', () => {
+      it('throws error when <Blocks> has unexpected element', () =>
+        expect(() =>
+          JSXSlack(
+            <Blocks>
+              <b>unexpected</b>
+            </Blocks>
+          )
+        ).toThrow())
+    })
+  })
+
+  describe('Block Kit components', () => {
     describe('<Section>', () => {
       const section: SectionBlock = {
         type: 'section',

--- a/test/index.tsx
+++ b/test/index.tsx
@@ -105,7 +105,7 @@ describe('jsx-slack', () => {
         }
       })
 
-      it('output section block with action accessories', () => {
+      it('outputs section block with action accessories', () => {
         for (const accessory of [
           <Button>Button</Button>,
           <Select>
@@ -131,10 +131,7 @@ describe('jsx-slack', () => {
           expect(
             JSXSlack(
               <Blocks>
-                <Section blockId="with_image">
-                  Accessory test
-                  {accessory}
-                </Section>
+                <Section blockId="with_image">test {accessory}</Section>
               </Blocks>
             )
           ).toStrictEqual([
@@ -142,6 +139,60 @@ describe('jsx-slack', () => {
               accessory: expect.objectContaining({ type: expect.any(String) }),
             }),
           ])
+        }
+      })
+
+      it('outputs section block with multi-select menus', () => {
+        // Static multiple select
+        const [s] = JSXSlack(
+          <Blocks>
+            <Section>
+              Select
+              <Select multiple maxSelectedItems={2} value={['a', 'c']}>
+                <Option value="a">a</Option>
+                <Option value="b">b</Option>
+                <Option value="c">c</Option>
+              </Select>
+            </Section>
+          </Blocks>
+        )
+
+        expect(s.accessory.type).toBe('multi_static_select')
+        expect(s.accessory.max_selected_items).toBe(2)
+        expect(s.accessory.initial_options).toHaveLength(2)
+
+        // Multiple select for external sources
+        for (const accessory of [
+          <ExternalSelect
+            multiple
+            maxSelectedItems={2}
+            initialOption={<Option value="a">a</Option>}
+          />,
+          <UsersSelect multiple maxSelectedItems={2} initialUser="U00000000" />,
+          <ConversationsSelect
+            multiple
+            maxSelectedItems={2}
+            initialConversation={['C00000000']}
+          />,
+          <ChannelsSelect
+            multiple
+            maxSelectedItems={2}
+            initialChannel="D00000000"
+          />,
+        ]) {
+          const [ms] = JSXSlack(
+            <Blocks>
+              <Section>Select {accessory}</Section>
+            </Blocks>
+          )
+
+          expect(ms.accessory.type.startsWith('multi_')).toBe(true)
+          expect(ms.accessory.max_selected_items).toBe(2)
+
+          const initialKey: any = Object.keys(ms.accessory).find(k =>
+            k.startsWith('initial_')
+          )
+          expect(ms.accessory[initialKey]).toHaveLength(1)
         }
       })
     })

--- a/test/index.tsx
+++ b/test/index.tsx
@@ -109,12 +109,19 @@ describe('jsx-slack', () => {
         for (const accessory of [
           <Button>Button</Button>,
           <Select>
-            <Option value="sel">Static select</Option>
+            <Option value="select">Static select</Option>
+          </Select>,
+          <Select multiple>
+            <Option value="select">Multiple select</Option>
           </Select>,
           <ExternalSelect />,
+          <ExternalSelect multiple />,
           <UsersSelect />,
+          <UsersSelect multiple />,
           <ConversationsSelect />,
+          <ConversationsSelect multiple />,
           <ChannelsSelect />,
+          <ChannelsSelect multiple />,
           <Overflow>
             <OverflowItem>Overflow</OverflowItem>
             <OverflowItem>item</OverflowItem>
@@ -292,8 +299,7 @@ describe('jsx-slack', () => {
       })
 
       it('outputs actions block with styled <Button>', () => {
-        // TODO: Remove type casting when supported style field on @slack/types
-        const buttonAction = (action as Function)(
+        const buttonAction = action(
           {
             type: 'button',
             text: { type: 'plain_text', text: 'Default', emoji: true },
@@ -723,6 +729,19 @@ describe('jsx-slack', () => {
           )
         ).toStrictEqual([buttonAction])
       })
+
+      it('throws error when passed selectable element with "multiple" prop', () =>
+        expect(() =>
+          JSXSlack(
+            <Blocks>
+              <Actions>
+                <Select multiple>
+                  <Option value="error">error</Option>
+                </Select>
+              </Actions>
+            </Blocks>
+          )
+        ).toThrow())
 
       it('throws error when the number of elements is 26', () =>
         expect(() =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -941,10 +941,10 @@
     "@parcel/utils" "^1.11.0"
     physical-cpu-count "^2.0.0"
 
-"@slack/types@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@slack/types/-/types-1.1.0.tgz#64465b6c7e2db66498f335934335da81c15812e7"
-  integrity sha512-uak4Jbi8nlX8xmElkPt1ixxVQXMKdBRbzBayn5bRzZ9Yx3bQGlyJdFs6GjEKI+fvFP0ZTiGWKOzlJTH3Tm/9fg==
+"@slack/types@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@slack/types/-/types-1.2.0.tgz#edad17244ccc335afb31c1089a0a86ae480373f5"
+  integrity sha512-XsksAErF2CN9jqNzKrm3tVkGke0wT6xsIdw80h9PIKaYJzmpt5soweaFGbV3j74VuwIOOq4P5sHjrSZaP0Du0w==
 
 "@types/babel__core@^7.1.0":
   version "7.1.2"


### PR DESCRIPTION
Added `multiple` attribute to multi-selectable components. It allows picking multiple options by user in `<Section>`'s accessory.

```jsx
<Blocks>
  <Section>
    What kind of dogs do you love? :dog:
    <Select actionId="dogs" multiple value={['labrador', 'golden_retriver']}>
      <Option value="labrador">Labrador</Option>
      <Option value="german_shepherd">German Shepherd</Option>
      <Option value="golden_retriver">Golden Retriever</Option>
      <Option value="bulldog">Bulldog</Option>
    </Select>
  </Section>
</Blocks>
```

<img width="600" alt="Message" src="https://user-images.githubusercontent.com/3993388/65671675-9ca5e980-e082-11e9-971c-ba9c5e99b06f.png">

It would work well in Modals too. (#57)

<img width="400" alt="Modals" src="https://user-images.githubusercontent.com/3993388/65671686-a4658e00-e082-11e9-97b0-ce5cf4fa6d7b.png">

We've updated type definitions for selectable elements to change allowed attributes and types by defined `multiple` attribute. They are working as usual when `multiple` is not defined. If defined, an extra base property `maxSelectedItems` and array value as initial values can pass.

Resolves #56.

> :warning: When there is the element using multiple attribute in `<Actions>`, jsx-slack will throw an error about incompatible elements because Slack does not supported it.

## ToDo

- [x] Add tests
  - [x] `multiple` attribute
  - [x] `maxSelectedItems` attribute
  - [x] Initial values
  - [x] Throw error by using multiple components in `<Actions>`
- [x] Update document