### PR TITLE
Check invalid elements in <Blocks> and <Input> strictly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Changed
 
 - Bump dependent packages to the latest version ([#59](https://github.com/speee/jsx-slack/pull/59))
+- Check invalid elements in `<Blocks>` and `<Input>` strictly ([#64](https://github.com/speee/jsx-slack/pull/64))
 
 ### Deprecated
 

--- a/src/block-kit/Blocks.tsx
+++ b/src/block-kit/Blocks.tsx
@@ -32,26 +32,18 @@ export const Blocks: JSXSlack.FC<BlocksProps> = props => {
   const internalType: InternalBlockType | undefined = props[blockTypeSymbol]
 
   const normalized = wrap(props.children).map(child => {
-    if (child && isNode(child)) {
-      if (typeof child.type === 'string') {
-        // Aliasing intrinsic elements to Block component
-        switch (child.type) {
-          case 'hr':
-            return <Divider {...child.props}>{...child.children}</Divider>
-          case 'img':
-            return <Image {...child.props}>{...child.children}</Image>
-          case 'section':
-            return <Section {...child.props}>{...child.children}</Section>
-          default:
-            throw new Error(
-              '<Blocks> allows only including layout block components.'
-            )
-        }
-      } else if (child.type === JSXSlack.NodeType.object) {
-        // Check layout blocks
-        if (internalType === undefined && child.props.type === 'input')
+    if (child && isNode(child) && typeof child.type === 'string') {
+      // Aliasing intrinsic elements to Block component
+      switch (child.type) {
+        case 'hr':
+          return <Divider {...child.props}>{...child.children}</Divider>
+        case 'img':
+          return <Image {...child.props}>{...child.children}</Image>
+        case 'section':
+          return <Section {...child.props}>{...child.children}</Section>
+        default:
           throw new Error(
-            '<Input> block cannot place in <Blocks> container for messaging.'
+            '<Blocks> allows only including layout block components.'
           )
       }
     }
@@ -64,6 +56,11 @@ export const Blocks: JSXSlack.FC<BlocksProps> = props => {
     // Check the final output again
     if (parsed.some(b => !knownBlocks.includes(b.type)))
       throw new Error('<Blocks> allows only including layout block components.')
+
+    if (internalType === undefined && parsed.some(b => b.type === 'input'))
+      throw new Error(
+        '<Input> block cannot place in <Blocks> container for messaging.'
+      )
   }
 
   return node

--- a/test/index.tsx
+++ b/test/index.tsx
@@ -38,10 +38,30 @@ import JSXSlack, {
   Textarea,
   UsersSelect,
 } from '../src/index'
+import { jsxOnParsed } from '../src/jsx'
 
 beforeEach(() => JSXSlack.exactMode(false))
 
 describe('jsx-slack', () => {
+  describe('#JSXSlack', () => {
+    it('executes specified func after parsing if passed internal node has jsxOnParsed symbol prop', () => {
+      const onParsed = jest.fn()
+      const node = (
+        <SelectFragment>
+          <Option value="a">A</Option>
+        </SelectFragment>
+      )
+
+      node.props[jsxOnParsed] = onParsed
+      JSXSlack(node)
+
+      expect(onParsed).toBeCalledTimes(1)
+    })
+
+    it('throws error by passed invalid node', () =>
+      expect(() => JSXSlack({ props: {}, type: -1 } as any)).toThrow())
+  })
+
   describe('Container components', () => {
     describe('<Blocks>', () => {
       it('throws error when <Blocks> has unexpected element', () => {

--- a/test/index.tsx
+++ b/test/index.tsx
@@ -1064,6 +1064,21 @@ describe('jsx-slack', () => {
             ).blocks
           ).toStrictEqual(blocks)
         })
+
+        it('throws error when wrapped invalid element', () => {
+          expect(() =>
+            JSXSlack(
+              <Modal title="test">
+                <Input label="invalid">
+                  <Overflow actionId="overflow">
+                    <OverflowItem value="a">A</OverflowItem>
+                    <OverflowItem value="b">B</OverflowItem>
+                  </Overflow>
+                </Input>
+              </Modal>
+            )
+          ).toThrow(/invalid/)
+        })
       })
 
       describe('as block element for plain-text input', () => {

--- a/test/index.tsx
+++ b/test/index.tsx
@@ -53,6 +53,14 @@ describe('jsx-slack', () => {
           )
         ).toThrow()
 
+        expect(() =>
+          JSXSlack(
+            <Blocks>
+              <Escape>unexpected</Escape>
+            </Blocks>
+          )
+        ).toThrow()
+
         // <Input> block cannot use in message
         expect(() =>
           JSXSlack(


### PR DESCRIPTION
By adding input-compatible props to existed interactive components (#63), the possibility of wrong usage would increase. For example, using `label` prop at interactive components in `<Blocks>` and `<Actions>` would not be thrown error but outputs invalid JSON when sending to Slack.

For helping user to notice mistake, we've refactored JSX parse logic and added after-parse validation to `<Blocks>` and `<Input>`.

Especially these were hard to check rendered elements if is used multi-level `<Fragment>`, so we changed internal JSX object to allow defining event function called at after parsed as internal props. Thereby we can validate to the final output of JSON.