### PR TITLE
Improve REPL demo to follow Block Kit Builder updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Improve REPL demo to follow Block Kit Builder updates ([#77](https://github.com/speee/jsx-slack/pull/77))
+
 ### Fixed
 
 - Throw an error when using `<File>` in `<Modal>` ([#76](https://github.com/speee/jsx-slack/pull/76))

--- a/demo/index.css
+++ b/demo/index.css
@@ -19,6 +19,58 @@ a:hover {
   color: #57c;
 }
 
+/* Button */
+.button {
+  align-items: center;
+  appearance: none;
+  background: #fcfcfc;
+  border-radius: 5px;
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  box-shadow: 0 2px 6px rgba(128, 128, 128, 0.4);
+  box-sizing: border-box;
+  color: #333;
+  cursor: pointer;
+  display: flex;
+  font-size: 15px;
+  height: 30px;
+  justify-content: center;
+  overflow: hidden;
+  padding: 0 20px;
+  user-select: none;
+}
+
+.button:hover {
+  background: #f8f8f8;
+}
+
+.button:hover:active {
+  background: #e8e8e8;
+}
+
+.button.disabled {
+  pointer-events: none;
+  opacity: 0.4;
+}
+
+.button > span {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 1;
+  overflow: hidden;
+}
+
+.button > img {
+  padding: 0 5px;
+}
+
+.button > img:first-child {
+  padding-left: 0;
+}
+
+.button > img:last-child {
+  padding-right: 0;
+}
+
 /* Header */
 header {
   align-items: center;
@@ -51,6 +103,7 @@ h1 > small {
 h2 {
   color: #666;
   font-size: 20px;
+  line-height: 30px;
   margin: 0;
   padding-bottom: 10px;
 }
@@ -173,24 +226,9 @@ footer > p {
 }
 
 #preview {
-  align-items: center;
   background: #262;
-  border-radius: 5px;
   border: 0;
-  box-shadow: 0 2px 6px rgba(128, 128, 128, 0.4);
   color: #fff;
-  cursor: pointer;
-  display: flex;
-  font-size: 15px;
-  height: 30px;
-  justify-content: center;
-  overflow: hidden;
-  padding: 0 20px;
-  user-select: none;
-}
-
-#preview > img {
-  padding-left: 5px;
 }
 
 #preview:hover {
@@ -201,46 +239,15 @@ footer > p {
   background: #151;
 }
 
-#previewTooltip {
-  pointer-events: none;
-}
-
-#previewTooltip::after {
-  background: rgba(0, 0, 0, 0.7);
-  border-radius: 5px;
-  bottom: calc(100% + 5px);
-  box-shadow: 0 2px 6px rgba(128, 128, 128, 0.4);
-  color: #fff;
-  display: block;
-  font-size: 12.5px;
-  opacity: 0;
-  padding: 5px 10px;
-  pointer-events: none;
-  position: absolute;
-  right: 0;
-  transform: translateY(10px);
-  transition: opacity 0.15s linear, transform 0.15s ease-out;
-}
-
-#preview[data-mode='modal'] + #previewTooltip::after {
-  content: 'Block Kit Builder can preview only contents in "blocks".';
-}
-
-#preview:hover + #previewTooltip::after {
-  opacity: 1;
-  transform: none;
-}
-
-#preview.disabled {
-  pointer-events: none;
-  opacity: 0.4;
-}
-
 #examples {
   font-size: 15px;
-  height: 25px;
-  line-height: 25px;
+  height: 30px;
+  line-height: 30px;
   display: block;
   float: right;
   cursor: pointer;
+}
+
+#copy {
+  float: right;
 }

--- a/demo/index.html
+++ b/demo/index.html
@@ -73,23 +73,36 @@
       <section>
         <h2>
           <label for="json">JSON</label>
+          <button id="copy" class="button">
+            <img
+              alt="Copy"
+              src="https://icongr.am/clarity/copy-to-clipboard.svg?size=20&color=333333"
+              width="20"
+              height="20"
+            />
+            <span>Copy to clipboard</span>
+          </button>
         </h2>
         <textarea id="json" readonly></textarea>
       </section>
     </main>
     <footer>
       <div id="previewContainer">
-        <a href="#" id="preview" target="jsx-slack" rel="noopener">
-          Preview in Slack Block Kit Builder
+        <a
+          href="#"
+          id="preview"
+          class="button"
+          target="jsx-slack"
+          rel="noopener"
+        >
+          <span>Preview in Slack Block Kit Builder</span>
           <img
             alt="External link"
             src="https://icongr.am/feather/external-link.svg?size=20&color=ffffff"
             width="20"
             height="20"
-            valign="center"
           />
         </a>
-        <span id="previewTooltip"></span>
       </div>
       <p>
         Copyright (c) 2019

--- a/demo/index.js
+++ b/demo/index.js
@@ -15,12 +15,11 @@ import 'codemirror/addon/hint/show-hint.css'
 
 const jsx = document.getElementById('jsx')
 const json = document.getElementById('json')
+const copy = document.getElementById('copy')
 const error = document.getElementById('error')
 const errorDetails = document.getElementById('errorDetails')
 const examplesSelect = document.getElementById('examples')
 const previewBtn = document.getElementById('preview')
-
-json.addEventListener('click', () => json.select())
 
 const parseHash = (hash = window.location.hash) => {
   if (!hash.toString().startsWith('#')) return undefined
@@ -115,7 +114,7 @@ const convert = () => {
     if (Array.isArray(output)) {
       setPreview({ blocks: JSON.stringify(output), mode: 'message' })
     } else if (output.type === 'modal') {
-      setPreview({ blocks: JSON.stringify(output.blocks), mode: 'modal' })
+      setPreview({ view: JSON.stringify(output), mode: 'modal' })
     } else {
       setPreview(false)
     }
@@ -144,4 +143,18 @@ examplesSelect.addEventListener('change', () => {
     jsxEditor.setValue(examples[examplesSelect.value])
     convert()
   }
+})
+
+copy.addEventListener('click', () => {
+  const tmpTextarea = document.createElement('textarea')
+  tmpTextarea.value = json.value
+  tmpTextarea.style =
+    'position:absolute;left:0;top:0;opacity:0;pointer-events:none;'
+
+  document.body.appendChild(tmpTextarea)
+  tmpTextarea.select()
+
+  document.execCommand('copy')
+  document.body.removeChild(tmpTextarea)
+  copy.focus()
 })


### PR DESCRIPTION
Today Slack introduced Block Kit Builder updates. We can follow some updates to improve our REPL demo.

- Support preview of the full modal created by `<Modal>`, by passing `view` query parameter.
- Add "Copy to clipboard" button on the top right corner as same as Block Kit Builder.