### PR TITLE
Don't throw error even if <Overflow> has only one <OverflowItem>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Don't throw error even if `<Overflow>` has only one `<OverflowItem>` ([#85](https://github.com/speee/jsx-slack/issues/85), [#86](https://github.com/speee/jsx-slack/pull/86))
 - Fix 413 error from Block Kit Builder when translated huge JSON on REPL demo ([#82](https://github.com/speee/jsx-slack/pull/82))
 - Improve internal type definitions for overloaded props ([#83](https://github.com/speee/jsx-slack/pull/83))
 

--- a/docs/block-elements.md
+++ b/docs/block-elements.md
@@ -311,7 +311,7 @@ A select menu with options consisted of public channels in the current workspace
 
 ### <a name="overflow" id="overflow"></a> [`<Overflow>`: Overflow menu](https://api.slack.com/reference/messaging/block-elements#overflow)
 
-An overflow menu displayed as `...` can access to some hidden menu items by many actions. _It must contain least of 2 `<OverflowItem>` components._
+An overflow menu displayed as `...` can access to some hidden menu items. It must contain 1 to 5 `<OverflowItem>` component(s).
 
 ```jsx
 <Blocks>

--- a/src/block-kit/elements/Overflow.tsx
+++ b/src/block-kit/elements/Overflow.tsx
@@ -8,12 +8,7 @@ import { ObjectOutput, PlainText } from '../../utils'
 export interface OverflowProps {
   actionId?: string
   confirm?: JSXSlack.Node<ConfirmProps>
-
-  // Slack disallows overflow button with only a single item, but jsx-slack may
-  // pass a <Fragment> containing multiple items.
   children: JSXSlack.Children<OverflowItemInternal>
-  // children: JSXSlack.Child<OverflowItemInternal>[]
-
   name?: string
 }
 
@@ -33,8 +28,8 @@ export const Overflow: JSXSlack.FC<OverflowProps> = props => {
     o => typeof o !== 'string'
   ) as JSXSlack.Node<OverflowItemInternal>[]
 
-  if (opts.length < 2)
-    throw new Error('<Overflow> must include least of 2 <OverflowItem>s.')
+  if (opts.length < 1)
+    throw new Error('<Overflow> must include least of 1 <OverflowItem>.')
 
   if (opts.some(o => o.props.type !== 'overflow-item'))
     throw new Error('<Overflow> must contain only <OverflowItem>.')

--- a/test/block-kit/block-elements/interactive-components.tsx
+++ b/test/block-kit/block-elements/interactive-components.tsx
@@ -595,14 +595,12 @@ describe('Interactive components', () => {
       ])
     })
 
-    it('throws error when <Overflow> has only one <OverflowItem>', () =>
+    it('throws error when <Overflow> has empty children', () =>
       expect(() =>
         JSXSlack(
           <Blocks>
             <Actions>
-              <Overflow>
-                <OverflowItem value="a">A</OverflowItem>
-              </Overflow>
+              <Overflow>{false}</Overflow>
             </Actions>
           </Blocks>
         )
@@ -614,7 +612,6 @@ describe('Interactive components', () => {
           <Blocks>
             <Actions>
               <Overflow>
-                <Button>btn</Button>
                 <Button>btn</Button>
               </Overflow>
             </Actions>


### PR DESCRIPTION
Resolves #85.