### PR TITLE
Improve internal type definitions for overloaded props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fix 413 error from Block Kit Builder when translated huge JSON on REPL demo ([#82](https://github.com/speee/jsx-slack/pull/82))
+- Improve internal type definitions for overloaded props ([#83](https://github.com/speee/jsx-slack/pull/83))
 
 ## v0.11.0 - 2019-10-24
 

--- a/src/block-kit/Input.tsx
+++ b/src/block-kit/Input.tsx
@@ -1,7 +1,7 @@
 /** @jsx JSXSlack.h */
 import { InputBlock } from '@slack/types'
 import { JSXSlack } from '../jsx'
-import { ObjectOutput, coerceToInteger } from '../utils'
+import { DistributedProps, ObjectOutput, coerceToInteger } from '../utils'
 import { BlockComponentProps } from './Blocks'
 import { plainText } from './composition/utils'
 import { PlainTextInput } from './elements/PlainTextInput'
@@ -13,74 +13,46 @@ export interface InputCommonProps extends BlockComponentProps {
   required?: boolean
 }
 
-type InputCommonUndefinedProps = { [key in keyof InputCommonProps]?: undefined }
-
 interface InputBlockProps extends InputCommonProps {
   children: JSXSlack.Node<{}>
   type?: undefined
-
-  // Disallow defining attributes for component usage
-  actionId?: undefined
-  name?: undefined
-  placeholder?: undefined
-  value?: undefined
-  maxLength?: undefined
-  minLength?: undefined
 }
 
 interface InputComponentProps extends InputCommonProps {
   children?: undefined
   type?: 'text'
-
-  actionId?: string // => PlainTextInput.actionId
-  name?: string // => PlainTextInput.actionId (Alias)
+  actionId?: string //    => PlainTextInput.actionId
+  name?: string //        => PlainTextInput.actionId (Alias)
   placeholder?: string // => PlainTextInput.placeholder
-  value?: string // => PlainTextInput.initialValue
-  maxLength?: number // => PlainTextInput.maxLength
-  minLength?: number // => PlainTextInput.minLength
+  value?: string //       => PlainTextInput.initialValue
+  maxLength?: number //   => PlainTextInput.maxLength
+  minLength?: number //   => PlainTextInput.minLength
 }
 
-interface InputHiddenProps extends InputCommonUndefinedProps {
+interface InputHiddenProps {
   children?: undefined
   type: 'hidden'
   name: string
   value: any
-
-  actionId?: undefined
-  placeholder?: undefined
-  maxLength?: undefined
-  minLength?: undefined
 }
 
-interface InputSubmitProps extends InputCommonUndefinedProps {
+interface InputSubmitProps {
   children?: undefined
   type: 'submit'
   value: string
-
-  actionId?: undefined
-  name?: undefined
-  placeholder?: undefined
-  maxLength?: undefined
-  minLength?: undefined
 }
 
-type InputProps =
+type InputPropsBase =
   | InputBlockProps
   | InputComponentProps
   | InputHiddenProps
   | InputSubmitProps
 
-export type IntrinsicInputProps =
-  | Omit<InputBlockProps, 'actionId' | 'blockId' | 'hint'>
-  | Omit<InputComponentProps, 'actionId' | 'blockId' | 'hint'>
-  | Omit<InputHiddenProps, 'actionId' | 'blockId' | 'hint'>
-  | Omit<InputSubmitProps, 'actionId' | 'blockId' | 'hint'>
-
+export type InputProps = DistributedProps<InputPropsBase>
 export type TextareaProps = Omit<InputComponentProps, 'type'>
 
-export type WithInputProps<T> =
-  | T & InputCommonUndefinedProps
-  | T & InputCommonProps
+// Helper type for input components
+export type WithInputProps<T> = DistributedProps<T | T & InputCommonProps>
 
 export const internalHiddenType = Symbol('jsx-slack-input-internal-hidden-type')
 export const internalSubmitType = Symbol('jsx-slack-input-internal-submit-type')

--- a/src/block-kit/elements/Select.tsx
+++ b/src/block-kit/elements/Select.tsx
@@ -20,6 +20,7 @@ import { plainText } from '../composition/utils'
 import { WithInputProps, wrapInInput } from '../Input'
 import { JSXSlack } from '../../jsx'
 import {
+  DistributedProps,
   ObjectOutput,
   PlainText,
   coerceToInteger,
@@ -31,19 +32,20 @@ import {
 export interface SingleSelectPropsBase {
   actionId?: string
   confirm?: JSXSlack.Node<ConfirmProps>
-  maxSelectedItems?: undefined
   multiple?: false
   name?: string
   placeholder?: string
 }
 
 export interface MultiSelectPropsBase
-  extends Omit<SingleSelectPropsBase, 'maxSelectedItems' | 'multiple'> {
+  extends Omit<SingleSelectPropsBase, 'multiple'> {
   maxSelectedItems?: number
   multiple: true
 }
 
-type SelectPropsBase = SingleSelectPropsBase | MultiSelectPropsBase
+type SelectPropsBase = DistributedProps<
+  SingleSelectPropsBase | MultiSelectPropsBase
+>
 
 // Fragments
 interface SelectFragmentProps {

--- a/src/jsx.ts
+++ b/src/jsx.ts
@@ -1,9 +1,9 @@
-/* eslint-disable import/export, @typescript-eslint/no-namespace, @typescript-eslint/no-empty-interface */
+/* eslint-disable import/export, @typescript-eslint/no-namespace */
 import flattenDeep from 'lodash.flattendeep'
 import { escapeChars, escapeEntity, parse } from './html'
 import turndown from './turndown'
-import { wrap } from './utils'
-import { IntrinsicInputProps, TextareaProps } from './block-kit/Input'
+import { IntrinsicProps, wrap } from './utils'
+import { InputProps, TextareaProps } from './block-kit/Input'
 import { ButtonProps } from './block-kit/elements/Button'
 import {
   SelectProps,
@@ -12,8 +12,6 @@ import {
 } from './block-kit/elements/Select'
 
 let internalExactMode = false
-
-type OnParsed = (parsed: any, context: ParseContext) => void
 
 enum ParseMode {
   normal,
@@ -147,20 +145,21 @@ export namespace JSXSlack {
       .map(c => (typeof c !== 'object' ? c.toString() : c))
 
   export namespace JSX {
+    // eslint-disable-next-line @typescript-eslint/no-empty-interface
     export interface Element extends Node {}
     export interface IntrinsicElements {
       a: { href: string; children?: Children<any> }
       b: {}
       blockquote: {}
       br: {}
-      button: Omit<ButtonProps, 'actionId'>
+      button: IntrinsicProps<ButtonProps>
       code: {}
       del: {}
       em: {}
       hr: { id?: string }
       i: {}
       img: { alt: string; id?: string; src: string; title?: string }
-      input: IntrinsicInputProps
+      input: IntrinsicProps<InputProps>
       li: {}
       ol: { start?: number; children: Children<any> }
       optgroup: OptgroupProps
@@ -169,11 +168,11 @@ export namespace JSXSlack {
       pre: {}
       s: {}
       section: { id?: string; children: Children<any> }
-      select: Omit<SelectProps, 'actionId' | 'blockId' | 'hint'>
+      select: IntrinsicProps<SelectProps>
       span: {}
       strike: {}
       strong: {}
-      textarea: Omit<TextareaProps, 'actionId' | 'blockId' | 'hint'>
+      textarea: IntrinsicProps<TextareaProps>
       time: {
         datetime: string | number | Date
         fallback?: string

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -1,6 +1,15 @@
 /** @jsx JSXSlack.h */
 import { JSXSlack } from './jsx'
 
+export type DistributedProps<
+  P,
+  K extends string | number | symbol = P extends never ? never : keyof P
+> = P extends never ? never : P & { [U in Exclude<K, keyof P>]?: undefined }
+
+export type IntrinsicProps<P> = P extends never
+  ? never
+  : Omit<P, 'actionId' | 'blockId' | 'hint'>
+
 export enum SpecialLink {
   ChannelMention,
   EveryoneMention,


### PR DESCRIPTION
While compiling JSX in TypeScript, jsx-slack can check correct definition of props in overloaded components, such as input components.

However, we have a problem about the complex type definition. Overloaded type definitions have required to define for unnecessary  (but may be used in  another definition) prop as `xxx?: undefined` manually. It works well but would make us harder to maintain.

We've refactored to extract this logic into `DistributedProps` type helper. It becomes easy to recognize required props in each overloads.