### PR TITLE
Recover for Mrkdwn component implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,14 @@
 
 ## [Unreleased]
 
-### Added
-
-- <Mrkdwn> component for use with <Section> and <Context> ([#73](https://github.com/speee/jsx-slack/issues/73), [#97](https://github.com/speee/jsx-slack/pull/97))
-
 ### Breaking
 
 - Components for [the outdated dialog](https://api.slack.com/dialogs) provided in `@speee-js/jsx-slack/dialog` can no longer use ([#84](https://github.com/speee/jsx-slack/pull/84))
 - Drop Node 8 support ([#100](https://github.com/speee/jsx-slack/pull/100))
+
+### Added
+
+- `<Mrkdwn>` text composition component ([#73](https://github.com/speee/jsx-slack/issues/73), [#97](https://github.com/speee/jsx-slack/pull/97) by [@javaPhil](https://github.com/javaPhil), [#103](https://github.com/speee/jsx-slack/pull/103))
 
 ### Fixed
 

--- a/demo/schema.js
+++ b/demo/schema.js
@@ -120,6 +120,7 @@ const schema = {
     children: [
       'Field',
       'Image',
+      'Mrkdwn',
       'img',
       ...blockInteractiveComponents,
       ...markupHTML,
@@ -130,12 +131,13 @@ const schema = {
     children: [
       'Field',
       'Image',
+      'Mrkdwn',
       'img',
       ...blockInteractiveComponents,
       ...markupHTML,
     ],
   },
-  Field: { attrs: {}, children: markupHTML },
+  Field: { attrs: {}, children: ['Mrkdwn', ...markupHTML] },
   Divider: { attrs: blockCommonAttrs, children: [] },
   hr: { attrs: { id: null }, children: [] },
   Image: {
@@ -149,7 +151,7 @@ const schema = {
   Actions: { attrs: blockCommonAttrs, children: blockInteractiveComponents },
   Context: {
     attrs: blockCommonAttrs,
-    children: ['Image', 'img', 'span', ...markupHTML],
+    children: ['Image', 'Mrkdwn', 'img', 'span', ...markupHTML],
   },
   File: {
     attrs: { externalId: null, source: ['remote'], ...blockCommonAttrs },
@@ -315,6 +317,10 @@ const schema = {
   // Composition objects
   Confirm: {
     attrs: { title: null, confirm: null, deny: null },
+    children: ['Mrkdwn', ...markupHTML],
+  },
+  Mrkdwn: {
+    attrs: { verbatim: [] },
     children: markupHTML,
   },
 

--- a/docs/block-elements.md
+++ b/docs/block-elements.md
@@ -501,9 +501,9 @@ You can use [HTML-like formatting](./html-like-formatting.md) to the content of 
 - `confirm` (**required**): A text content of the button to confirm.
 - `deny` (**required**): A text content of the button to cancel.
 
-### <a name="mrkdwn_component" id="mrkdwn_component"></a> [`<Mrkdwn>`: Markdown Composition Component](https://api.slack.com/reference/block-kit/composition-objects#text)
+### <a name="mrkdwn" id="mrkdwn"></a> [`<Mrkdwn>`: Markdown Composition Component](https://api.slack.com/reference/block-kit/composition-objects#text)
 
-Mrkdwn is a text composition component is used when its needed to have a Text object and explicitly set the `verbatim` property. Setting `verbatim` to false will tell Slack to auto-convert links, conversaion names, and certain mentions to be linkified and automatically parsed. If `verbatim` set to true Slack will skip any prepreprocessing.
+Mrkdwn is a text composition component is used when its needed to have a text object and explicitly set the `verbatim` property. Setting `verbatim` to false will tell Slack to auto-convert links, conversaion names, and certain mentions to be linkified and automatically parsed. If `verbatim` set to true Slack will skip any preprocessing.
 
 _Note: Slack recommends disabling automatic parsing on Text composition components and they have made it clear that they might deprecate this feature in the future. More information can be found <a href="https://api.slack.com/reference/surfaces/formatting#why_you_should_consider_disabling_automatic_parsing">here</a>_.
 
@@ -517,7 +517,7 @@ _Note: Slack recommends disabling automatic parsing on Text composition componen
 
 ### Props
 
-- verbatim: (optional): A boolean prop to specify whether or not Slack auto-convert links, conversaion names, and mentions.
+- `verbatim`: (optional): A boolean prop to specify whether or not Slack auto-convert links, conversaion names, and mentions.
 
 ## Input components for modal
 

--- a/docs/block-elements.md
+++ b/docs/block-elements.md
@@ -503,29 +503,58 @@ You can use [HTML-like formatting](./html-like-formatting.md) to the content of 
 
 ### <a name="mrkdwn" id="mrkdwn"></a> [`<Mrkdwn>`: Text composition object for `mrkdwn` type](https://api.slack.com/reference/block-kit/composition-objects#text)
 
-`<Mrkdwn>`, is a component for text composition component, is used when its needed to have a text and explicitly set the `verbatim` property.
+`<Mrkdwn>`, is a component for text composition component, can use as a child of components which support HTML-like formatting. Typically it would be used when needed to set `verbatim` property explicitly.
 
 Setting `verbatim` to `false` will tell Slack to auto-convert links, conversation names, and certain mentions to be linkified and automatically parsed. If `verbatim` set to true Slack will skip any preprocessing.
 
 ```jsx
 <Blocks>
+  {/* Section block */}
   <Section>
-    <Mrkdwn verbatim={false}>Hello @user!</Mrkdwn>
+    <Mrkdwn verbatim={false}>https://example.com/</Mrkdwn>
   </Section>
+
+  {/* Section block with fields */}
+  <Section>
+    <Field>
+      <Mrkdwn verbatim={false}>#general</Mrkdwn>
+    </Field>
+  </Section>
+
+  {/* Context block */}
+  <Context>
+    <Mrkdwn verbatim={false}>@here</Mrkdwn>
+    Hello!
+  </Context>
+
+  {/* Confirm composition object */}
+  <Actions>
+    <Button
+      confirm={
+        <Confirm title="Commit your action" confirm="Yes, please" deny="Cancel">
+          <Mrkdwn verbatim={false}>
+            <b>@foobar</b> Are you sure?
+          </Mrkdwn>
+        </Confirm>
+      }
+    >
+      Button
+    </Button>
+  </Actions>
 </Blocks>
 ```
 
-#### :warning: Note
+[<img src="https://raw.githubusercontent.com/speee/jsx-slack/master/docs/preview-btn.svg?sanitize=true" width="240" />](https://api.slack.com/tools/block-kit-builder?mode=message&blocks=%5B%7B%22type%22%3A%22section%22%2C%22text%22%3A%7B%22type%22%3A%22mrkdwn%22%2C%22text%22%3A%22https%3A%2F%2Fexample.com%2F%22%2C%22verbatim%22%3Afalse%7D%7D%2C%7B%22type%22%3A%22section%22%2C%22fields%22%3A%5B%7B%22type%22%3A%22mrkdwn%22%2C%22text%22%3A%22%23general%22%2C%22verbatim%22%3Afalse%7D%5D%7D%2C%7B%22type%22%3A%22context%22%2C%22elements%22%3A%5B%7B%22type%22%3A%22mrkdwn%22%2C%22text%22%3A%22%40here%22%2C%22verbatim%22%3Afalse%7D%2C%7B%22type%22%3A%22mrkdwn%22%2C%22text%22%3A%22Hello!%22%2C%22verbatim%22%3Atrue%7D%5D%7D%2C%7B%22type%22%3A%22actions%22%2C%22elements%22%3A%5B%7B%22type%22%3A%22button%22%2C%22text%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Button%22%2C%22emoji%22%3Atrue%7D%2C%22confirm%22%3A%7B%22title%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Commit%20your%20action%22%2C%22emoji%22%3Atrue%7D%2C%22text%22%3A%7B%22type%22%3A%22mrkdwn%22%2C%22text%22%3A%22*%40here*%20Are%20you%20sure%3F%22%2C%22verbatim%22%3Afalse%7D%2C%22confirm%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Yes%2C%20please%22%2C%22emoji%22%3Atrue%7D%2C%22deny%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Cancel%22%2C%22emoji%22%3Atrue%7D%7D%7D%5D%7D%5D)
 
-_Slack recommends disabling automatic parsing on text composition components and they have made it clear that they might deprecate this feature in the future._
+#### Note
 
-jsx-slack will disable automatic parsing by default even if you were not used `<Mrkdwn>` specifically. If possible, we recommend _not to enable automatic parsing through `<Mrkdwn verbatim={false}>`_ in Slack app created newly with jsx-slack.
+_Slack recommends disabling automatic parsing on text composition components and they have made it clear that they might deprecate this feature in the future._ More information can be found [here](https://api.slack.com/reference/surfaces/formatting#why_you_should_consider_disabling_automatic_parsing).
 
-More information can be found [here](https://api.slack.com/reference/surfaces/formatting#why_you_should_consider_disabling_automatic_parsing).
+jsx-slack will disable automatic parsing by default even if you were not used `<Mrkdwn>` specifically. If possible, **we recommend never to use `<Mrkdwn>`** in Slack app created newly with jsx-slack.
 
 #### Props
 
-- `verbatim`: (optional): A boolean prop to specify whether or not Slack auto-convert links, conversation names, and mentions.
+- `verbatim`: (optional): A boolean prop whether to disable automatic parsing for links, conversation names, and mentions by Slack.
 
 ## Input components for modal
 

--- a/docs/block-elements.md
+++ b/docs/block-elements.md
@@ -501,11 +501,11 @@ You can use [HTML-like formatting](./html-like-formatting.md) to the content of 
 - `confirm` (**required**): A text content of the button to confirm.
 - `deny` (**required**): A text content of the button to cancel.
 
-### <a name="mrkdwn" id="mrkdwn"></a> [`<Mrkdwn>`: Markdown Composition Component](https://api.slack.com/reference/block-kit/composition-objects#text)
+### <a name="mrkdwn" id="mrkdwn"></a> [`<Mrkdwn>`: Text composition object for `mrkdwn` type](https://api.slack.com/reference/block-kit/composition-objects#text)
 
-Mrkdwn is a text composition component is used when its needed to have a text object and explicitly set the `verbatim` property. Setting `verbatim` to false will tell Slack to auto-convert links, conversaion names, and certain mentions to be linkified and automatically parsed. If `verbatim` set to true Slack will skip any preprocessing.
+`<Mrkdwn>`, is a component for text composition component, is used when its needed to have a text and explicitly set the `verbatim` property.
 
-_Note: Slack recommends disabling automatic parsing on Text composition components and they have made it clear that they might deprecate this feature in the future. More information can be found <a href="https://api.slack.com/reference/surfaces/formatting#why_you_should_consider_disabling_automatic_parsing">here</a>_.
+Setting `verbatim` to `false` will tell Slack to auto-convert links, conversation names, and certain mentions to be linkified and automatically parsed. If `verbatim` set to true Slack will skip any preprocessing.
 
 ```jsx
 <Blocks>
@@ -515,9 +515,17 @@ _Note: Slack recommends disabling automatic parsing on Text composition componen
 </Blocks>
 ```
 
-### Props
+#### :warning: Note
 
-- `verbatim`: (optional): A boolean prop to specify whether or not Slack auto-convert links, conversaion names, and mentions.
+_Slack recommends disabling automatic parsing on text composition components and they have made it clear that they might deprecate this feature in the future._
+
+jsx-slack will disable automatic parsing by default even if you were not used `<Mrkdwn>` specifically. If possible, we recommend _not to enable automatic parsing through `<Mrkdwn verbatim={false}>`_ in Slack app created newly with jsx-slack.
+
+More information can be found [here](https://api.slack.com/reference/surfaces/formatting#why_you_should_consider_disabling_automatic_parsing).
+
+#### Props
+
+- `verbatim`: (optional): A boolean prop to specify whether or not Slack auto-convert links, conversation names, and mentions.
 
 ## Input components for modal
 

--- a/docs/html-like-formatting.md
+++ b/docs/html-like-formatting.md
@@ -71,7 +71,7 @@ The above would be replaced to just a plain text like this:
 
 ## Links
 
-jsx-slack will not recognize URL-like string as hyperlink. You should use `<a href="">` whenever you want to use a link.
+jsx-slack will not recognize URL-like string as hyperlink unless using [`<Mrkdwn verbatim={false}>`](block-elements.md#mrkdwn). Generally you should use `<a>` tag whenever you want to use a link.
 
 For example, `<a href="https://example.com/">Link</a>` will be converted to `<https://example.com/|Link>`, and rendered as like as "[Link](https://example.com)".
 

--- a/docs/jsx-components-for-block-kit.md
+++ b/docs/jsx-components-for-block-kit.md
@@ -41,6 +41,7 @@
 ### **[Composition objects](block-elements.md#composition-objects)**
 
 - [**`<Confirm>`**: Confirmation dialog](block-elements.md#confirm)
+- [**`<Mrkdwn>`**: Text composition object for `mrkdwn` type](block-elements.md#mrkdwn)
 
 ### **[Input components for modal](block-elements.md#input-components-for-modal)**
 

--- a/docs/layout-blocks.md
+++ b/docs/layout-blocks.md
@@ -146,7 +146,7 @@ Display message context. It allows mixed contents consisted of texts and `<Image
 
 [<img src="https://raw.githubusercontent.com/speee/jsx-slack/master/docs/preview-btn.svg?sanitize=true" width="240" />](https://api.slack.com/tools/block-kit-builder?blocks=%5B%7B%22type%22%3A%22context%22%2C%22elements%22%3A%5B%7B%22type%22%3A%22image%22%2C%22image_url%22%3A%22https%3A%2F%2Fplacekitten.com%2F100%2F100%22%2C%22alt_text%22%3A%22Kitten%22%7D%2C%7B%22type%22%3A%22mrkdwn%22%2C%22text%22%3A%22A%20kitten%20and%22%2C%22verbatim%22%3Atrue%7D%2C%7B%22type%22%3A%22image%22%2C%22image_url%22%3A%22https%3A%2F%2Fplacekitten.com%2F100%2F100%22%2C%22alt_text%22%3A%22Kitten%22%7D%2C%7B%22type%22%3A%22mrkdwn%22%2C%22text%22%3A%22more%20kitten.%22%2C%22verbatim%22%3Atrue%7D%5D%7D%5D)
 
-Text contents will merge in pertinent mrkdwn elements automatically, but they also may divide clearly by using `<span>` HTML intrinsic element.
+Text contents will merge in pertinent mrkdwn elements automatically, but they also may divide clearly by using `<span>` HTML intrinsic element (or [`<Mrkdwn>` component](block-elements.md#mrkdwn) for text composition object).
 
 ```jsx
 <Blocks>

--- a/src/block-kit/Context.tsx
+++ b/src/block-kit/Context.tsx
@@ -3,6 +3,7 @@ import { ContextBlock, ImageElement, MrkdwnElement } from '@slack/types'
 import html from '../html'
 import { JSXSlack } from '../jsx'
 import { ObjectOutput } from '../utils'
+import { mrkdwnSymbol } from './composition/Mrkdwn'
 import { BlockComponentProps } from './Blocks'
 
 type ContextElement = ImageElement | MrkdwnElement
@@ -33,24 +34,23 @@ export const Context: JSXSlack.FC<BlockComponentProps & {
           alt_text: props.alt,
         }
 
-      // A converted <Image> component
-      if (child.type === JSXSlack.NodeType.object && props.type === 'image')
-        return {
-          type: 'image' as const,
-          image_url: props.image_url,
-          alt_text: props.alt_text,
-        }
+      if (child.type === JSXSlack.NodeType.object) {
+        // A converted <Image> component
+        if (props.type === 'image')
+          return {
+            type: 'image' as const,
+            image_url: props.image_url,
+            alt_text: props.alt_text,
+          }
 
-      // A converted <MrkDwn> component
-      if (
-        child.type === JSXSlack.NodeType.object &&
-        props.type === 'mrkdwn_component'
-      )
-        return {
-          type: 'mrkdwn' as const,
-          text: props.text,
-          verbatim: props.verbatim,
-        }
+        // <MrkDwn> component
+        if (props.type === mrkdwnSymbol)
+          return {
+            type: 'mrkdwn' as const,
+            text: props.text,
+            verbatim: props.verbatim,
+          }
+      }
 
       return undefined
     })()

--- a/src/block-kit/Context.tsx
+++ b/src/block-kit/Context.tsx
@@ -4,6 +4,7 @@ import html from '../html'
 import { JSXSlack } from '../jsx'
 import { ObjectOutput } from '../utils'
 import { mrkdwnSymbol } from './composition/Mrkdwn'
+import { mrkdwn } from './composition/utils'
 import { BlockComponentProps } from './Blocks'
 
 type ContextElement = ImageElement | MrkdwnElement
@@ -23,8 +24,7 @@ export const Context: JSXSlack.FC<BlockComponentProps & {
       const { props } = child
 
       // <span> intrinsic HTML element
-      if (child.type === 'span')
-        return { type: 'mrkdwn' as const, text: html(child), verbatim: true }
+      if (child.type === 'span') return mrkdwn(html(child))
 
       // <img> intrinsic HTML element
       if (child.type === 'img')
@@ -45,11 +45,7 @@ export const Context: JSXSlack.FC<BlockComponentProps & {
 
         // <MrkDwn> component
         if (props.type === mrkdwnSymbol)
-          return {
-            type: 'mrkdwn' as const,
-            text: props.text,
-            verbatim: props.verbatim,
-          }
+          return mrkdwn(props.text, props.verbatim)
       }
 
       return undefined
@@ -57,7 +53,7 @@ export const Context: JSXSlack.FC<BlockComponentProps & {
 
     if (current.length > 0 && (independentElement || child === endSymbol)) {
       // Text content
-      elements.push({ type: 'mrkdwn', text: html(current), verbatim: true })
+      elements.push(mrkdwn(html(current)))
       current = []
     }
 

--- a/src/block-kit/Context.tsx
+++ b/src/block-kit/Context.tsx
@@ -24,7 +24,7 @@ export const Context: JSXSlack.FC<BlockComponentProps & {
       const { props } = child
 
       // <span> intrinsic HTML element
-      if (child.type === 'span') return mrkdwn(html(child))
+      if (child.type === 'span') return mrkdwn(html(child), true)
 
       // <img> intrinsic HTML element
       if (child.type === 'img')
@@ -53,7 +53,7 @@ export const Context: JSXSlack.FC<BlockComponentProps & {
 
     if (current.length > 0 && (independentElement || child === endSymbol)) {
       // Text content
-      elements.push(mrkdwn(html(current)))
+      elements.push(mrkdwn(html(current), true))
       current = []
     }
 

--- a/src/block-kit/Section.tsx
+++ b/src/block-kit/Section.tsx
@@ -5,9 +5,10 @@ import { JSXSlack } from '../jsx'
 import { ObjectOutput, aliasTo } from '../utils'
 import html from '../html'
 import { BlockComponentProps } from './Blocks'
-import { Image } from './Image'
+import { mrkdwnSymbol } from './composition/Mrkdwn'
 import { Button } from './elements/Button'
 import { Select } from './elements/Select'
+import { Image } from './Image'
 
 export const sectionAccessoryTypes = [
   'image',
@@ -46,7 +47,7 @@ export const Section: JSXSlack.FC<BlockComponentProps & {
         } else if (child.props.type === 'mrkdwn') {
           if (!fields) fields = []
           fields.push(child.props)
-        } else if (child.props.type === 'mrkdwn_component') {
+        } else if (child.props.type === mrkdwnSymbol) {
           text = {
             type: 'mrkdwn',
             text: child.props.text,

--- a/src/block-kit/Section.tsx
+++ b/src/block-kit/Section.tsx
@@ -73,7 +73,7 @@ export const Section: JSXSlack.FC<BlockComponentProps & {
 
   if (!text) {
     const rendered = html(normalized)
-    if (rendered) text = mrkdwn(rendered)
+    if (rendered) text = mrkdwn(rendered, true)
   }
 
   return (
@@ -90,5 +90,5 @@ export const Section: JSXSlack.FC<BlockComponentProps & {
 export const Field: JSXSlack.FC<{
   children: JSXSlack.Children<{}>
 }> = ({ children }) => (
-  <ObjectOutput<MrkdwnElement> {...mrkdwn(html(children))} />
+  <ObjectOutput<MrkdwnElement> {...mrkdwn(html(children), true)} />
 )

--- a/src/block-kit/composition/Confirm.tsx
+++ b/src/block-kit/composition/Confirm.tsx
@@ -22,7 +22,7 @@ export const Confirm: JSXSlack.FC<ConfirmProps> = props => (
       if (typeof child === 'object' && child.props.type === mrkdwnSymbol)
         return mrkdwn(child.props.text, child.props.verbatim)
 
-      return mrkdwn(html(props.children))
+      return mrkdwn(html(props.children), true)
     })()}
     confirm={plainText(props.confirm)}
     deny={plainText(props.deny)}

--- a/src/block-kit/composition/Confirm.tsx
+++ b/src/block-kit/composition/Confirm.tsx
@@ -1,10 +1,8 @@
 /** @jsx JSXSlack.h */
-import { Confirm as SlackConfirm, MrkdwnElement } from '@slack/types'
-import { mrkdwnSymbol } from '../composition/Mrkdwn'
-import html from '../../html'
+import { Confirm as SlackConfirm } from '@slack/types'
 import { JSXSlack } from '../../jsx'
 import { ObjectOutput } from '../../utils'
-import { plainText, mrkdwn } from './utils'
+import { plainText, mrkdwnFromNode } from './utils'
 
 export interface ConfirmProps {
   children: JSXSlack.Children<{}>
@@ -16,14 +14,7 @@ export interface ConfirmProps {
 export const Confirm: JSXSlack.FC<ConfirmProps> = props => (
   <ObjectOutput<SlackConfirm>
     title={plainText(props.title)}
-    text={((): MrkdwnElement => {
-      const [child] = JSXSlack.normalizeChildren(props.children)
-
-      if (typeof child === 'object' && child.props.type === mrkdwnSymbol)
-        return mrkdwn(child.props.text, child.props.verbatim)
-
-      return mrkdwn(html(props.children), true)
-    })()}
+    text={mrkdwnFromNode(props.children)}
     confirm={plainText(props.confirm)}
     deny={plainText(props.deny)}
   />

--- a/src/block-kit/composition/Confirm.tsx
+++ b/src/block-kit/composition/Confirm.tsx
@@ -20,11 +20,7 @@ export const Confirm: JSXSlack.FC<ConfirmProps> = props => (
       const [child] = JSXSlack.normalizeChildren(props.children)
 
       if (typeof child === 'object' && child.props.type === mrkdwnSymbol)
-        return {
-          type: 'mrkdwn' as const,
-          text: child.props.text,
-          verbatim: child.props.verbatim,
-        }
+        return mrkdwn(child.props.text, child.props.verbatim)
 
       return mrkdwn(html(props.children))
     })()}

--- a/src/block-kit/composition/Confirm.tsx
+++ b/src/block-kit/composition/Confirm.tsx
@@ -1,5 +1,6 @@
 /** @jsx JSXSlack.h */
 import { Confirm as SlackConfirm, MrkdwnElement } from '@slack/types'
+import { mrkdwnSymbol } from '../composition/Mrkdwn'
 import html from '../../html'
 import { JSXSlack } from '../../jsx'
 import { ObjectOutput } from '../../utils'
@@ -12,25 +13,22 @@ export interface ConfirmProps {
   title: string
 }
 
-export const Confirm: JSXSlack.FC<ConfirmProps> = props => {
-  let confirmTextObject: string | MrkdwnElement = mrkdwn(html(props.children))
+export const Confirm: JSXSlack.FC<ConfirmProps> = props => (
+  <ObjectOutput<SlackConfirm>
+    title={plainText(props.title)}
+    text={((): MrkdwnElement => {
+      const [child] = JSXSlack.normalizeChildren(props.children)
 
-  for (const child of JSXSlack.normalizeChildren(props.children)) {
-    if (typeof child === 'object' && child.props.type === 'mrkdwn_component') {
-      confirmTextObject = {
-        type: 'mrkdwn',
-        text: child.props.text,
-        verbatim: child.props.verbatim,
-      }
-    }
-  }
+      if (typeof child === 'object' && child.props.type === mrkdwnSymbol)
+        return {
+          type: 'mrkdwn' as const,
+          text: child.props.text,
+          verbatim: child.props.verbatim,
+        }
 
-  return (
-    <ObjectOutput<SlackConfirm>
-      title={plainText(props.title)}
-      text={confirmTextObject}
-      confirm={plainText(props.confirm)}
-      deny={plainText(props.deny)}
-    />
-  )
-}
+      return mrkdwn(html(props.children))
+    })()}
+    confirm={plainText(props.confirm)}
+    deny={plainText(props.deny)}
+  />
+)

--- a/src/block-kit/composition/Mrkdwn.tsx
+++ b/src/block-kit/composition/Mrkdwn.tsx
@@ -3,23 +3,23 @@ import { JSXSlack } from '../../jsx'
 import { ObjectOutput } from '../../utils'
 import html from '../../html'
 
+export const mrkdwnSymbol = Symbol('jsx-slack-mrkdwn-composition')
+
 interface MrkdwnProps {
   children: JSXSlack.Children<{}>
   verbatim?: boolean
 }
 
 interface MrkdwnComponentProps {
-  type: 'mrkdwn_component'
+  type: typeof mrkdwnSymbol
   text: string
   verbatim?: boolean
 }
 
-export const Mrkdwn: JSXSlack.FC<MrkdwnProps> = ({ children, verbatim }) => {
-  return (
-    <ObjectOutput<MrkdwnComponentProps>
-      type="mrkdwn_component"
-      text={html(children)}
-      verbatim={verbatim}
-    />
-  )
-}
+export const Mrkdwn: JSXSlack.FC<MrkdwnProps> = ({ children, verbatim }) => (
+  <ObjectOutput<MrkdwnComponentProps>
+    type={mrkdwnSymbol}
+    text={html(children)}
+    verbatim={verbatim}
+  />
+)

--- a/src/block-kit/composition/utils.ts
+++ b/src/block-kit/composition/utils.ts
@@ -9,7 +9,10 @@ export const plainText = (
   emoji: !!opts.emoji,
 })
 
-export const mrkdwn = (mrkdwnText: string, verbatim = true): MrkdwnElement => ({
+export const mrkdwn = (
+  mrkdwnText: string,
+  verbatim?: boolean
+): MrkdwnElement => ({
   type: 'mrkdwn',
   text: mrkdwnText,
   verbatim,

--- a/src/block-kit/composition/utils.ts
+++ b/src/block-kit/composition/utils.ts
@@ -9,8 +9,8 @@ export const plainText = (
   emoji: !!opts.emoji,
 })
 
-export const mrkdwn = (mrkdwnText: string): MrkdwnElement => ({
+export const mrkdwn = (mrkdwnText: string, verbatim = true): MrkdwnElement => ({
   type: 'mrkdwn',
   text: mrkdwnText,
-  verbatim: true,
+  verbatim,
 })

--- a/src/block-kit/composition/utils.ts
+++ b/src/block-kit/composition/utils.ts
@@ -1,4 +1,7 @@
 import { MrkdwnElement, PlainTextElement } from '@slack/types'
+import html from '../../html'
+import { JSXSlack } from '../../jsx'
+import { mrkdwnSymbol } from './Mrkdwn'
 
 export const plainText = (
   text: string,
@@ -17,3 +20,12 @@ export const mrkdwn = (
   text: mrkdwnText,
   verbatim,
 })
+
+export const mrkdwnFromNode = (node: JSXSlack.Children<{}>): MrkdwnElement => {
+  const [child] = JSXSlack.normalizeChildren(node)
+
+  if (typeof child === 'object' && child.props.type === mrkdwnSymbol)
+    return mrkdwn(child.props.text, child.props.verbatim)
+
+  return mrkdwn(html(node), true)
+}

--- a/test/block-kit/block-elements/composition-objects.tsx
+++ b/test/block-kit/block-elements/composition-objects.tsx
@@ -8,6 +8,7 @@ import JSXSlack, {
   Mrkdwn,
   Section,
   Context,
+  Field,
 } from '../../../src/index'
 
 beforeEach(() => JSXSlack.exactMode(false))
@@ -152,6 +153,23 @@ describe('Composition objects', () => {
         {
           type: 'section',
           text: { type: 'mrkdwn', text: 'Hello!', verbatim: false },
+        },
+      ])
+
+      expect(
+        JSXSlack(
+          <Blocks>
+            <Section>
+              <Field>
+                <Mrkdwn verbatim={false}>Hello!</Mrkdwn>
+              </Field>
+            </Section>
+          </Blocks>
+        )
+      ).toEqual([
+        {
+          type: 'section',
+          fields: [{ type: 'mrkdwn', text: 'Hello!', verbatim: false }],
         },
       ])
     })

--- a/test/block-kit/block-elements/composition-objects.tsx
+++ b/test/block-kit/block-elements/composition-objects.tsx
@@ -77,7 +77,7 @@ describe('Composition objects', () => {
         ]
       `))
 
-    it('outputs action included <Confirm> object with a <Mrkdwn> child', () => {
+    it('outputs action included <Confirm> object with a <Mrkdwn> child', () =>
       expect(
         JSXSlack(
           <Blocks>
@@ -89,7 +89,9 @@ describe('Composition objects', () => {
                     confirm="Yes, please"
                     deny="Cancel"
                   >
-                    <Mrkdwn verbatim={false}>submit @user</Mrkdwn>
+                    <Mrkdwn verbatim={false}>
+                      <b>Are you sure?</b> Message will be share.
+                    </Mrkdwn>
                   </Confirm>
                 }
               >
@@ -98,45 +100,46 @@ describe('Composition objects', () => {
             </Actions>
           </Blocks>
         )
-      ).toEqual([
-        {
-          block_id: 'actions',
-          elements: [
-            {
-              confirm: {
-                confirm: {
-                  emoji: true,
-                  text: 'Yes, please',
-                  type: 'plain_text',
+      ).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "block_id": "actions",
+            "elements": Array [
+              Object {
+                "confirm": Object {
+                  "confirm": Object {
+                    "emoji": true,
+                    "text": "Yes, please",
+                    "type": "plain_text",
+                  },
+                  "deny": Object {
+                    "emoji": true,
+                    "text": "Cancel",
+                    "type": "plain_text",
+                  },
+                  "text": Object {
+                    "text": "*Are you sure?* Message will be share.",
+                    "type": "mrkdwn",
+                    "verbatim": false,
+                  },
+                  "title": Object {
+                    "emoji": true,
+                    "text": "Share to SNS",
+                    "type": "plain_text",
+                  },
                 },
-                deny: {
-                  emoji: true,
-                  text: 'Cancel',
-                  type: 'plain_text',
+                "text": Object {
+                  "emoji": true,
+                  "text": "Share",
+                  "type": "plain_text",
                 },
-                text: {
-                  text: 'submit @user',
-                  type: 'mrkdwn',
-                  verbatim: false,
-                },
-                title: {
-                  emoji: true,
-                  text: 'Share to SNS',
-                  type: 'plain_text',
-                },
+                "type": "button",
               },
-              text: {
-                emoji: true,
-                text: 'Share',
-                type: 'plain_text',
-              },
-              type: 'button',
-            },
-          ],
-          type: 'actions',
-        },
-      ])
-    })
+            ],
+            "type": "actions",
+          },
+        ]
+      `))
   })
 
   describe('<Mrkdwn>', () => {
@@ -149,7 +152,7 @@ describe('Composition objects', () => {
             </Section>
           </Blocks>
         )
-      ).toEqual([
+      ).toStrictEqual([
         {
           type: 'section',
           text: { type: 'mrkdwn', text: 'Hello!', verbatim: false },
@@ -166,7 +169,7 @@ describe('Composition objects', () => {
             </Section>
           </Blocks>
         )
-      ).toEqual([
+      ).toStrictEqual([
         {
           type: 'section',
           fields: [{ type: 'mrkdwn', text: 'Hello!', verbatim: false }],
@@ -174,7 +177,7 @@ describe('Composition objects', () => {
       ])
     })
 
-    it('outputs a <Context> block with an image and multiple mrkdwn elements', () => {
+    it('outputs a <Context> block with an image and multiple mrkdwn elements', () =>
       expect(
         JSXSlack(
           <Blocks>
@@ -188,7 +191,7 @@ describe('Composition objects', () => {
             </Context>
           </Blocks>
         )
-      ).toEqual([
+      ).toStrictEqual([
         {
           type: 'context',
           elements: [
@@ -214,8 +217,7 @@ describe('Composition objects', () => {
             },
           ],
         },
-      ])
-    })
+      ]))
 
     it('converts <Mrkdwn> elements into mrkdwn elements and preserves the verbatim prop', () =>
       expect(
@@ -227,7 +229,7 @@ describe('Composition objects', () => {
             </Context>
           </Blocks>
         )
-      ).toEqual([
+      ).toStrictEqual([
         {
           type: 'context',
           elements: [

--- a/test/block-kit/block-elements/composition-objects.tsx
+++ b/test/block-kit/block-elements/composition-objects.tsx
@@ -75,6 +75,7 @@ describe('Composition objects', () => {
           },
         ]
       `))
+
     it('outputs action included <Confirm> object with a <Mrkdwn> child', () => {
       expect(
         JSXSlack(
@@ -135,84 +136,87 @@ describe('Composition objects', () => {
         },
       ])
     })
-    describe('<Mrkdwn>', () => {
-      it('outputs a <Section> block with a <Mrkdwn> component and preserves the verbatim prop', () => {
-        expect(
-          JSXSlack(
-            <Blocks>
-              <Section>
-                <Mrkdwn verbatim={false}>Hello!</Mrkdwn>
-              </Section>
-            </Blocks>
-          )
-        ).toEqual([
-          {
-            type: 'section',
-            text: { type: 'mrkdwn', text: 'Hello!', verbatim: false },
-          },
-        ])
-      })
-      it('outputs a <Context> block with an image and multiple mrkdwn elements', () => {
-        expect(
-          JSXSlack(
-            <Blocks>
-              <Context>
-                <Image src="https://example.com/test.jpg" alt="Test Image" />
-                Supporting <code>context</code> block would be hard!
-                <Mrkdwn verbatim={false}>
-                  <i>@here</i>
-                </Mrkdwn>
-                :dizzy_face:
-              </Context>
-            </Blocks>
-          )
-        ).toEqual([
-          {
-            type: 'context',
-            elements: [
-              {
-                type: 'image',
-                image_url: 'https://example.com/test.jpg',
-                alt_text: 'Test Image',
-              },
-              {
-                type: 'mrkdwn',
-                text: 'Supporting `context` block would be hard!',
-                verbatim: true,
-              },
-              {
-                type: 'mrkdwn',
-                text: '_@here_',
-                verbatim: false,
-              },
-              {
-                type: 'mrkdwn',
-                text: ':dizzy_face:',
-                verbatim: true,
-              },
-            ],
-          },
-        ])
-      })
-      it('converts <Mrkdwn> elements into mrkdwn elements and preserves the verbatim prop', () =>
-        expect(
-          JSXSlack(
-            <Blocks>
-              <Context>
-                <Mrkdwn verbatim={false}>Hello</Mrkdwn>
-                World
-              </Context>
-            </Blocks>
-          )
-        ).toEqual([
-          {
-            type: 'context',
-            elements: [
-              { type: 'mrkdwn', text: 'Hello', verbatim: false },
-              { type: 'mrkdwn', text: 'World', verbatim: true },
-            ],
-          },
-        ]))
+  })
+
+  describe('<Mrkdwn>', () => {
+    it('outputs a <Section> block with a <Mrkdwn> component and preserves the verbatim prop', () => {
+      expect(
+        JSXSlack(
+          <Blocks>
+            <Section>
+              <Mrkdwn verbatim={false}>Hello!</Mrkdwn>
+            </Section>
+          </Blocks>
+        )
+      ).toEqual([
+        {
+          type: 'section',
+          text: { type: 'mrkdwn', text: 'Hello!', verbatim: false },
+        },
+      ])
     })
+
+    it('outputs a <Context> block with an image and multiple mrkdwn elements', () => {
+      expect(
+        JSXSlack(
+          <Blocks>
+            <Context>
+              <Image src="https://example.com/test.jpg" alt="Test Image" />
+              Supporting <code>context</code> block would be hard!
+              <Mrkdwn verbatim={false}>
+                <i>@here</i>
+              </Mrkdwn>
+              :dizzy_face:
+            </Context>
+          </Blocks>
+        )
+      ).toEqual([
+        {
+          type: 'context',
+          elements: [
+            {
+              type: 'image',
+              image_url: 'https://example.com/test.jpg',
+              alt_text: 'Test Image',
+            },
+            {
+              type: 'mrkdwn',
+              text: 'Supporting `context` block would be hard!',
+              verbatim: true,
+            },
+            {
+              type: 'mrkdwn',
+              text: '_@here_',
+              verbatim: false,
+            },
+            {
+              type: 'mrkdwn',
+              text: ':dizzy_face:',
+              verbatim: true,
+            },
+          ],
+        },
+      ])
+    })
+
+    it('converts <Mrkdwn> elements into mrkdwn elements and preserves the verbatim prop', () =>
+      expect(
+        JSXSlack(
+          <Blocks>
+            <Context>
+              <Mrkdwn verbatim={false}>Hello</Mrkdwn>
+              World
+            </Context>
+          </Blocks>
+        )
+      ).toEqual([
+        {
+          type: 'context',
+          elements: [
+            { type: 'mrkdwn', text: 'Hello', verbatim: false },
+            { type: 'mrkdwn', text: 'World', verbatim: true },
+          ],
+        },
+      ]))
   })
 })


### PR DESCRIPTION
#97 was merged but looks like there is still incorrect behavior for `<Field>` component. A better auto-complete for REPL demo is lacked too.

This PR is recover pull request for #97. Close #73 again.

### ToDo

- [x] Add test case for `<Mrkdwn>` + `<Field>`
  - [x] Fix behavior
- [x] Update existing test case to use `toStrictEqual` rather than `toEqual`
- [x] Organize documentation
  - [x] Add use cases and preview link
  - [x] Match the tone of documentation into ours
  - [x] Be clearer the description of (confusable) `verbatim` prop
  - [x] Add `<Mrkdwn>` component to TOC of jsx-slack components
- [x] Support auto-completion in REPL demo
  - REPL has disabled JSX interpolation through `{}` by security reason, so it only supports to specify true with omitted value.
- [x] Refactor
  - [x] Refactor components to use `mrkdwn()` internal helper if possible
  - [x] Adopt symbol instead of string as jsx-slack internal node type (Prevent specifying internal object unexpectedly by user) 