### PR TITLE
Get rid of lodash.flattendeep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### Removed
 
 - Remove deprecated dialog support ([#84](https://github.com/speee/jsx-slack/pull/84), [#99](https://github.com/speee/jsx-slack/pull/99))
+- Get rid of `lodash.flattendeep` dependency ([#102](https://github.com/speee/jsx-slack/pull/102))
 
 ## v0.12.0 - 2019-11-22
 

--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "@slack/types": "^1.3.0",
     "he": "^1.2.0",
     "htm": "^2.2.1",
-    "lodash.flattendeep": "^4.4.0",
     "turndown": "^5.0.3"
   }
 }

--- a/src/block-kit/elements/Select.tsx
+++ b/src/block-kit/elements/Select.tsx
@@ -14,7 +14,6 @@ import {
   Option as SlackOption,
   UsersSelect as SlackUsersSelect,
 } from '@slack/types'
-import flattenDeep from 'lodash.flattendeep'
 import { ConfirmProps } from '../composition/Confirm'
 import { plainText } from '../composition/utils'
 import { WithInputProps, wrapInInput } from '../Input'
@@ -23,8 +22,9 @@ import {
   DistributedProps,
   ObjectOutput,
   PlainText,
-  coerceToInteger,
   aliasTo,
+  coerceToInteger,
+  flattenDeep,
   isNode,
   wrap,
 } from '../../utils'

--- a/src/jsx.ts
+++ b/src/jsx.ts
@@ -1,8 +1,7 @@
 /* eslint-disable import/export, @typescript-eslint/no-namespace */
-import flattenDeep from 'lodash.flattendeep'
 import { escapeChars, escapeEntity, parse } from './html'
 import turndown from './turndown'
-import { IntrinsicProps, wrap } from './utils'
+import { IntrinsicProps, flattenDeep, wrap } from './utils'
 import { InputProps, TextareaProps } from './block-kit/Input'
 import { ButtonProps } from './block-kit/elements/Button'
 import {

--- a/src/tag.ts
+++ b/src/tag.ts
@@ -1,8 +1,8 @@
 /* eslint-disable no-new-wrappers */
 import he from 'he'
 import htm from 'htm'
-import flattenDeep from 'lodash.flattendeep'
 import * as blockKitComponents from './components'
+import { flattenDeep } from './utils'
 import { JSXSlack } from './index'
 
 type JSXSlackTemplate<T = any> = (

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -80,3 +80,11 @@ export function coerceToInteger(
 
   return coerced
 }
+
+export function flattenDeep<T = any>(arr: any[]): T[] {
+  if ((Array.prototype as any).flat) return (arr as any).flat(Infinity)
+
+  return Array.isArray(arr)
+    ? arr.reduce((a, b) => a.concat(flattenDeep(b)), [] as T[])
+    : [arr]
+}

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -82,6 +82,7 @@ export function coerceToInteger(
 }
 
 export function flattenDeep<T = any>(arr: any[]): T[] {
+  // Node.js >= 11 has supported Array.prototype.flat
   if ((Array.prototype as any).flat) return (arr as any).flat(Infinity)
 
   return Array.isArray(arr)

--- a/yarn.lock
+++ b/yarn.lock
@@ -4399,11 +4399,6 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
 
-lodash.flattendeep@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
-  integrity sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=
-
 lodash.memoize@4.x, lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"


### PR DESCRIPTION
jsx-slack does no longer require `lodash.flattendeep` as a part of dependency. [`_.flattenDeep` can replace with native function](https://github.com/you-dont-need/You-Dont-Need-Lodash-Underscore#_flattendeep) or [`Array.prototype.flat(Infinity)`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat) (only in Node.js >= 11).