### PR TITLE
Mark <Home> container as stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Mark `<Home>` container as stable ([#105](https://github.com/speee/jsx-slack/pull/105))
+
 ## v1.0.0 - 2020-01-10
 
 ### Breaking

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ By using jsx-slack, you can build a template with piling up Block Kit blocks by 
 </Modal>
 ```
 
-### [For home tab](https://speee-jsx-slack.netlify.com/#home) _(experimental)_
+### [For home tab](https://speee-jsx-slack.netlify.com/#home)
 
 ```jsx
 <Home>

--- a/docs/block-containers.md
+++ b/docs/block-containers.md
@@ -81,7 +81,7 @@ export default function shareModal(opts) {
 
 > :information_source: Slack requires the submit text when modal has component for inputs, so jsx-slack would set the text "Submit" as the default value of `submit` prop if you are setting no submit text in any way together with using input components.
 
-## <a name="home" id="home"></a> [`<Home>`: The view container for home tabs](https://api.slack.com/surfaces/tabs) _(experimental)_
+## <a name="home" id="home"></a> [`<Home>`: The view container for home tabs](https://api.slack.com/surfaces/tabs)
 
 The container component for [home tabs](https://api.slack.com/surfaces/tabs). You can build view payload for home tab.
 
@@ -99,8 +99,6 @@ api.views.publish({
 ```
 
 [<img src="https://raw.githubusercontent.com/speee/jsx-slack/master/docs/preview-btn.svg?sanitize=true" width="240" />](https://api.slack.com/tools/block-kit-builder?mode=appHome&view=%7B%22type%22%3A%22home%22%2C%22blocks%22%3A%5B%7B%22type%22%3A%22section%22%2C%22text%22%3A%7B%22text%22%3A%22Welcome%20to%20my%20home!%22%2C%22type%22%3A%22mrkdwn%22%2C%22verbatim%22%3Atrue%7D%7D%5D%7D)
-
-> :warning: _`<Home>` container component is experimental._ Slack's home tab is currently open beta, so we expect its spec might be updated with high-frequency.
 
 ### Props
 

--- a/docs/jsx-components-for-block-kit.md
+++ b/docs/jsx-components-for-block-kit.md
@@ -6,7 +6,7 @@
 
 - [**`<Blocks>`**: The basic container for messages](block-containers.md#blocks)
 - [**`<Modal>`**: The view container for modals](block-containers.md#modal)
-- [**`<Home>`**: The view container for home tabs](block-containers.md#home) _(experimental)_
+- [**`<Home>`**: The view container for home tabs](block-containers.md#home)
 
 ## **[Layout blocks](layout-blocks.md)**
 

--- a/src/block-kit/Home.tsx
+++ b/src/block-kit/Home.tsx
@@ -16,7 +16,6 @@ export interface HomeProps {
   privateMetadata?: string
 }
 
-/** [experimental] */
 export const Home: JSXSlack.FC<HomeProps> = props => (
   <ObjectOutput<View & { external_id?: string }>
     type="home"


### PR DESCRIPTION
jsx-slack had marked `<Home>` container as experimental because Home tab is beta feature in Slack platform.

And today, [Home tab is out of beta](https://api.slack.com/changelog#January_2020) without any changes of feeling to use API. Thus, `<Home>` container is no longer experimental too.