### PR TITLE
Make interpolated fragments in template literal work correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Make interpolated fragments in template literal work correctly ([#71](https://github.com/speee/jsx-slack/pull/71))
+
 ## v0.10.1 - 2019-10-10
 
 ### Fixed

--- a/src/tag.ts
+++ b/src/tag.ts
@@ -47,20 +47,25 @@ const firstPass: JSXSlackTemplate<VirtualNode | VirtualNode[]> = htm.bind(
   })
 )
 
-const render = (parsed: any) =>
-  typeof parsed === 'object'
-    ? JSXSlack.h(
-        parsed.type,
-        parsed.props,
-        ...parsed.children.map(c => render(c))
-      )
-    : parsed
+const render = (parsed: unknown) => {
+  if (typeof parsed === 'object' && parsed) {
+    const node = parsed as VirtualNode
+
+    return JSXSlack.h(
+      node.type,
+      node.props,
+      ...node.children.map(c => render(c))
+    )
+  }
+  return parsed
+}
 
 // Resolve built-in components
-const resolveComponent = (target: VirtualNode, context: any = undefined) => {
-  if (typeof target !== 'object') return target
+const resolveComponent = (target: unknown, context: any = undefined) => {
+  if (!(typeof target === 'object' && target)) return target
 
-  let { type } = target
+  const node = target as VirtualNode
+  let { type } = node
 
   if (typeof type === 'string') {
     if (
@@ -90,8 +95,8 @@ const resolveComponent = (target: VirtualNode, context: any = undefined) => {
 
   return {
     type,
-    props: target.props,
-    children: target.children.map(c => resolveComponent(c, childrenContext)),
+    props: node.props,
+    children: node.children.map(c => resolveComponent(c, childrenContext)),
   }
 }
 

--- a/test/tag.tsx
+++ b/test/tag.tsx
@@ -145,6 +145,25 @@ describe('Tagged template', () => {
     )
   })
 
+  it('can use interpolated fragment through conditional rendering', () => {
+    const template = jsxslack`
+      <Blocks>
+        <Section>conditional</Section>
+        ${true && jsxslack.fragment`<Section>rendering</Section>`}
+        ${false && jsxslack.fragment`<Section>test</Section>`}
+      </Blocks>
+    `
+
+    expect(template).toStrictEqual(
+      JSXSlack(
+        <Blocks>
+          <Section>conditional</Section>
+          <Section>rendering</Section>
+        </Blocks>
+      )
+    )
+  })
+
   it('has same decode behavior compatible with JSX for HTML entities', () => {
     const [jsxEntitySection] = JSXSlack(
       <Blocks>

--- a/test/tag.tsx
+++ b/test/tag.tsx
@@ -145,10 +145,10 @@ describe('Tagged template', () => {
     )
   })
 
-  it('can use interpolated fragment through conditional rendering', () => {
+  it('can use interpolations through conditional rendering', () => {
     const template = jsxslack`
       <Blocks>
-        <Section>conditional</Section>
+        <Section>cond${'i'}tio${null}nal</Section>
         ${true && jsxslack.fragment`<Section>rendering</Section>`}
         ${false && jsxslack.fragment`<Section>test</Section>`}
       </Blocks>


### PR DESCRIPTION
Parser for `jsxslack` template literal is using virtual node whose different interface from JSX. An error `Unknown node type: undefined` would throw when using interpolated fragments like this:

```javascript
// Unknown node type: undefined
jsxslack`
  <Blocks>
    <Section>conditional</Section>
    ${true && jsxslack.fragment`<Section>rendering</Section>`}
    ${false && jsxslack.fragment`<Section>test</Section>`}
  </Blocks>
`
```

`jsxslack.fragment` renders virtual node with JSX interface. However, `jsxslack` template literal tag will only allow unique interface and won't match with the interpolated node's.

By matching interface, suited fallback for JSX node will be apply to template literal too.