### PR TITLE
Fix regression about not rendered special spaces around the content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix regression about not rendered special spaces around the content ([#113](https://github.com/speee/jsx-slack/pull/113))
+
 ## v1.3.0 - 2020-02-14
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "he": "^1.2.0",
     "htm": "^3.0.3",
     "mdast-util-phrasing": "^1.0.3",
-    "turndown": "^5.0.3"
+    "turndown": "^5.0.3",
+    "unist-util-visit": "^2.0.1"
   }
 }

--- a/src/mrkdwn/index.ts
+++ b/src/mrkdwn/index.ts
@@ -1,5 +1,7 @@
 import hast2mdast from 'hast-util-to-mdast'
-import parser from './parser'
+import root from 'hast-util-to-mdast/lib/handlers/root'
+import visit from 'unist-util-visit'
+import parser, { decodeEntity } from './parser'
 import stringifier from './stringifier'
 
 const list = (h, node) => {
@@ -22,6 +24,13 @@ const mrkdwn = (html: string) =>
     hast2mdast(parser(html), {
       document: false,
       handlers: {
+        root: (h, node) => {
+          visit(node, n => {
+            // eslint-disable-next-line no-param-reassign
+            if (n.type === 'text') n.value = decodeEntity(n.value)
+          })
+          return root(h, node)
+        },
         code: (h, node) =>
           h.augment(node, {
             type: 'inlineCode',

--- a/test/html.tsx
+++ b/test/html.tsx
@@ -38,6 +38,20 @@ describe('HTML parser for mrkdwn', () => {
       expect(html(<i>{'&lt;&amp;&gt;'}</i>)).toBe('_&amp;lt;&amp;amp;&amp;gt;_')
       expect(html(<i>&lt;{'<mixed>'}&gt;</i>)).toBe('_&lt;&lt;mixed&gt;&gt;_')
     })
+
+    it('keeps special spaces around the content', () => {
+      expect(
+        html(
+          <i>
+            {'  '}test{'  '}
+          </i>
+        )
+      ).toBe('_test_')
+      expect(html(<i>&#9;&#9;tab&#9;&#9;</i>)).toBe('_tab_')
+      expect(
+        html(<i>&thinsp;&nbsp;&ensp;&emsp;sp&emsp;&ensp;&nbsp;&thinsp;</i>)
+      ).toBe('_\u2009\u00a0\u2002\u2003sp\u2003\u2002\u00a0\u2009_')
+    })
   })
 
   describe('Italic', () => {

--- a/test/legacy.tsx
+++ b/test/legacy.tsx
@@ -119,6 +119,20 @@ describe('Legacy parser for mrkdwn', () => {
       expect(html(<i>{'&lt;&amp;&gt;'}</i>)).toBe('_&amp;lt;&amp;amp;&amp;gt;_')
       expect(html(<i>&lt;{'<mixed>'}&gt;</i>)).toBe('_&lt;&lt;mixed&gt;&gt;_')
     })
+
+    it('keeps special spaces around the content', () => {
+      expect(
+        html(
+          <i>
+            {'  '}test{'  '}
+          </i>
+        )
+      ).toBe('_test_')
+      expect(html(<i>&#9;&#9;tab&#9;&#9;</i>)).toBe('_tab_')
+      expect(
+        html(<i>&thinsp;&nbsp;&ensp;&emsp;sp&emsp;&ensp;&nbsp;&thinsp;</i>)
+      ).toBe('_\u2009\u00a0\u2002\u2003sp\u2003\u2002\u00a0\u2009_')
+    })
   })
 
   describe('Italic', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7477,7 +7477,7 @@ unist-util-visit-parents@^3.0.0:
     "@types/unist" "^2.0.0"
     unist-util-is "^4.0.0"
 
-unist-util-visit@^2.0.0:
+unist-util-visit@^2.0.0, unist-util-visit@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-2.0.1.tgz#b4e1c1cb414250c6b3cb386b8e461d79312108ae"
   integrity sha512-bEDa5S/O8WRDeI1mLaMoKuFFi89AjF+UAoMNxO+bbVdo06q+53Vhq4iiv1PenL6Rx1ZxIpXIzqZoc5HD2I1oMA==


### PR DESCRIPTION
`hast-util-to-mdast` -> `rehype-minify-whitespace` -> [`collapse-white-space`](https://github.com/wooorm/collapse-white-space) whitespace matched in [regexp `/\s/`](https://github.com/wooorm/collapse-white-space/blob/master/index.js).  However, this rule does not follow HTML spec correctly ([See specification of the 'white-space' processing model](https://www.w3.org/TR/CSS2/text.html#white-space-model)). This change would break Slack messages for jsx-slack <= v1.2.0.

We will encode special spaces while creating hast tree, and decode them when parsing root node in `hast-util-to-mdast`. At that time, regular spaces are already collapsed so decoded spaces will keep in the content.