### PR TITLE
Mark the legacy parser as deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 
 - Prevent over-escaping for link and time formatting ([#118](https://github.com/speee/jsx-slack/issues/118), [#120](https://github.com/speee/jsx-slack/pull/120))
 
+### Deprecated
+
+- Mark the legacy parser as deprecated ([#121](https://github.com/speee/jsx-slack/pull/121))
+
 ## v1.3.1 - 2020-02-14
 
 ### Fixed

--- a/docs/html-like-formatting.md
+++ b/docs/html-like-formatting.md
@@ -169,7 +169,7 @@ Since jsx-slack v1.3.0, we are using a fully rewritten parser to generate mrkdwn
 
 For example, [the total size of the required modules in a simple message becomes from `4.59MB` to **`107.55KB`**](https://github.com/speee/jsx-slack/pull/112) (x43 smaller).
 
-### Legacy parser
+### Legacy parser _(DEPRECATED)_
 
 General use-cases are well-tested and you should not see remarkable differences during current parser and the previous parser in a rendering of Slack. Even though, there are a few slight differences about a way of parsing elements and rendering mrkdwn.
 
@@ -183,6 +183,8 @@ import JSXSlack, { legacyParser } from '@speee-js/jsx-slack'
 // Enable legacy parser (Call before generating JSON)
 legacyParser()
 ```
+
+_Please take care that the legacy parser has been deprecated and will remove in future version._
 
 ---
 

--- a/src/legacy/index.ts
+++ b/src/legacy/index.ts
@@ -2,6 +2,7 @@ import { JSXSlack, customHtmlToMrkdwn, customJsxToHtml } from '../jsx'
 import legacyJsxToHtml from './jsx'
 import legacyHtmlToMrkdwn from './turndown'
 
+/** @deprecated The legacy parser was deprecated and will remove in future version. Please migrate into the default parser by stop calling this. */
 export default function legacyParser() {
   console.warn(
     '[DEPRECATION WARNING] The legacy parser was deprecated and will remove in future version. Please migrate into the default parser by stop calling legacyParser().'

--- a/src/legacy/index.ts
+++ b/src/legacy/index.ts
@@ -3,6 +3,10 @@ import legacyJsxToHtml from './jsx'
 import legacyHtmlToMrkdwn from './turndown'
 
 export default function legacyParser() {
+  console.warn(
+    '[DEPRECATION WARNING] The legacy parser was deprecated and will remove in future version. Please migrate into the default parser by stop calling legacyParser().'
+  )
+
   Object.defineProperties(JSXSlack, {
     [customHtmlToMrkdwn]: {
       configurable: true,


### PR DESCRIPTION
We've no longer applied bug fixes to legacy parser, such as #118. So jsx-slack have to mark `legacyParser()` as deprecated.