### PR TITLE
Allow text formatting through mrkdwn and HTML-like elements in <RadioButton>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 
 - Change spaces for indenting lists into unicode spaces that were based on measured width in Slack's font ([#117](https://github.com/speee/jsx-slack/pull/117))
+- Allow text formatting through mrkdwn and HTML-like elements in `<RadioButton>` ([#122](https://github.com/speee/jsx-slack/pull/122))
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -194,9 +194,24 @@ By using jsx-slack, you can build a template with piling up Block Kit blocks by 
   <Section>What's next?</Section>
   <Actions>
     <RadioButtonGroup value="tickets">
-      <RadioButton value="tickets">See assigned tickets :ticket:</RadioButton>
-      <RadioButton value="reminder">Remind a task later :memo:</RadioButton>
-      <RadioButton value="pomodoro">Start pomodoro timer :tomato:</RadioButton>
+      <RadioButton value="tickets">
+        <b>See assigned tickets</b> :ticket:
+        <small>
+          <i>Check your tickets to start your work.</i>
+        </small>
+      </RadioButton>
+      <RadioButton value="reminder">
+        <b>Remind a task later</b> :memo:
+        <small>
+          <i>We will remember a task for you.</i>
+        </small>
+      </RadioButton>
+      <RadioButton value="pomodoro">
+        <b>Start pomodoro timer</b> :tomato:
+        <small>
+          <i>Get focused on your time, with tomato!</i>
+        </small>
+      </RadioButton>
     </RadioButtonGroup>
     <Button actionId="start" style="primary">
       Start working

--- a/README.md
+++ b/README.md
@@ -28,11 +28,13 @@ Build JSON object for [Slack][slack] [Block Kit] surfaces from readable [JSX].
 - **[Block Kit as components](docs/jsx-components-for-block-kit.md)** - Build contents for any surfaces by composing components for Block Kit with JSX.
 - **[HTML-like formatting](docs/html-like-formatting.md)** - Keep a readability by using well-known elements.
 
+See **[references](#references)** to dive into jsx-slack deeply.
+
 ## Motivation
 
 When developing Slack-integrated app, continuous maintenance of the rich contents is a difficult task. A team member must read and write JSON with deep knowledge about specifications of payload for Slack API.
 
-Slack has shipped [Block Kit] and [Block Kit Builder], and efforts to develop app easily. We believe JSX-based template would enhance a developer experience of Slack app to the next stage.
+Slack has shipped [Block Kit] and [Block Kit Builder], and efforts to develop app easily. We believe well-known JSX-based template would enhance a developer experience of Slack app to the next stage.
 
 ## Project goal
 

--- a/README.md
+++ b/README.md
@@ -103,10 +103,10 @@ A prgama would work in Babel ([@babel/plugin-transform-react-jsx](https://babelj
 
 ### Use template in Slack API
 
-After than, just use created template in Slack API. We are using the official Node SDK [`@slack/client`](https://github.com/slackapi/node-slack-sdk) in this example. [See also Slack guide.](https://slackapi.github.io/node-slack-sdk/web_api)
+After than, just use created template in Slack API. We are using the official Node SDK [`@slack/web-api`](https://github.com/slackapi/node-slack-sdk) in this example. [See also Slack guide.](https://slackapi.github.io/node-slack-sdk/web_api)
 
 ```javascript
-import { WebClient } from '@slack/client'
+import { WebClient } from '@slack/web-api'
 import exampleBlock from './example'
 
 const web = new WebClient(process.env.SLACK_TOKEN)

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ By using jsx-slack, you can build a template with piling up Block Kit blocks by 
       <RadioButton value="reminder">
         <b>Remind a task later</b> :memo:
         <small>
-          <i>We will remember a task for you.</i>
+          <i>I'll remember a task for you.</i>
         </small>
       </RadioButton>
       <RadioButton value="pomodoro">

--- a/demo/example.js
+++ b/demo/example.js
@@ -54,9 +54,24 @@ export const home = `
   <Section>What's next?</Section>
   <Actions>
     <RadioButtonGroup value="tickets">
-      <RadioButton value="tickets">See assigned tickets :ticket:</RadioButton>
-      <RadioButton value="reminder">Remind a task later :memo:</RadioButton>
-      <RadioButton value="pomodoro">Start pomodoro timer :tomato:</RadioButton>
+      <RadioButton value="tickets">
+        <b>See assigned tickets</b> :ticket:
+        <small>
+          <i>Check your tickets to start your work.</i>
+        </small>
+      </RadioButton>
+      <RadioButton value="reminder">
+        <b>Remind a task later</b> :memo:
+        <small>
+          <i>We will remember a task for you.</i>
+        </small>
+      </RadioButton>
+      <RadioButton value="pomodoro">
+        <b>Start pomodoro timer</b> :tomato:
+        <small>
+          <i>Get focused on your time, with tomato!</i>
+        </small>
+      </RadioButton>
     </RadioButtonGroup>
     <Button actionId="start" style="primary">
       Start working

--- a/demo/example.js
+++ b/demo/example.js
@@ -63,7 +63,7 @@ export const home = `
       <RadioButton value="reminder">
         <b>Remind a task later</b> :memo:
         <small>
-          <i>We will remember a task for you.</i>
+          <i>I'll remember a task for you.</i>
         </small>
       </RadioButton>
       <RadioButton value="pomodoro">

--- a/demo/schema.js
+++ b/demo/schema.js
@@ -316,7 +316,10 @@ const schema = {
     },
     children: ['RadioButton'],
   },
-  RadioButton: { attrs: { value: null, description: null }, children: [] },
+  RadioButton: {
+    attrs: { value: null, description: null },
+    children: ['Mrkdwn', 'small', ...markupHTML.filter(tag => tag !== 'a')],
+  },
   CheckboxGroup: {
     attrs: {
       values: null,
@@ -327,7 +330,7 @@ const schema = {
   },
   Checkbox: {
     attrs: { value: null, checked: [], description: null },
-    children: ['Mrkdwn', 'small', ...markupHTML],
+    children: ['Mrkdwn', 'small', ...markupHTML.filter(tag => tag !== 'a')],
   },
 
   // Composition objects
@@ -404,7 +407,7 @@ const schema = {
       t => t !== 's' && t !== 'strike' && t !== 'del'
     ),
   },
-  small: { attrs: {}, children: markupHTML },
+  small: { attrs: {}, children: markupHTML.filter(tag => tag !== 'a') },
   span: { attrs: {}, children: markupHTML },
   strike: {
     attrs: {},

--- a/docs/block-elements.md
+++ b/docs/block-elements.md
@@ -520,23 +520,33 @@ _This component is only for [`<Modal>`](block-containers.md#modal) and [`<Home>`
     Select the tier of our service:
     <RadioButtonGroup actionId="tier" value="free">
       <RadioButton value="free" description="$0!">
-        Free
+        <b>Free</b>
       </RadioButton>
-      <RadioButton value="standard" description="$5/month and 30 days trial!">
-        Standard
+      <RadioButton
+        value="standard"
+        description={
+          <Fragment>
+            $5/month, <b>and 30 days trial!</b>
+          </Fragment>
+        }
+      >
+        <b>Standard</b>
       </RadioButton>
       <RadioButton value="premium" description="$30/month">
-        Premium
+        <b>Premium</b>
       </RadioButton>
-      <RadioButton value="business" description="Please contact to support.">
-        Business
+      <RadioButton
+        value="business"
+        description={<i>Please contact to support.</i>}
+      >
+        <b>Business</b>
       </RadioButton>
     </RadioButtonGroup>
   </Section>
 </Home>
 ```
 
-[<img src="https://raw.githubusercontent.com/speee/jsx-slack/master/docs/preview-btn.svg?sanitize=true" width="240" />](https://api.slack.com/tools/block-kit-builder?mode=appHome&view=%7B%22type%22%3A%22home%22%2C%22blocks%22%3A%5B%7B%22type%22%3A%22section%22%2C%22text%22%3A%7B%22text%22%3A%22Select%20the%20tier%20of%20our%20service%3A%22%2C%22type%22%3A%22mrkdwn%22%2C%22verbatim%22%3Atrue%7D%2C%22accessory%22%3A%7B%22type%22%3A%22radio_buttons%22%2C%22action_id%22%3A%22tier%22%2C%22options%22%3A%5B%7B%22text%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Free%22%2C%22emoji%22%3Atrue%7D%2C%22value%22%3A%22free%22%2C%22description%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22%240!%22%2C%22emoji%22%3Atrue%7D%7D%2C%7B%22text%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Standard%22%2C%22emoji%22%3Atrue%7D%2C%22value%22%3A%22standard%22%2C%22description%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22%245%2Fmonth%20and%2030%20days%20trial!%22%2C%22emoji%22%3Atrue%7D%7D%2C%7B%22text%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Premium%22%2C%22emoji%22%3Atrue%7D%2C%22value%22%3A%22premium%22%2C%22description%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22%2430%2Fmonth%22%2C%22emoji%22%3Atrue%7D%7D%2C%7B%22text%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Business%22%2C%22emoji%22%3Atrue%7D%2C%22value%22%3A%22business%22%2C%22description%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Please%20contact%20to%20support.%22%2C%22emoji%22%3Atrue%7D%7D%5D%2C%22initial_option%22%3A%7B%22text%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Free%22%2C%22emoji%22%3Atrue%7D%2C%22value%22%3A%22free%22%2C%22description%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22%240!%22%2C%22emoji%22%3Atrue%7D%7D%7D%7D%5D%7D)
+[<img src="https://raw.githubusercontent.com/speee/jsx-slack/master/docs/preview-btn.svg?sanitize=true" width="240" />](https://api.slack.com/tools/block-kit-builder?mode=appHome&view=%7B%22type%22%3A%22home%22%2C%22blocks%22%3A%5B%7B%22type%22%3A%22section%22%2C%22text%22%3A%7B%22type%22%3A%22mrkdwn%22%2C%22text%22%3A%22Select%20the%20tier%20of%20our%20service%3A%22%2C%22verbatim%22%3Atrue%7D%2C%22accessory%22%3A%7B%22type%22%3A%22radio_buttons%22%2C%22action_id%22%3A%22tier%22%2C%22options%22%3A%5B%7B%22text%22%3A%7B%22type%22%3A%22mrkdwn%22%2C%22text%22%3A%22*Free*%22%2C%22verbatim%22%3Atrue%7D%2C%22value%22%3A%22free%22%2C%22description%22%3A%7B%22type%22%3A%22mrkdwn%22%2C%22text%22%3A%22%240!%22%2C%22verbatim%22%3Atrue%7D%7D%2C%7B%22text%22%3A%7B%22type%22%3A%22mrkdwn%22%2C%22text%22%3A%22*Standard*%22%2C%22verbatim%22%3Atrue%7D%2C%22value%22%3A%22standard%22%2C%22description%22%3A%7B%22type%22%3A%22mrkdwn%22%2C%22text%22%3A%22%245%2Fmonth%2C%20*and%2030%20days%20trial!*%22%2C%22verbatim%22%3Atrue%7D%7D%2C%7B%22text%22%3A%7B%22type%22%3A%22mrkdwn%22%2C%22text%22%3A%22*Premium*%22%2C%22verbatim%22%3Atrue%7D%2C%22value%22%3A%22premium%22%2C%22description%22%3A%7B%22type%22%3A%22mrkdwn%22%2C%22text%22%3A%22%2430%2Fmonth%22%2C%22verbatim%22%3Atrue%7D%7D%2C%7B%22text%22%3A%7B%22type%22%3A%22mrkdwn%22%2C%22text%22%3A%22*Business*%22%2C%22verbatim%22%3Atrue%7D%2C%22value%22%3A%22business%22%2C%22description%22%3A%7B%22type%22%3A%22mrkdwn%22%2C%22text%22%3A%22_Please%20contact%20to%20support._%22%2C%22verbatim%22%3Atrue%7D%7D%5D%2C%22initial_option%22%3A%7B%22text%22%3A%7B%22type%22%3A%22mrkdwn%22%2C%22text%22%3A%22*Free*%22%2C%22verbatim%22%3Atrue%7D%2C%22value%22%3A%22free%22%2C%22description%22%3A%7B%22type%22%3A%22mrkdwn%22%2C%22text%22%3A%22%240!%22%2C%22verbatim%22%3Atrue%7D%7D%7D%7D%5D%7D)
 
 #### Props
 
@@ -572,7 +582,7 @@ In `<Modal>` container, `<RadioButtonGroup>` can place as `<Modal>`'s direct chi
 </Modal>
 ```
 
-[<img src="https://raw.githubusercontent.com/speee/jsx-slack/master/docs/preview-btn.svg?sanitize=true" width="240" />](https://api.slack.com/tools/block-kit-builder?mode=modal&view=%7B%22type%22%3A%22modal%22%2C%22title%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Preferences%22%2C%22emoji%22%3Atrue%7D%2C%22submit%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22OK%22%2C%22emoji%22%3Atrue%7D%2C%22close%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Cancel%22%2C%22emoji%22%3Atrue%7D%2C%22blocks%22%3A%5B%7B%22type%22%3A%22input%22%2C%22block_id%22%3A%22notifications%22%2C%22hint%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Setting%20a%20frequency%20of%20notifications%20by%20app.%22%2C%22emoji%22%3Atrue%7D%2C%22label%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Notifications%22%2C%22emoji%22%3Atrue%7D%2C%22optional%22%3Afalse%2C%22element%22%3A%7B%22type%22%3A%22radio_buttons%22%2C%22action_id%22%3A%22notifications%22%2C%22options%22%3A%5B%7B%22text%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22All%20events%22%2C%22emoji%22%3Atrue%7D%2C%22value%22%3A%22all%22%2C%22description%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Notify%20all%20received%20events%20every%20time.%22%2C%22emoji%22%3Atrue%7D%7D%2C%7B%22text%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Daily%20summary%22%2C%22emoji%22%3Atrue%7D%2C%22value%22%3A%22summary%22%2C%22description%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Send%20a%20daily%20summary%20at%20AM%209%3A30%20every%20day.%22%2C%22emoji%22%3Atrue%7D%7D%2C%7B%22text%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Off%22%2C%22emoji%22%3Atrue%7D%2C%22value%22%3A%22off%22%7D%5D%2C%22initial_option%22%3A%7B%22text%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22All%20events%22%2C%22emoji%22%3Atrue%7D%2C%22value%22%3A%22all%22%2C%22description%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Notify%20all%20received%20events%20every%20time.%22%2C%22emoji%22%3Atrue%7D%7D%7D%7D%5D%7D)
+[<img src="https://raw.githubusercontent.com/speee/jsx-slack/master/docs/preview-btn.svg?sanitize=true" width="240" />](https://api.slack.com/tools/block-kit-builder?mode=modal&view=%7B%22type%22%3A%22modal%22%2C%22title%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Preferences%22%2C%22emoji%22%3Atrue%7D%2C%22submit%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22OK%22%2C%22emoji%22%3Atrue%7D%2C%22close%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Cancel%22%2C%22emoji%22%3Atrue%7D%2C%22blocks%22%3A%5B%7B%22type%22%3A%22input%22%2C%22block_id%22%3A%22notifications%22%2C%22hint%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Setting%20a%20frequency%20of%20notifications%20by%20app.%22%2C%22emoji%22%3Atrue%7D%2C%22label%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Notifications%22%2C%22emoji%22%3Atrue%7D%2C%22optional%22%3Afalse%2C%22element%22%3A%7B%22type%22%3A%22radio_buttons%22%2C%22action_id%22%3A%22notifications%22%2C%22options%22%3A%5B%7B%22text%22%3A%7B%22type%22%3A%22mrkdwn%22%2C%22text%22%3A%22All%20events%22%2C%22verbatim%22%3Atrue%7D%2C%22value%22%3A%22all%22%2C%22description%22%3A%7B%22type%22%3A%22mrkdwn%22%2C%22text%22%3A%22Notify%20all%20received%20events%20every%20time.%22%2C%22verbatim%22%3Atrue%7D%7D%2C%7B%22text%22%3A%7B%22type%22%3A%22mrkdwn%22%2C%22text%22%3A%22Daily%20summary%22%2C%22verbatim%22%3Atrue%7D%2C%22value%22%3A%22summary%22%2C%22description%22%3A%7B%22type%22%3A%22mrkdwn%22%2C%22text%22%3A%22Send%20a%20daily%20summary%20at%20AM%209%3A30%20every%20day.%22%2C%22verbatim%22%3Atrue%7D%7D%2C%7B%22text%22%3A%7B%22type%22%3A%22mrkdwn%22%2C%22text%22%3A%22Off%22%2C%22verbatim%22%3Atrue%7D%2C%22value%22%3A%22off%22%7D%5D%2C%22initial_option%22%3A%7B%22text%22%3A%7B%22type%22%3A%22mrkdwn%22%2C%22text%22%3A%22All%20events%22%2C%22verbatim%22%3Atrue%7D%2C%22value%22%3A%22all%22%2C%22description%22%3A%7B%22type%22%3A%22mrkdwn%22%2C%22text%22%3A%22Notify%20all%20received%20events%20every%20time.%22%2C%22verbatim%22%3Atrue%7D%7D%7D%7D%5D%7D)
 
 ##### Props for modal's input
 
@@ -585,32 +595,36 @@ In `<Modal>` container, `<RadioButtonGroup>` can place as `<Modal>`'s direct chi
 
 An item of the radio button. It must place in the children of `<RadioButtonGroup>`.
 
-_Unlike checkbox, the content of text and description cannot style via [mrkdwn format](https://api.slack.com/reference/surfaces/formatting) and [HTML elements](./html-like-formatting.md) because Slack only allows plain text in the radio button._
+It supports raw [mrkdwn format](https://api.slack.com/reference/surfaces/formatting) / [HTML-like formatting](./html-like-formatting.md) in the both of contents and `description` property.
+
+```jsx
+<RadioButton value="radio" description={<i>Description</i>}>
+  <b>Radio button</b>
+</RadioButton>
+```
+
+[<img src="https://raw.githubusercontent.com/speee/jsx-slack/master/docs/preview-btn.svg?sanitize=true" width="240" />](https://api.slack.com/tools/block-kit-builder?mode=appHome&view=%7B%22type%22%3A%22home%22%2C%22blocks%22%3A%5B%7B%22type%22%3A%22actions%22%2C%22elements%22%3A%5B%7B%22type%22%3A%22radio_buttons%22%2C%22options%22%3A%5B%7B%22text%22%3A%7B%22type%22%3A%22mrkdwn%22%2C%22text%22%3A%22*Radio%20button*%22%2C%22verbatim%22%3Atrue%7D%2C%22value%22%3A%22radio%22%2C%22description%22%3A%7B%22type%22%3A%22mrkdwn%22%2C%22text%22%3A%22_Description_%22%2C%22verbatim%22%3Atrue%7D%7D%5D%7D%5D%7D%5D%7D)
+
+> :information_source: [Links and mentions through `<a>` tag](https://github.com/speee/jsx-slack/blob/master/docs/html-like-formatting.md#links) will be ignored by Slack.
 
 #### Props
 
 - `value` (**required**): A string value to send to Slack App when choosing the radio button.
-- `description` (optional): A description text for the current radio button. It can see with faded color just below the main label. `<RadioButton>` prefers this prop than redirection by `<small>`.
+- `description` (optional): A description string or JSX element for the current radio button. It can see with faded color just below the main label. `<RadioButton>` prefers this prop than redirection by `<small>`.
 
 #### Redirect `<small>` into description
 
 `<RadioButton>` allows `<small>` element for ergonomic templating, to redirect the text content into description when `description` prop is not defined.
 
-For example, below 2 elements are meaning exactly the same radio button.
+A below radio button is meaning exactly the same as an example shown earlier.
 
 ```jsx
-<RadioButtonGroup>
-  {/* Define description through prop */}
-  <RadioButton value="radio" description="Description">
-    Radio button
-  </RadioButton>
-
-  {/* Define description through <small> element */}
-  <RadioButton value="radio">
-    Radio button
-    <small>Description</small>
-  </RadioButton>
-</RadioButtonGroup>
+<RadioButton value="radio">
+  <b>Radio button</b>
+  <small>
+    <i>Description</i>
+  </small>
+</RadioButton>
 ```
 
 ## [Composition objects](https://api.slack.com/reference/messaging/composition-objects)

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "typescript": "^3.7.5"
   },
   "dependencies": {
-    "@slack/types": "^1.3.0",
+    "@slack/types": "^1.4.0",
     "hast-util-to-mdast": "^6.0.0",
     "he": "^1.2.0",
     "htm": "^3.0.3",

--- a/src/block-kit/elements/Checkbox.tsx
+++ b/src/block-kit/elements/Checkbox.tsx
@@ -1,10 +1,10 @@
 /** @jsx JSXSlack.h */
-import { PlainTextElement, MrkdwnElement } from '@slack/types'
+import { MrkdwnElement } from '@slack/types'
 import { findNode, pickInternalNodes } from './utils'
 import { ConfirmProps } from '../composition/Confirm'
 import { mrkdwnFromNode } from '../composition/utils'
 import { JSXSlack } from '../../jsx'
-import { ObjectOutput, isNode } from '../../utils'
+import { ObjectOutput } from '../../utils'
 import { WithInputProps, wrapInInput } from '../Input'
 
 const checkboxInternal = Symbol('checkboxInternal')

--- a/src/block-kit/elements/RadioButton.tsx
+++ b/src/block-kit/elements/RadioButton.tsx
@@ -1,13 +1,19 @@
 /** @jsx JSXSlack.h */
-import { Option, RadioButtons } from '@slack/types'
+import { MrkdwnElement } from '@slack/types'
 import { findNode, pickInternalNodes } from './utils'
 import { ConfirmProps } from '../composition/Confirm'
-import { plainText } from '../composition/utils'
+import { mrkdwnFromNode } from '../composition/utils'
 import { JSXSlack } from '../../jsx'
-import { ObjectOutput, PlainText } from '../../utils'
+import { ObjectOutput } from '../../utils'
 import { WithInputProps, wrapInInput } from '../Input'
 
 const radioButtonInternal = Symbol('radioButtonInternal')
+
+interface RadioButtonOption {
+  text: MrkdwnElement // jsx-slack alaways uses mrkdwn element
+  value?: string
+  description?: MrkdwnElement
+}
 
 interface RadioButtonGroupPropsBase {
   actionId?: string
@@ -21,7 +27,7 @@ export type RadioButtonGroupProps = WithInputProps<RadioButtonGroupPropsBase>
 
 export interface RadioButtonProps {
   children: JSXSlack.Children<{}>
-  description?: string
+  description?: JSXSlack.Children<{}>
   value: string
 }
 
@@ -29,22 +35,26 @@ interface RadioButtonInternalProps extends RadioButtonProps {
   type: typeof radioButtonInternal
 }
 
-const toOptionObject = (props: RadioButtonInternalProps): Option => {
-  let description: string | undefined
+const toOptionObject = (props: RadioButtonInternalProps): RadioButtonOption => {
+  let description: JSXSlack.Children<{}> | undefined
   const small = findNode(props.children, ({ type }) => type === 'small')
 
   if (small) {
-    description = JSXSlack(<PlainText children={small.children} />)
+    description = small.children
     small.children = []
   }
 
-  const option: Option = {
-    text: plainText(JSXSlack(<PlainText children={props.children} />)),
+  const option: RadioButtonOption = {
+    text: mrkdwnFromNode(props.children),
     value: props.value,
   }
 
   description = props.description || description
-  if (description) option.description = plainText(description)
+
+  if (description)
+    option.description = mrkdwnFromNode(description, {
+      verbatim: option.text.verbatim,
+    })
 
   return option
 }
@@ -65,7 +75,7 @@ export const RadioButtonGroup: JSXSlack.FC<RadioButtonGroupProps> = props => {
     : undefined
 
   const element = (
-    <ObjectOutput<RadioButtons>
+    <ObjectOutput
       type="radio_buttons"
       action_id={props.actionId || props.name}
       options={options}

--- a/test/block-kit/block-elements/interactive-components.tsx
+++ b/test/block-kit/block-elements/interactive-components.tsx
@@ -652,39 +652,39 @@ describe('Interactive components', () => {
 
   describe('<RadioButtonGroup>', () => {
     it('outputs radio button group in actions block', () => {
-      const radioButtonAction: RadioButtons = {
+      const radioButtonAction = {
         type: 'radio_buttons',
         action_id: 'radio-buttons',
         options: [
           {
-            text: { type: 'plain_text', text: '1st', emoji: true },
+            text: { type: 'mrkdwn', text: '1st', verbatim: true },
             description: {
-              type: 'plain_text',
+              type: 'mrkdwn',
               text: 'The first option',
-              emoji: true,
+              verbatim: true,
             },
             value: 'first',
           },
           {
-            text: { type: 'plain_text', text: '2nd', emoji: true },
+            text: { type: 'mrkdwn', text: '*2nd*', verbatim: true },
             description: {
-              type: 'plain_text',
-              text: 'The second option',
-              emoji: true,
+              type: 'mrkdwn',
+              text: 'The _second_ option',
+              verbatim: true,
             },
             value: 'second',
           },
           {
-            text: { type: 'plain_text', text: '3rd', emoji: true },
+            text: { type: 'mrkdwn', text: '3rd', verbatim: true },
             value: 'third',
           },
         ],
         initial_option: {
-          text: { type: 'plain_text', text: '2nd', emoji: true },
+          text: { type: 'mrkdwn', text: '*2nd*', verbatim: true },
           description: {
-            type: 'plain_text',
-            text: 'The second option',
-            emoji: true,
+            type: 'mrkdwn',
+            text: 'The _second_ option',
+            verbatim: true,
           },
           value: 'second',
         },
@@ -698,8 +698,15 @@ describe('Interactive components', () => {
                 <RadioButton value="first" description="The first option">
                   1st
                 </RadioButton>
-                <RadioButton value="second" description="The second option">
-                  2nd
+                <RadioButton
+                  value="second"
+                  description={
+                    <Fragment>
+                      The <i>second</i> option
+                    </Fragment>
+                  }
+                >
+                  <strong>2nd</strong>
                 </RadioButton>
                 <RadioButton value="third">3rd</RadioButton>
               </RadioButtonGroup>
@@ -727,8 +734,10 @@ describe('Interactive components', () => {
                   <small>The first option</small>
                 </RadioButton>
                 <RadioButton value="second">
-                  2nd
-                  <small>The second option</small>
+                  <b>2nd</b>
+                  <small>
+                    The <i>second</i> option
+                  </small>
                 </RadioButton>
                 <RadioButton value="third">3rd</RadioButton>
               </RadioButtonGroup>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1023,10 +1023,10 @@
   dependencies:
     type-detect "4.0.8"
 
-"@slack/types@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@slack/types/-/types-1.3.0.tgz#ea71916449ce7cb79fc57ce756743abfeba0f752"
-  integrity sha512-3AjHsDJjJKT3q0hQzFHQN7piYIh99LuN7Po56W/R6P/uscqZqwS5xm1U1cTYGIzk8fmsuW7TvWVg0W85hKY/MQ==
+"@slack/types@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@slack/types/-/types-1.4.0.tgz#24e0f0cd5b3c4578a7e023aba97969d89c667562"
+  integrity sha512-G5u2gCl7oci0k4E9KIX33nmA4YPp1pXYwS/It7ct9dOglCcj63Ee5GRCgtplzOBS+2++DMdp6l3ZCq+VeAMrfw==
 
 "@tootallnate/once@1":
   version "1.0.0"


### PR DESCRIPTION
Now `<RadioButton>` allows formatting text and `description` prop through mrkdwn and HTML-like elements, as same as `<Checkbox>`. Close #119.

```jsx
<Home>
  <Actions>
    <RadioButtonGroup value="tickets">
      <RadioButton value="tickets">
        <b>See assigned tickets</b> :ticket:
        <small>
          <i>Check your tickets to start your work.</i>
        </small>
      </RadioButton>
      <RadioButton value="reminder">
        <b>Remind a task later</b> :memo:
        <small>
          <i>I'll remember a task for you.</i>
        </small>
      </RadioButton>
      <RadioButton value="pomodoro">
        <b>Start pomodoro timer</b> :tomato:
        <small>
          <i>Get focused on your time, with tomato!</i>
        </small>
      </RadioButton>
    </RadioButtonGroup>
    <Button actionId="start" style="primary">
      Start working
    </Button>
  </Actions>
</Home>
```

The internal logic for `<RadioButton>` became almost same as `<Checkbox>`.

By this change, the output JSON for radio button will always use `mrkdwn` type instead of `plain_text`. In the most cases, there is no problem even if bumped jsx-slack straightly. However, some users using mrkdwn characters in `<RadioButton>` may have to take care of escaping via `<Escape>`.