### PR TITLE
Remove maxSelectedItems prop from multiple select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Upgrade dependent packages to the latest version ([#92](https://github.com/speee/jsx-slack/pull/92))
 
+### Removed
+
+- `maxSelectedItems` prop in multiple select components (Slack has no longer supported `max_selected_items` field) ([#93](https://github.com/speee/jsx-slack/issues/93), [#94](https://github.com/speee/jsx-slack/pull/94))
+
 ## v0.12.0 - 2019-11-22
 
 ### Added

--- a/demo/schema.js
+++ b/demo/schema.js
@@ -21,7 +21,6 @@ const blockInteractiveCommonAttrs = {
 }
 const multipleSelectAttrs = {
   multiple: [],
-  maxSelectedItems: null,
 }
 const inputIntrinsicAttrs = {
   label: null,

--- a/docs/block-elements.md
+++ b/docs/block-elements.md
@@ -55,6 +55,7 @@ A menu element with static options passed by `<Option>` or `<Optgroup>`. It has 
 
 - `name` / `actionId` (optional): An identifier for the action.
 - `placeholder` (optional): A plain text to be shown at first.
+- `multiple` (optional): A boolean value that shows whether [multiple options can be selected][multiple select].
 - `value` (optional): A value of item to show initially. It must choose value from defined `<Option>` elements in children. It can pass multiple string values by array when `multiple` is enabled.
 - `confirm` (optional): [`<Confirm>` element](#confirm) to show confirmation dialog.
 
@@ -87,11 +88,6 @@ By defining `multiple` attribute, you also can provide [the selectable menu from
 [<img src="https://raw.githubusercontent.com/speee/jsx-slack/master/docs/preview-btn.svg?sanitize=true" width="240" />](<https://api.slack.com/tools/block-kit-builder?blocks=%5B%7B%22type%22%3A%22section%22%2C%22text%22%3A%7B%22text%22%3A%22What%20kind%20of%20dogs%20do%20you%20love%3F%20%3Adog%3A%22%2C%22type%22%3A%22mrkdwn%22%2C%22verbatim%22%3Atrue%7D%2C%22accessory%22%3A%7B%22type%22%3A%22multi_static_select%22%2C%22action_id%22%3A%22dogs%22%2C%22placeholder%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Choose%20favorite%20dog(s)%22%2C%22emoji%22%3Atrue%7D%2C%22initial_options%22%3A%5B%7B%22value%22%3A%22labrador%22%2C%22text%22%3A%7B%22text%22%3A%22Labrador%22%2C%22type%22%3A%22plain_text%22%2C%22emoji%22%3Atrue%7D%7D%2C%7B%22value%22%3A%22golden_retriver%22%2C%22text%22%3A%7B%22text%22%3A%22Golden%20Retriever%22%2C%22type%22%3A%22plain_text%22%2C%22emoji%22%3Atrue%7D%7D%5D%2C%22options%22%3A%5B%7B%22value%22%3A%22labrador%22%2C%22text%22%3A%7B%22text%22%3A%22Labrador%22%2C%22type%22%3A%22plain_text%22%2C%22emoji%22%3Atrue%7D%7D%2C%7B%22value%22%3A%22german_shepherd%22%2C%22text%22%3A%7B%22text%22%3A%22German%20Shepherd%22%2C%22type%22%3A%22plain_text%22%2C%22emoji%22%3Atrue%7D%7D%2C%7B%22value%22%3A%22golden_retriver%22%2C%22text%22%3A%7B%22text%22%3A%22Golden%20Retriever%22%2C%22type%22%3A%22plain_text%22%2C%22emoji%22%3Atrue%7D%7D%2C%7B%22value%22%3A%22bulldog%22%2C%22text%22%3A%7B%22text%22%3A%22Bulldog%22%2C%22type%22%3A%22plain_text%22%2C%22emoji%22%3Atrue%7D%7D%5D%7D%7D%5D&mode=message>)
 
 > :warning: **Slack does not allow to place the multi-select menu in `Actions` block.** So jsx-slack throws error if you're trying to use `multiple` attribute in the children of `<Actions>`.
-
-##### Props for [multiple select]
-
-- `multiple` (optional): A boolean value that shows whether multiple options can be selected.
-- `maxSelectedItems` (optional): A maximum number of items to allow selected.
 
 #### As [an input component for modal](#input-components-for-modal)
 
@@ -199,14 +195,10 @@ It requires setup JSON entry URL in your Slack app. [Learn about external source
 
 - `name` / `actionId` (optional): An identifier for the action.
 - `placeholder` (optional): A plain text to be shown at first.
+- `multiple` (optional): A boolean value that shows whether [multiple options can be selected][multiple select].
 - `initialOption` (optional): An initial option exactly matched to provided options from external source. It allows raw JSON object or `<Option>`. It can pass multiple options by array when `multiple` is enabled.
 - `minQueryLength` (optional): A length of typed characters to begin JSON request.
 - `confirm` (optional): [`<Confirm>` element](#confirm) to show confirmation dialog.
-
-##### Props for [multiple select]
-
-- `multiple` (optional): A boolean value that shows whether multiple options can be selected.
-- `maxSelectedItems` (optional): A maximum number of items to allow selected.
 
 ##### Props for modal's input
 
@@ -248,13 +240,9 @@ A select menu with options consisted of users in the current workspace.
 
 - `name` / `actionId` (optional): An identifier for the action.
 - `placeholder` (optional): A plain text to be shown at first.
+- `multiple` (optional): A boolean value that shows whether [multiple options can be selected][multiple select].
 - `initialUser` (optional): The initial user ID. It can pass multiple string values by array when `multiple` is enabled.
 - `confirm` (optional): [`<Confirm>` element](#confirm) to show confirmation dialog.
-
-##### Props for [multiple select]
-
-- `multiple` (optional): A boolean value that shows whether multiple options can be selected.
-- `maxSelectedItems` (optional): A maximum number of items to allow selected.
 
 ##### Props for modal's input
 
@@ -271,13 +259,9 @@ A select menu with options consisted of any type of conversations in the current
 
 - `name` / `actionId` (optional): An identifier for the action.
 - `placeholder` (optional): A plain text to be shown at first.
+- `multiple` (optional): A boolean value that shows whether [multiple options can be selected][multiple select].
 - `initialConversation` (optional): The initial conversation ID. It can pass multiple string values by array when `multiple` is enabled.
 - `confirm` (optional): [`<Confirm>` element](#confirm) to show confirmation dialog.
-
-##### Props for [multiple select]
-
-- `multiple` (optional): A boolean value that shows whether multiple options can be selected.
-- `maxSelectedItems` (optional): A maximum number of items to allow selected.
 
 ##### Props for modal's input
 
@@ -294,13 +278,9 @@ A select menu with options consisted of public channels in the current workspace
 
 - `name` / `actionId` (optional): An identifier for the action.
 - `placeholder` (optional): A plain text to be shown at first.
+- `multiple` (optional): A boolean value that shows whether [multiple options can be selected][multiple select].
 - `initialChannel` (optional): The initial channel ID. It can pass multiple string values by array when `multiple` is enabled.
 - `confirm` (optional): [`<Confirm>` element](#confirm) to show confirmation dialog.
-
-##### Props for [multiple select]
-
-- `multiple` (optional): A boolean value that shows whether multiple options can be selected.
-- `maxSelectedItems` (optional): A maximum number of items to allow selected.
 
 ##### Props for modal's input
 

--- a/src/block-kit/elements/Select.tsx
+++ b/src/block-kit/elements/Select.tsx
@@ -39,7 +39,6 @@ export interface SingleSelectPropsBase {
 
 export interface MultiSelectPropsBase
   extends Omit<SingleSelectPropsBase, 'multiple'> {
-  maxSelectedItems?: number
   multiple: true
 }
 
@@ -174,15 +173,12 @@ export const Optgroup: JSXSlack.FC<OptgroupProps> = props => (
 
 const baseProps = (
   props: SelectPropsBase
-):
-  | Pick<SlackSelect, 'action_id' | 'confirm' | 'placeholder'>
-  | Pick<
-      MultiSelect,
-      'action_id' | 'confirm' | 'placeholder' | 'max_selected_items'
-    > => ({
+): Pick<
+  SlackSelect | MultiSelect,
+  'action_id' | 'confirm' | 'placeholder'
+> => ({
   action_id: props.actionId || props.name,
   confirm: props.confirm ? JSXSlack(props.confirm) : undefined,
-  max_selected_items: coerceToInteger(props.maxSelectedItems),
   placeholder: props.placeholder ? plainText(props.placeholder) : undefined,
 })
 

--- a/test/block-kit/layout-blocks.tsx
+++ b/test/block-kit/layout-blocks.tsx
@@ -151,7 +151,7 @@ describe('Layout blocks', () => {
         <Blocks>
           <Section>
             Select
-            <Select multiple maxSelectedItems={2} value={['a', 'c']}>
+            <Select multiple value={['a', 'c']}>
               <Option value="a">a</Option>
               <Option value="b">b</Option>
               <Option value="c">c</Option>
@@ -161,27 +161,17 @@ describe('Layout blocks', () => {
       )
 
       expect(s.accessory.type).toBe('multi_static_select')
-      expect(s.accessory.max_selected_items).toBe(2)
       expect(s.accessory.initial_options).toHaveLength(2)
 
       // Multiple select for external sources
       for (const accessory of [
         <ExternalSelect
           multiple
-          maxSelectedItems={2}
           initialOption={<Option value="a">a</Option>}
         />,
-        <UsersSelect multiple maxSelectedItems={2} initialUser="U00000000" />,
-        <ConversationsSelect
-          multiple
-          maxSelectedItems={2}
-          initialConversation={['C00000000']}
-        />,
-        <ChannelsSelect
-          multiple
-          maxSelectedItems={2}
-          initialChannel="D00000000"
-        />,
+        <UsersSelect multiple initialUser="U00000000" />,
+        <ConversationsSelect multiple initialConversation={['C00000000']} />,
+        <ChannelsSelect multiple initialChannel="D00000000" />,
       ]) {
         const [ms] = JSXSlack(
           <Blocks>
@@ -190,7 +180,6 @@ describe('Layout blocks', () => {
         )
 
         expect(ms.accessory.type.startsWith('multi_')).toBe(true)
-        expect(ms.accessory.max_selected_items).toBe(2)
 
         const initialKey: any = Object.keys(ms.accessory).find(k =>
           k.startsWith('initial_')


### PR DESCRIPTION
Closes #93.

Slack have no longer supported `max_selected_items` field in multi-select menu components.