### PR TITLE
Fix 413 error from Block Kit Builder when translated huge JSON on REPL demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix 413 error from Block Kit Builder when translated huge JSON on REPL demo ([#82](https://github.com/speee/jsx-slack/pull/82))
+
 ## v0.11.0 - 2019-10-24
 
 ### Added

--- a/demo/index.js
+++ b/demo/index.js
@@ -91,9 +91,8 @@ const setPreview = query => {
     previewBtn.setAttribute('tabindex', -1)
     previewBtn.classList.add('disabled')
   } else if (typeof query === 'object') {
-    const q = Object.keys(query)
-      .map(k => `${k}=${encodeURIComponent(query[k])}`)
-      .join('&')
+    const q = new URLSearchParams()
+    Object.keys(query).forEach(k => q.append(k, query[k]))
 
     if (query.mode) previewBtn.setAttribute('data-mode', query.mode)
 
@@ -109,7 +108,7 @@ const setPreview = query => {
 const convert = () => {
   try {
     const output = jsxslack([jsxEditor.getValue()])
-    const encoded = encodeURIComponent(JSON.stringify(output))
+    const encoded = JSON.stringify(output)
 
     json.value = JSON.stringify(output, null, '  ')
 

--- a/demo/index.js
+++ b/demo/index.js
@@ -108,7 +108,7 @@ const setPreview = query => {
 const convert = () => {
   try {
     const output = jsxslack([jsxEditor.getValue()])
-    const encoded = JSON.stringify(output)
+    const encoded = JSON.stringify(output).replace(/\+/g, '%2b')
 
     json.value = JSON.stringify(output, null, '  ')
 


### PR DESCRIPTION
By double encoding in REPL demo, "Preview in Block Kit Builder" button on REPL demo returns 413 error when the converted JSON is too huge.

<img width="930" src="https://user-images.githubusercontent.com/3993388/67559456-f66a0400-f753-11e9-9e51-101b8d1215ef.png" />

We've fixed just to pass raw JSON string to `URLSearchParams`. (Nevertheless, sometimes Slack may return [414 URI Too Long](https://developer.mozilla.org/en/docs/Web/HTTP/Status/414) internally)
