### PR TITLE
Fix invalid array children in template literal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix invalid array children in template literal ([#69](https://github.com/speee/jsx-slack/pull/69))
+
 ## v0.10.0 - 2019-10-02
 
 ### Added

--- a/src/tag.ts
+++ b/src/tag.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-new-wrappers */
 import he from 'he'
 import htm from 'htm'
+import flattenDeep from 'lodash.flattendeep'
 import * as blockKitComponents from './components'
 import * as dialogComponents from './dialog/components'
 import { JSXSlack } from './index'
@@ -42,7 +43,7 @@ const firstPass: JSXSlackTemplate<VirtualNode | VirtualNode[]> = htm.bind(
           {}
         )
       : props,
-    children: children.map(c => normalize(c)),
+    children: flattenDeep(children.map(c => normalize(c))),
   })
 )
 

--- a/test/tag.tsx
+++ b/test/tag.tsx
@@ -116,6 +116,35 @@ describe('Tagged template', () => {
     `).toMatchSnapshot()
   })
 
+  it('can use fragmented options in <Select>', () => {
+    const template = jsxslack`
+      <Blocks>
+        <Actions>
+          <Select>
+            ${[...Array(10)].map(
+              (_, i) =>
+                jsxslack.fragment`<Option value=${i.toString()}>${i}</Option>`
+            )}
+          </Select>
+        </Actions>
+      </Blocks>
+    `
+
+    expect(template).toStrictEqual(
+      JSXSlack(
+        <Blocks>
+          <Actions>
+            <BlockKitSelect>
+              {[...Array(10)].map((_, i) => (
+                <BlockKitOption value={i.toString()}>{i}</BlockKitOption>
+              ))}
+            </BlockKitSelect>
+          </Actions>
+        </Blocks>
+      )
+    )
+  })
+
   it('has same decode behavior compatible with JSX for HTML entities', () => {
     const [jsxEntitySection] = JSXSlack(
       <Blocks>


### PR DESCRIPTION
By the similar reason as #53, `jsxslack` template literal tag cannot place array as children. It means that `<Option>` embedded list won't work in `<Select>`'s children unlike JSX.

```
// TypeError: Cannot read property 'map' of undefined
jsxslack`
  <Blocks>
    <Actions>
      <Select>
        ${[...Array(10)].map(
          (_, i) =>
            jsxslack.fragment`<Option value=${i.toString()}>${i}</Option>`
        )}
      </Select>
    </Actions>
  </Blocks>
`
```

I've fixed this by using `lodash.flattendeep` in first parsing of template literal.