### PR TITLE
Add experimental filter props to <ConversationsSelect>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Added
 
-- Added `responseUrlEnabled` property for modal's input component to `<ConversationsSelect>` and `<ChannelsSelect>` ([#135](https://github.com/speee/jsx-slack/pull/135))
+- `responseUrlEnabled` property for modal's input component to `<ConversationsSelect>` and `<ChannelsSelect>` ([#134](https://github.com/speee/jsx-slack/issues/134), [#135](https://github.com/speee/jsx-slack/pull/135))
+- Experimental filter properties to `<ConversationsSelect>`: `include`, `excludeExternalSharedChannels`, and `excludeBotUsers` ([#133](https://github.com/speee/jsx-slack/issues/133), [#136](https://github.com/speee/jsx-slack/pull/136))
 
 ## v1.5.1 - 2020-03-16
 

--- a/README.md
+++ b/README.md
@@ -176,11 +176,14 @@ By using jsx-slack, you can build a template with piling up Block Kit blocks by 
   <Divider />
 
   <Input type="text" name="subject" label="Subject" required />
-  <Textarea name="message" label="Message" maxLength={500} />
+  <Textarea name="message" label="Message" maxLength="500" />
+
   <ConversationsSelect
     name="shareWith"
     label="Share with..."
     required
+    include="public im"
+    excludeBotUsers
     responseUrlEnabled
   />
 

--- a/README.md
+++ b/README.md
@@ -176,13 +176,13 @@ By using jsx-slack, you can build a template with piling up Block Kit blocks by 
   <Divider />
 
   <Input type="text" name="subject" label="Subject" required />
-  <Textarea name="message" label="Message" maxLength="500" />
+  <Textarea name="message" label="Message" maxLength={500} />
 
   <ConversationsSelect
     name="shareWith"
     label="Share with..."
     required
-    include="public im"
+    include={['public', 'im']}
     excludeBotUsers
     responseUrlEnabled
   />

--- a/demo/example.js
+++ b/demo/example.js
@@ -37,10 +37,13 @@ export const modal = `
 
   <Input type="text" name="subject" label="Subject" required />
   <Textarea name="message" label="Message" maxLength="500" />
+
   <ConversationsSelect
     name="shareWith"
     label="Share with..."
     required
+    include="public im"
+    excludeBotUsers
     responseUrlEnabled
   />
 

--- a/demo/schema.js
+++ b/demo/schema.js
@@ -281,6 +281,9 @@ const schema = {
     attrs: {
       placeholder: null,
       initialConversation: null,
+      include: ['im', 'mpim', 'private', 'public'],
+      excludeBotUsers: [],
+      excludeExternalSharedChannels: [],
       ...blockInteractiveCommonAttrs,
       ...multipleSelectAttrs,
       ...inputComponentAttrs,

--- a/docs/block-elements.md
+++ b/docs/block-elements.md
@@ -277,6 +277,13 @@ A select menu with options consisted of any type of conversations in the current
 - `placeholder` (optional): A plain text to be shown at first.
 - `initialConversation` (optional): The initial conversation ID. It can pass multiple string values by array when `multiple` is enabled.
 - `confirm` (optional): [`<Confirm>` element](#confirm) to show confirmation dialog.
+- _`include`_ (optional): An array of the kind or a string of space-separated kinds, to indicate which kind of conversation types are included in list. By default, all conversation types are included. _(experimental)_
+  - `public`: Public channel
+  - `private`: Private channel
+  - `im`: Direct message
+  - `mpim`: Group direct message
+- _`excludeExternalSharedChannels`_ (optional): A boolean value whether to exclude external [shared channels](https://api.slack.com/enterprise/shared-channels) from conversations list. _(experimental)_
+- _`excludeBotUsers`_ (optional): A boolean value whether to exclude bot users from conversations list. _(experimental)_
 
 ##### Props for [multiple select]
 

--- a/src/block-kit/elements/Select.tsx
+++ b/src/block-kit/elements/Select.tsx
@@ -395,17 +395,17 @@ export const ConversationsSelect: JSXSlack.FC<ConversationsSelectProps> = props 
     <ObjectOutput<MultiConversationsSelect>
       type="multi_conversations_select"
       {...baseProps(props)}
-      filter={filterComposition}
       initial_conversations={
         props.initialConversation ? wrap(props.initialConversation) : undefined
       }
+      filter={filterComposition}
     />
   ) : (
     <ObjectOutput<SlackConversationsSelect>
       type="conversations_select"
       {...baseProps(props)}
-      filter={filterComposition}
       initial_conversation={props.initialConversation}
+      filter={filterComposition}
       response_url_enabled={
         props.responseUrlEnabled !== undefined
           ? !!props.responseUrlEnabled

--- a/src/block-kit/elements/Select.tsx
+++ b/src/block-kit/elements/Select.tsx
@@ -109,8 +109,13 @@ type UsersSelectProps = WithInputProps<
 
 // Conversations select
 interface ConversationsSelectPropsBase {
+  /** [Experimental] Properties to filter conversations list are beta. */
   include?: string | ('im' | 'mpim' | 'private' | 'public')[]
+
+  /** [Experimental] Properties to filter conversations list are beta. */
   excludeExternalSharedChannels?: boolean
+
+  /** [Experimental] Properties to filter conversations list are beta. */
   excludeBotUsers?: boolean
 }
 

--- a/test/block-kit/block-elements/interactive-components.tsx
+++ b/test/block-kit/block-elements/interactive-components.tsx
@@ -494,6 +494,65 @@ describe('Interactive components', () => {
         )
       ).toStrictEqual([selectAction])
     })
+
+    it('adds filter composition object when specified filter props', () => {
+      const filterCmp = (element: JSXSlack.Node) =>
+        JSXSlack(
+          <Blocks>
+            <Section>test{element}</Section>
+          </Blocks>
+        )[0].accessory.filter
+
+      expect(filterCmp(<ConversationsSelect />)).toBeUndefined()
+      expect(filterCmp(<ConversationsSelect include={[]} />)).toBeUndefined()
+      expect(filterCmp(<ConversationsSelect include="" />)).toBeUndefined()
+      expect(filterCmp(<ConversationsSelect include=" " />)).toBeUndefined()
+      expect(filterCmp(<ConversationsSelect include="?" />)).toBeUndefined()
+
+      expect(
+        filterCmp(
+          <ConversationsSelect include={['public', 'private', 'im', 'mpim']} />
+        )
+      ).toStrictEqual({ include: ['public', 'private', 'im', 'mpim'] })
+      expect(
+        filterCmp(
+          <ConversationsSelect multiple include="public private im mpim" />
+        )
+      ).toStrictEqual({ include: ['public', 'private', 'im', 'mpim'] })
+      expect(
+        filterCmp(<ConversationsSelect include={['im', 'im']} />)
+      ).toStrictEqual({ include: ['im'] })
+      expect(
+        filterCmp(<ConversationsSelect include="unknown im" />)
+      ).toStrictEqual({ include: ['im'] })
+      expect(
+        filterCmp(<ConversationsSelect include="   public and  private " />)
+      ).toStrictEqual({ include: ['public', 'private'] })
+
+      expect(filterCmp(<ConversationsSelect excludeBotUsers />)).toStrictEqual({
+        exclude_bot_users: true,
+      })
+
+      expect(
+        filterCmp(<ConversationsSelect excludeExternalSharedChannels />)
+      ).toStrictEqual({
+        exclude_external_shared_channels: true,
+      })
+
+      expect(
+        filterCmp(
+          <ConversationsSelect
+            include="public im"
+            excludeBotUsers
+            excludeExternalSharedChannels
+          />
+        )
+      ).toStrictEqual({
+        include: ['public', 'im'],
+        exclude_bot_users: true,
+        exclude_external_shared_channels: true,
+      })
+    })
   })
 
   describe('<ChannelsSelect>', () => {


### PR DESCRIPTION
Added 3 filter props to `<ConversationsSelect>`, for assigning [filter composition object (beta)](https://api.slack.com/reference/block-kit/composition-objects#filter_conversations): `include`, `excludeExternalSharedChannels`, and `excludeBotUsers`.

jsx-slack should mark them as experimental during provided in beta.