### PR TITLE
Upgrade dependent packages to the latest version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade dependent packages to the latest version ([#137](https://github.com/speee/jsx-slack/pull/137))
+
 ## v1.6.0 - 2020-03-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ web.chat
     channel: 'C1232456',
     blocks: exampleBlock({ name: 'Yuki Hattori' }),
   })
-  .then(res => console.log('Message sent: ', res.ts))
+  .then((res) => console.log('Message sent: ', res.ts))
   .catch(console.error)
 ```
 

--- a/demo/index.js
+++ b/demo/index.js
@@ -37,13 +37,13 @@ const completeAfter = (cm, pred) => {
   return CodeMirror.Pass
 }
 
-const completeIfAfterLt = cm =>
+const completeIfAfterLt = (cm) =>
   completeAfter(cm, () => {
     const cur = cm.getCursor()
     return cm.getRange(CodeMirror.Pos(cur.line, cur.ch - 1), cur) === '<'
   })
 
-const completeIfInTag = cm =>
+const completeIfInTag = (cm) =>
   completeAfter(cm, () => {
     const tok = cm.getTokenAt(cm.getCursor())
     if (
@@ -84,7 +84,7 @@ const jsxEditor = CodeMirror(jsx, {
   })(),
 })
 
-const setPreview = query => {
+const setPreview = (query) => {
   previewBtn.removeAttribute('data-mode')
 
   if (query === false) {
@@ -92,7 +92,7 @@ const setPreview = query => {
     previewBtn.classList.add('disabled')
   } else if (typeof query === 'object') {
     const q = new URLSearchParams()
-    Object.keys(query).forEach(k => q.append(k, query[k]))
+    Object.keys(query).forEach((k) => q.append(k, query[k]))
 
     if (query.mode) previewBtn.setAttribute('data-mode', query.mode)
 

--- a/demo/schema.js
+++ b/demo/schema.js
@@ -323,7 +323,7 @@ const schema = {
   },
   RadioButton: {
     attrs: { value: null, description: null },
-    children: ['Mrkdwn', 'small', ...markupHTML.filter(tag => tag !== 'a')],
+    children: ['Mrkdwn', 'small', ...markupHTML.filter((tag) => tag !== 'a')],
   },
   CheckboxGroup: {
     attrs: {
@@ -335,7 +335,7 @@ const schema = {
   },
   Checkbox: {
     attrs: { value: null, checked: [], description: null },
-    children: ['Mrkdwn', 'small', ...markupHTML.filter(tag => tag !== 'a')],
+    children: ['Mrkdwn', 'small', ...markupHTML.filter((tag) => tag !== 'a')],
   },
 
   // Composition objects
@@ -377,52 +377,55 @@ const schema = {
   Escape: { attrs: {}, children: markupHTML },
 
   // HTML elements
-  a: { attrs: { href: null }, children: markupHTML.filter(t => t !== 'a') },
+  a: { attrs: { href: null }, children: markupHTML.filter((t) => t !== 'a') },
   b: {
     attrs: {},
-    children: markupHTML.filter(t => t !== 'b' && t !== 'strong'),
+    children: markupHTML.filter((t) => t !== 'b' && t !== 'strong'),
   },
   blockquote: {
     attrs: {},
-    children: markupHTML.filter(t => t !== 'blockquote'),
+    children: markupHTML.filter((t) => t !== 'blockquote'),
   },
   br: { attrs: {}, children: [] },
   code: { attrs: {}, children: [] },
   del: {
     attrs: {},
     children: markupHTML.filter(
-      t => t !== 's' && t !== 'strike' && t !== 'del'
+      (t) => t !== 's' && t !== 'strike' && t !== 'del'
     ),
   },
-  em: { attrs: {}, children: markupHTML.filter(t => t !== 'i' && t !== 'em') },
-  i: { attrs: {}, children: markupHTML.filter(t => t !== 'i' && t !== 'em') },
+  em: {
+    attrs: {},
+    children: markupHTML.filter((t) => t !== 'i' && t !== 'em'),
+  },
+  i: { attrs: {}, children: markupHTML.filter((t) => t !== 'i' && t !== 'em') },
   li: {
     attrs: { value: null },
-    children: markupHTML.filter(t => t !== 'ul' && t !== 'ol' && t !== 'li'),
+    children: markupHTML.filter((t) => t !== 'ul' && t !== 'ol' && t !== 'li'),
   },
   ol: {
     attrs: { start: null, type: ['1', 'a', 'A', 'i', 'I'] },
     children: ['li'],
   },
-  p: { attrs: {}, children: markupHTML.filter(t => t !== 'p') },
+  p: { attrs: {}, children: markupHTML.filter((t) => t !== 'p') },
   pre: { attrs: {}, children: [] },
   s: {
     attrs: {},
     children: markupHTML.filter(
-      t => t !== 's' && t !== 'strike' && t !== 'del'
+      (t) => t !== 's' && t !== 'strike' && t !== 'del'
     ),
   },
-  small: { attrs: {}, children: markupHTML.filter(tag => tag !== 'a') },
+  small: { attrs: {}, children: markupHTML.filter((tag) => tag !== 'a') },
   span: { attrs: {}, children: markupHTML },
   strike: {
     attrs: {},
     children: markupHTML.filter(
-      t => t !== 's' && t !== 'strike' && t !== 'del'
+      (t) => t !== 's' && t !== 'strike' && t !== 'del'
     ),
   },
   strong: {
     attrs: {},
-    children: markupHTML.filter(t => t !== 'b' && t !== 'strong'),
+    children: markupHTML.filter((t) => t !== 'b' && t !== 'strong'),
   },
   time: { attrs: { datetime: null, fallback: null }, children: [] },
   ul: { attrs: {}, children: ['li'] },

--- a/docs/block-elements.md
+++ b/docs/block-elements.md
@@ -833,7 +833,7 @@ If you want to store hidden values by own way, you can use a custom transformer 
 ```jsx
 <Modal
   title="test"
-  privateMetadata={hidden => hidden && new URLSearchParams(hidden).toString()}
+  privateMetadata={(hidden) => hidden && new URLSearchParams(hidden).toString()}
 >
   <Input type="hidden" name="A" value="foobar" />
   <Input type="hidden" name="B" value={123} />

--- a/package.json
+++ b/package.json
@@ -58,28 +58,27 @@
   },
   "prettier": {
     "semi": false,
-    "singleQuote": true,
-    "trailingComma": "es5"
+    "singleQuote": true
   },
   "publishConfig": {
     "access": "public"
   },
   "devDependencies": {
     "@types/jest": "^25.1.3",
-    "@typescript-eslint/eslint-plugin": "^2.22.0",
-    "@typescript-eslint/parser": "^2.22.0",
+    "@typescript-eslint/eslint-plugin": "^2.24.0",
+    "@typescript-eslint/parser": "^2.24.0",
     "codecov": "^3.6.4",
-    "codemirror": "^5.52.0",
+    "codemirror": "^5.52.2",
     "eslint": "^6.8.0",
     "eslint-config-airbnb-base": "14.1.0",
-    "eslint-config-prettier": "^6.10.0",
+    "eslint-config-prettier": "^6.10.1",
     "eslint-plugin-import": "^2.20.1",
     "jest": "^25.1.0",
     "jest-junit": "^10.0.0",
     "lodash.debounce": "^4.0.8",
     "npm-run-all": "^4.1.5",
     "parcel": "^1.12.4",
-    "prettier": "^1.19.1",
+    "prettier": "^2.0.1",
     "puppeteer": "^2.1.1",
     "rimraf": "^3.0.1",
     "ts-jest": "^25.2.1",

--- a/src/block-kit/Actions.tsx
+++ b/src/block-kit/Actions.tsx
@@ -19,7 +19,7 @@ const noop = () => {}
 
 const actionTypeValidators = {
   button: noop,
-  channels_select: accessory => {
+  channels_select: (accessory) => {
     if (accessory.response_url_enabled)
       throw new Error(
         "responseUrlEnabled in <ChannelsSelect> is available only in the usage of Modal's input component."
@@ -44,8 +44,8 @@ export const actionTypes = Object.keys(
   actionTypeValidators
 ) as (keyof typeof actionTypeValidators)[]
 
-export const Actions: JSXSlack.FC<ActionsProps> = props => {
-  const children = JSXSlack.normalizeChildren(props.children).map(child => {
+export const Actions: JSXSlack.FC<ActionsProps> = (props) => {
+  const children = JSXSlack.normalizeChildren(props.children).map((child) => {
     if (isNode(child)) {
       if (child.type === 'button') return aliasTo(Button, child)
       if (child.type === 'select') return aliasTo(Select, child)

--- a/src/block-kit/Blocks.tsx
+++ b/src/block-kit/Blocks.tsx
@@ -56,7 +56,7 @@ knownBlocks.set(InternalBlockType.Home, basicBlocks)
 knownActions.set(InternalBlockType.Home, [...actionTypes])
 knownSectionAccessories.set(InternalBlockType.Home, [...sectionAccessoryTypes])
 
-export const Blocks: JSXSlack.FC<BlocksProps> = props => {
+export const Blocks: JSXSlack.FC<BlocksProps> = (props) => {
   const internalType: InternalBlockType | undefined = props[blockTypeSymbol]
 
   const availableBlocks = knownBlocks.get(internalType) || []
@@ -64,7 +64,7 @@ export const Blocks: JSXSlack.FC<BlocksProps> = props => {
   const availableSectionAccessories =
     knownSectionAccessories.get(internalType) || []
 
-  const normalized = JSXSlack.normalizeChildren(props.children).map(child => {
+  const normalized = JSXSlack.normalizeChildren(props.children).map((child) => {
     if (isNode(child) && typeof child.type === 'string') {
       // Aliasing intrinsic elements to Block component
       switch (child.type) {
@@ -97,7 +97,7 @@ export const Blocks: JSXSlack.FC<BlocksProps> = props => {
         // Validate compatibillity of actions and section accessory with container
         if (
           child.props.type === 'actions' &&
-          child.props.elements.some(e => !availableActions.includes(e.type))
+          child.props.elements.some((e) => !availableActions.includes(e.type))
         )
           throw new Error(
             '<Actions> block has an incompatible element with container.'
@@ -125,6 +125,8 @@ export const Blocks: JSXSlack.FC<BlocksProps> = props => {
   return makeSerializableToJSON(<ArrayOutput>{normalized}</ArrayOutput>)
 }
 
-export const BlocksInternal: JSXSlack.FC<BlocksProps & {
-  [blockTypeSymbol]?: InternalBlockType
-}> = props => Blocks(props)
+export const BlocksInternal: JSXSlack.FC<
+  BlocksProps & {
+    [blockTypeSymbol]?: InternalBlockType
+  }
+> = (props) => Blocks(props)

--- a/src/block-kit/Context.tsx
+++ b/src/block-kit/Context.tsx
@@ -11,9 +11,11 @@ type ContextElement = ImageElement | MrkdwnElement
 
 const endSymbol = Symbol('EndOfContext')
 
-export const Context: JSXSlack.FC<BlockComponentProps & {
-  children: JSXSlack.Children<{}>
-}> = ({ blockId, children, id }) => {
+export const Context: JSXSlack.FC<
+  BlockComponentProps & {
+    children: JSXSlack.Children<{}>
+  }
+> = ({ blockId, children, id }) => {
   const elements: ContextElement[] = []
   let current: (string | JSXSlack.Node)[] = []
 

--- a/src/block-kit/Divider.tsx
+++ b/src/block-kit/Divider.tsx
@@ -4,8 +4,10 @@ import { JSXSlack } from '../jsx'
 import { ObjectOutput } from '../utils'
 import { BlockComponentProps } from './Blocks'
 
-export const Divider: JSXSlack.FC<BlockComponentProps & {
-  children?: undefined
-}> = ({ blockId, id }) => (
+export const Divider: JSXSlack.FC<
+  BlockComponentProps & {
+    children?: undefined
+  }
+> = ({ blockId, id }) => (
   <ObjectOutput<DividerBlock> type="divider" block_id={id || blockId} />
 )

--- a/src/block-kit/File.tsx
+++ b/src/block-kit/File.tsx
@@ -10,7 +10,7 @@ interface FileProps extends BlockComponentProps {
   source?: string
 }
 
-export const File: JSXSlack.FC<FileProps> = props => (
+export const File: JSXSlack.FC<FileProps> = (props) => (
   <ObjectOutput<FileBlock>
     type="file"
     block_id={props.id || props.blockId}

--- a/src/block-kit/Home.tsx
+++ b/src/block-kit/Home.tsx
@@ -16,7 +16,7 @@ export interface HomeProps {
   privateMetadata?: string
 }
 
-export const Home: JSXSlack.FC<HomeProps> = props =>
+export const Home: JSXSlack.FC<HomeProps> = (props) =>
   makeSerializableToJSON(
     <ObjectOutput<View & { external_id?: string }>
       type="home"

--- a/src/block-kit/Image.tsx
+++ b/src/block-kit/Image.tsx
@@ -12,7 +12,7 @@ interface ImageProps extends BlockComponentProps {
   title?: string
 }
 
-export const Image: JSXSlack.FC<ImageProps> = props => (
+export const Image: JSXSlack.FC<ImageProps> = (props) => (
   <ObjectOutput<ImageBlock>
     type="image"
     alt_text={props.alt}

--- a/src/block-kit/Input.tsx
+++ b/src/block-kit/Input.tsx
@@ -102,9 +102,11 @@ export const wrapInInput = (
   />
 )
 
-const InputComponent: JSXSlack.FC<InputComponentProps & {
-  multiline?: boolean
-}> = props =>
+const InputComponent: JSXSlack.FC<
+  InputComponentProps & {
+    multiline?: boolean
+  }
+> = (props) =>
   wrapInInput(
     <PlainTextInput
       actionId={props.actionId || props.name}
@@ -117,7 +119,7 @@ const InputComponent: JSXSlack.FC<InputComponentProps & {
     props
   )
 
-export const Input: JSXSlack.FC<InputProps> = props => {
+export const Input: JSXSlack.FC<InputProps> = (props) => {
   if (props.children === undefined) {
     switch (props.type) {
       case 'hidden':
@@ -158,5 +160,5 @@ export const Input: JSXSlack.FC<InputProps> = props => {
   )
 }
 
-export const Textarea: JSXSlack.FC<TextareaProps> = props =>
+export const Textarea: JSXSlack.FC<TextareaProps> = (props) =>
   InputComponent({ ...props, multiline: true })

--- a/src/block-kit/Modal.tsx
+++ b/src/block-kit/Modal.tsx
@@ -29,7 +29,7 @@ export interface ModalProps {
 
 const submitText = plainText('Submit')
 
-export const Modal: JSXSlack.FC<ModalProps> = props => {
+export const Modal: JSXSlack.FC<ModalProps> = (props) => {
   let hasInputBlock = false
   let hidden: object | undefined
   let inputSubmit: string | undefined
@@ -76,7 +76,7 @@ export const Modal: JSXSlack.FC<ModalProps> = props => {
       private_metadata={
         typeof props.privateMetadata === 'string'
           ? props.privateMetadata.toString()
-          : (props.privateMetadata || (h => h && JSON.stringify(h)))(hidden)
+          : (props.privateMetadata || ((h) => h && JSON.stringify(h)))(hidden)
       }
       clear_on_close={
         props.clearOnClose !== undefined ? !!props.clearOnClose : undefined

--- a/src/block-kit/Section.tsx
+++ b/src/block-kit/Section.tsx
@@ -23,7 +23,7 @@ interface FieldInternalObject {
 
 const sectionAccessoryValidators = {
   button: noop,
-  channels_select: accessory => {
+  channels_select: (accessory) => {
     if (accessory.response_url_enabled)
       throw new Error(
         "responseUrlEnabled in <ChannelsSelect> is available only in the usage of Modal's input component."
@@ -54,9 +54,11 @@ export const sectionAccessoryTypes = Object.keys(
   sectionAccessoryValidators
 ) as (keyof typeof sectionAccessoryValidators)[]
 
-export const Section: JSXSlack.FC<BlockComponentProps & {
-  children: JSXSlack.Children<{}>
-}> = ({ blockId, children, id }) => {
+export const Section: JSXSlack.FC<
+  BlockComponentProps & {
+    children: JSXSlack.Children<{}>
+  }
+> = ({ blockId, children, id }) => {
   const normalized: (string | JSXSlack.Node)[] = []
 
   let accessory: SectionBlock['accessory']

--- a/src/block-kit/composition/Confirm.tsx
+++ b/src/block-kit/composition/Confirm.tsx
@@ -11,7 +11,7 @@ export interface ConfirmProps {
   title: string
 }
 
-export const Confirm: JSXSlack.FC<ConfirmProps> = props => (
+export const Confirm: JSXSlack.FC<ConfirmProps> = (props) => (
   <ObjectOutput<SlackConfirm>
     title={plainText(props.title)}
     text={mrkdwnFromNode(props.children)}

--- a/src/block-kit/composition/Mrkdwn.tsx
+++ b/src/block-kit/composition/Mrkdwn.tsx
@@ -13,6 +13,6 @@ interface MrkdwnInternalProps extends MrkdwnProps {
   type: typeof mrkdwnSymbol
 }
 
-export const Mrkdwn: JSXSlack.FC<MrkdwnProps> = props => (
+export const Mrkdwn: JSXSlack.FC<MrkdwnProps> = (props) => (
   <ObjectOutput<MrkdwnInternalProps> {...props} type={mrkdwnSymbol} />
 )

--- a/src/block-kit/elements/Button.tsx
+++ b/src/block-kit/elements/Button.tsx
@@ -15,7 +15,7 @@ export interface ButtonProps {
   value?: string
 }
 
-export const Button: JSXSlack.FC<ButtonProps> = props => (
+export const Button: JSXSlack.FC<ButtonProps> = (props) => (
   <ObjectOutput<SlackButton>
     type="button"
     text={plainText(JSXSlack(<PlainText>{props.children}</PlainText>))}

--- a/src/block-kit/elements/Checkbox.tsx
+++ b/src/block-kit/elements/Checkbox.tsx
@@ -60,7 +60,7 @@ const toOptionObject = (props: CheckboxInternalProps): CheckboxOption => {
   return option
 }
 
-export const CheckboxGroup: JSXSlack.FC<CheckboxGroupProps> = props => {
+export const CheckboxGroup: JSXSlack.FC<CheckboxGroupProps> = (props) => {
   const states = new Map<string, boolean>()
   const values = props.values || []
 
@@ -99,6 +99,6 @@ export const CheckboxGroup: JSXSlack.FC<CheckboxGroupProps> = props => {
   return props.label ? wrapInInput(element, props) : element
 }
 
-export const Checkbox: JSXSlack.FC<CheckboxProps> = props => (
+export const Checkbox: JSXSlack.FC<CheckboxProps> = (props) => (
   <ObjectOutput<CheckboxInternalProps> {...props} type={checkboxInternal} />
 )

--- a/src/block-kit/elements/DatePicker.tsx
+++ b/src/block-kit/elements/DatePicker.tsx
@@ -24,7 +24,7 @@ const formatYMD = (date: Date) =>
     `${date.getDate()}`.padStart(2, '0'),
   ].join('-')
 
-export const DatePicker: JSXSlack.FC<DatePickerProps> = props => {
+export const DatePicker: JSXSlack.FC<DatePickerProps> = (props) => {
   const element = (
     <ObjectOutput<Datepicker>
       type="datepicker"

--- a/src/block-kit/elements/Overflow.tsx
+++ b/src/block-kit/elements/Overflow.tsx
@@ -23,15 +23,15 @@ interface OverflowItemInternal extends OverflowItemProps {
   text: string
 }
 
-export const Overflow: JSXSlack.FC<OverflowProps> = props => {
+export const Overflow: JSXSlack.FC<OverflowProps> = (props) => {
   const opts = JSXSlack.normalizeChildren(props.children).filter(
-    o => typeof o !== 'string'
+    (o) => typeof o !== 'string'
   ) as JSXSlack.Node<OverflowItemInternal>[]
 
   if (opts.length < 1)
     throw new Error('<Overflow> must include least of 1 <OverflowItem>.')
 
-  if (opts.some(o => o.props.type !== 'overflow-item'))
+  if (opts.some((o) => o.props.type !== 'overflow-item'))
     throw new Error('<Overflow> must contain only <OverflowItem>.')
 
   return (
@@ -50,7 +50,7 @@ export const Overflow: JSXSlack.FC<OverflowProps> = props => {
   )
 }
 
-export const OverflowItem: JSXSlack.FC<OverflowItemProps> = props => (
+export const OverflowItem: JSXSlack.FC<OverflowItemProps> = (props) => (
   <ObjectOutput<OverflowItemInternal>
     {...props}
     type="overflow-item"

--- a/src/block-kit/elements/PlainTextInput.tsx
+++ b/src/block-kit/elements/PlainTextInput.tsx
@@ -14,7 +14,7 @@ export interface PlainTextInputProps {
   minLength?: number
 }
 
-export const PlainTextInput: JSXSlack.FC<PlainTextInputProps> = props => (
+export const PlainTextInput: JSXSlack.FC<PlainTextInputProps> = (props) => (
   <ObjectOutput<SlackPlainTextInput>
     type="plain_text_input"
     action_id={props.actionId}

--- a/src/block-kit/elements/RadioButton.tsx
+++ b/src/block-kit/elements/RadioButton.tsx
@@ -59,11 +59,11 @@ const toOptionObject = (props: RadioButtonInternalProps): RadioButtonOption => {
   return option
 }
 
-export const RadioButtonGroup: JSXSlack.FC<RadioButtonGroupProps> = props => {
+export const RadioButtonGroup: JSXSlack.FC<RadioButtonGroupProps> = (props) => {
   const options = pickInternalNodes<RadioButtonInternalProps>(
     radioButtonInternal,
     props.children as JSXSlack.Children<RadioButtonInternalProps>
-  ).map(radio => toOptionObject(radio.props))
+  ).map((radio) => toOptionObject(radio.props))
 
   if (options.length === 0)
     throw new Error(
@@ -71,7 +71,7 @@ export const RadioButtonGroup: JSXSlack.FC<RadioButtonGroupProps> = props => {
     )
 
   const initialOption = props.value
-    ? options.find(o => o.value === props.value)
+    ? options.find((o) => o.value === props.value)
     : undefined
 
   const element = (
@@ -87,7 +87,7 @@ export const RadioButtonGroup: JSXSlack.FC<RadioButtonGroupProps> = props => {
   return props.label ? wrapInInput(element, props) : element
 }
 
-export const RadioButton: JSXSlack.FC<RadioButtonProps> = props => (
+export const RadioButton: JSXSlack.FC<RadioButtonProps> = (props) => (
   <ObjectOutput<RadioButtonInternalProps>
     {...props}
     type={radioButtonInternal}

--- a/src/block-kit/elements/Select.tsx
+++ b/src/block-kit/elements/Select.tsx
@@ -189,7 +189,7 @@ type SelectFragmentObject<T extends 'options' | 'option_groups'> = Required<
   Pick<StaticSelect, T>
 >
 
-export const Option: JSXSlack.FC<OptionProps> = props => (
+export const Option: JSXSlack.FC<OptionProps> = (props) => (
   <ObjectOutput<OptionInternal>
     {...props}
     type="option"
@@ -197,7 +197,7 @@ export const Option: JSXSlack.FC<OptionProps> = props => (
   />
 )
 
-export const Optgroup: JSXSlack.FC<OptgroupProps> = props => (
+export const Optgroup: JSXSlack.FC<OptgroupProps> = (props) => (
   <ObjectOutput<OptgroupInternal> {...props} type="optgroup" />
 )
 
@@ -248,7 +248,7 @@ const generateFragments = (
   return fragment
 }
 
-export const SelectFragment: JSXSlack.FC<SelectFragmentProps> = props =>
+export const SelectFragment: JSXSlack.FC<SelectFragmentProps> = (props) =>
   makeSerializableToJSON(
     (() => {
       const opts = filter(props.children)
@@ -257,7 +257,7 @@ export const SelectFragment: JSXSlack.FC<SelectFragmentProps> = props =>
         return <ObjectOutput<SelectFragmentObject<'options'>> options={[]} />
 
       const { type } = opts[0].props
-      if (!opts.every(o => o.props.type === type))
+      if (!opts.every((o) => o.props.type === type))
         throw new Error(
           'Component for selection must only include either of <Option> and <Optgroup>.'
         )
@@ -266,7 +266,7 @@ export const SelectFragment: JSXSlack.FC<SelectFragmentProps> = props =>
         case 'option':
           return (
             <ObjectOutput<SelectFragmentObject<'options'>>
-              options={(opts as JSXSlack.Node<OptionInternal>[]).map(n =>
+              options={(opts as JSXSlack.Node<OptionInternal>[]).map((n) =>
                 createOption(n.props)
               )}
             />
@@ -275,9 +275,9 @@ export const SelectFragment: JSXSlack.FC<SelectFragmentProps> = props =>
           return (
             <ObjectOutput<SelectFragmentObject<'option_groups'>>
               option_groups={
-                (opts as JSXSlack.Node<OptgroupInternal>[]).map(n => ({
+                (opts as JSXSlack.Node<OptgroupInternal>[]).map((n) => ({
                   label: plainText(n.props.label),
-                  options: filter(n.props.children).map(o =>
+                  options: filter(n.props.children).map((o) =>
                     createOption(o.props)
                   ),
                 })) as any
@@ -290,17 +290,17 @@ export const SelectFragment: JSXSlack.FC<SelectFragmentProps> = props =>
     })()
   )
 
-export const Select: JSXSlack.FC<SelectProps> = props => {
+export const Select: JSXSlack.FC<SelectProps> = (props) => {
   const fragment = generateFragments(props.children)
 
   // Find initial option(s)
   const initialOptions: SlackOption[] = []
   const opts: SlackOption[] =
     fragment.options ||
-    flattenDeep(fragment.option_groups.map(og => og.options))
+    flattenDeep(fragment.option_groups.map((og) => og.options))
 
   for (const target of wrap(props.value || [])) {
-    const found = opts.find(o => o.value === target)
+    const found = opts.find((o) => o.value === target)
     if (found) initialOptions.push(found)
   }
 
@@ -324,10 +324,10 @@ export const Select: JSXSlack.FC<SelectProps> = props => {
   return props.label ? wrapInInput(element, props) : element
 }
 
-export const ExternalSelect: JSXSlack.FC<ExternalSelectProps> = props => {
+export const ExternalSelect: JSXSlack.FC<ExternalSelectProps> = (props) => {
   const minQueryLength = coerceToInteger(props.minQueryLength)
   const initialOptions = props.initialOption
-    ? wrap(props.initialOption).map(opt =>
+    ? wrap(props.initialOption).map((opt) =>
         isNode<OptionInternal>(opt) ? createOption(opt.props) : opt
       )
     : []
@@ -351,7 +351,7 @@ export const ExternalSelect: JSXSlack.FC<ExternalSelectProps> = props => {
   return props.label ? wrapInInput(element, props) : element
 }
 
-export const UsersSelect: JSXSlack.FC<UsersSelectProps> = props => {
+export const UsersSelect: JSXSlack.FC<UsersSelectProps> = (props) => {
   const element = props.multiple ? (
     <ObjectOutput<MultiUsersSelect>
       type="multi_users_select"
@@ -369,14 +369,16 @@ export const UsersSelect: JSXSlack.FC<UsersSelectProps> = props => {
   return props.label ? wrapInInput(element, props) : element
 }
 
-export const ConversationsSelect: JSXSlack.FC<ConversationsSelectProps> = props => {
+export const ConversationsSelect: JSXSlack.FC<ConversationsSelectProps> = (
+  props
+) => {
   let filterComposition: SlackConversationsSelect['filter'] = {}
   let { include } = props
 
   if (include) {
     if (!Array.isArray(include)) include = include.split(' ') as any[]
 
-    include = [...new Set(include)].filter(o =>
+    include = [...new Set(include)].filter((o) =>
       ['im', 'mpim', 'private', 'public'].includes(o)
     )
 
@@ -417,7 +419,7 @@ export const ConversationsSelect: JSXSlack.FC<ConversationsSelectProps> = props 
   return props.label ? wrapInInput(element, props) : element
 }
 
-export const ChannelsSelect: JSXSlack.FC<ChannelsSelectProps> = props => {
+export const ChannelsSelect: JSXSlack.FC<ChannelsSelectProps> = (props) => {
   const element = props.multiple ? (
     <ObjectOutput<MultiChannelsSelect>
       type="multi_channels_select"

--- a/src/html.tsx
+++ b/src/html.tsx
@@ -52,10 +52,7 @@ export const escapeChars = (
     .join('')
 
 export const escapeEntity = (str: string) =>
-  str
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
+  str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
 
 export const buildAttr = (
   props: { [key: string]: any },
@@ -75,8 +72,9 @@ export const buildAttr = (
   return attr
 }
 
-export const Escape: JSXSlack.FC<{ children: JSXSlack.Children<{}> }> = props =>
-  JSXSlack.h(JSXSlack.NodeType.escapeInHtml, props)
+export const Escape: JSXSlack.FC<{ children: JSXSlack.Children<{}> }> = (
+  props
+) => JSXSlack.h(JSXSlack.NodeType.escapeInHtml, props)
 
 export default function html(children: JSXSlack.Children<{}>) {
   return JSXSlack(<Html>{children}</Html>)

--- a/src/jsx.ts
+++ b/src/jsx.ts
@@ -150,8 +150,8 @@ export namespace JSXSlack {
   // Remove conditional value from children
   export const normalizeChildren = (cr: Children<any>): (Node | string)[] =>
     flattenDeep(wrap(cr))
-      .filter(c => c != null && c !== false && c !== true)
-      .map(c => (typeof c !== 'object' ? c.toString() : c))
+      .filter((c) => c != null && c !== false && c !== true)
+      .map((c) => (typeof c !== 'object' ? c.toString() : c))
 
   export namespace JSX {
     // eslint-disable-next-line @typescript-eslint/no-empty-interface

--- a/src/legacy/jsx.ts
+++ b/src/legacy/jsx.ts
@@ -14,10 +14,11 @@ const legacyJsxToHtml = (
   const text = () => children.join('')
 
   const isChild = (...elements: string[]) =>
-    parents.length > 0 && elements.some(e => e === parents[parents.length - 1])
+    parents.length > 0 &&
+    elements.some((e) => e === parents[parents.length - 1])
 
   const isDescendant = (...elements: string[]) =>
-    elements.some(e => parents.includes(e))
+    elements.some((e) => parents.includes(e))
 
   if (name === 'br') return '<br />'
   if (isChild('pre', 'code') && !['a', 'time'].includes(name)) return text()

--- a/src/legacy/turndown.ts
+++ b/src/legacy/turndown.ts
@@ -54,7 +54,7 @@ const turndownService = () => {
         breaks = ['', '\n']
         processed = processed
           .split('\n')
-          .map(l => `<<list-indent:${elmUniqId()}>>${l}`)
+          .map((l) => `<<list-indent:${elmUniqId()}>>${l}`)
           .join('\n')
       }
     }

--- a/src/mrkdwn/index.ts
+++ b/src/mrkdwn/index.ts
@@ -13,7 +13,7 @@ const list = (h, node) => {
   const start = ordered ? Number.parseInt(node.properties.start ?? 1, 10) : null
 
   // Mark implied list item
-  const children = h.handlers.span(h, node).map(item => {
+  const children = h.handlers.span(h, node).map((item) => {
     if (item.type !== 'listItem')
       return { type: 'listItem', data: { implied: true }, children: [item] }
 
@@ -29,7 +29,7 @@ const mrkdwn = (html: string) =>
       document: false,
       handlers: {
         root: (h, node) => {
-          visit(node, n => {
+          visit(node, (n) => {
             // eslint-disable-next-line no-param-reassign
             if (n.type === 'text') n.value = decodeEntity(n.value)
           })

--- a/src/mrkdwn/jsx.ts
+++ b/src/mrkdwn/jsx.ts
@@ -14,9 +14,9 @@ const replaceUnmatchedString = (
     .join('')
 
 const escapeEverythingContents = (str: string) =>
-  replaceUnmatchedString(str, /(<[\s\S]*?>)/, s =>
-    replaceUnmatchedString(s, /(&\w+;)/, ss =>
-      [...ss].map(x => `&#${x.codePointAt(0)};`)
+  replaceUnmatchedString(str, /(<[\s\S]*?>)/, (s) =>
+    replaceUnmatchedString(s, /(&\w+;)/, (ss) =>
+      [...ss].map((x) => `&#${x.codePointAt(0)};`)
     )
   )
 
@@ -31,10 +31,11 @@ const jsxToHtml = (
   const text = () => children.join('')
 
   const isChild = (...elements: string[]) =>
-    parents.length > 0 && elements.some(e => e === parents[parents.length - 1])
+    parents.length > 0 &&
+    elements.some((e) => e === parents[parents.length - 1])
 
   const isDescendant = (...elements: string[]) =>
-    elements.some(e => parents.includes(e))
+    elements.some((e) => parents.includes(e))
 
   if (name === 'br') return '<br />'
   if (isChild('pre', 'code') && !['a', 'time'].includes(name)) return text()

--- a/src/mrkdwn/measure.ts
+++ b/src/mrkdwn/measure.ts
@@ -18,7 +18,7 @@ export function makeIndent(width: number): string {
     indent = ''
     let targetWidth = width
 
-    spaceWidth.forEach(w => {
+    spaceWidth.forEach((w) => {
       const num = Math.floor(targetWidth / w)
       if (num > 0) indent += flippedSpaces[w].repeat(num)
 

--- a/src/mrkdwn/parser.ts
+++ b/src/mrkdwn/parser.ts
@@ -1,6 +1,6 @@
 import htm from 'htm/mini'
 
-export const decodeEntity = obj => {
+export const decodeEntity = (obj) => {
   if (typeof obj === 'string')
     return obj.replace(/&(amp|gt|lt|quot|#\d+);/g, (_, entity: string) => {
       if (entity.startsWith('#'))
@@ -17,7 +17,7 @@ export const decodeEntity = obj => {
 const decodeForMdast = (text: string): string =>
   text
     .replace(/&/g, '&amp;')
-    .replace(/(?![\t\n\r ])\s/g, sp => `&#${sp.codePointAt(0)};`)
+    .replace(/(?![\t\n\r ])\s/g, (sp) => `&#${sp.codePointAt(0)};`)
 
 const html2hastLight = htm.bind<any>((tagName, props, ...children) => {
   const hast = {

--- a/src/tag.ts
+++ b/src/tag.ts
@@ -45,7 +45,7 @@ const firstPass: JSXSlackTemplate<VirtualNode | VirtualNode[]> = htm.bind(
           {}
         )
       : props,
-    children: flattenDeep(children.map(c => normalize(c))),
+    children: flattenDeep(children.map((c) => normalize(c))),
   })
 )
 
@@ -60,7 +60,7 @@ const render = (parsed: unknown) => {
     )
       type = blockKitComponents[type]
 
-    return JSXSlack.h(type, node.props, ...node.children.map(c => render(c)))
+    return JSXSlack.h(type, node.props, ...node.children.map((c) => render(c)))
   }
   return parsed
 }
@@ -68,7 +68,7 @@ const render = (parsed: unknown) => {
 const parse = (template: TemplateStringsArray, ...substitutions: any[]) => {
   const parsed = firstPass(
     template,
-    ...substitutions.map(s =>
+    ...substitutions.map((s) =>
       typeof s === 'string'
         ? Object.defineProperty(new String(s), stringSubsitutionSymbol, {
             value: true,
@@ -77,7 +77,7 @@ const parse = (template: TemplateStringsArray, ...substitutions: any[]) => {
     )
   )
 
-  return Array.isArray(parsed) ? parsed.map(p => render(p)) : render(parsed)
+  return Array.isArray(parsed) ? parsed.map((p) => render(p)) : render(parsed)
 }
 
 const jsxslack: JSXSlackTemplateTag = Object.defineProperties(

--- a/test/block-kit/block-elements/input-components-for-modal.tsx
+++ b/test/block-kit/block-elements/input-components-for-modal.tsx
@@ -25,7 +25,7 @@ beforeEach(() => JSXSlack.exactMode(false))
 describe('Input components for modal', () => {
   it('wraps input-compatible block elements in <Input> block when passed label prop', () => {
     for (const Compatible of [
-      props => (
+      (props) => (
         <Select {...props}>
           <Option value="test">test</Option>
         </Select>
@@ -35,12 +35,12 @@ describe('Input components for modal', () => {
       ConversationsSelect,
       UsersSelect,
       DatePicker,
-      props => (
+      (props) => (
         <RadioButtonGroup {...props}>
           <RadioButton value="test">test</RadioButton>
         </RadioButtonGroup>
       ),
-      props => (
+      (props) => (
         <CheckboxGroup {...props}>
           <Checkbox value="test">test</Checkbox>
         </CheckboxGroup>
@@ -152,7 +152,7 @@ describe('Input components for modal', () => {
 
     it('can customize private metadata transformer for assigned hidden values', () => {
       const transformer = jest.fn(
-        hidden => hidden && new URLSearchParams(hidden).toString()
+        (hidden) => hidden && new URLSearchParams(hidden).toString()
       )
 
       expect(

--- a/test/block-kit/block-elements/interactive-components.tsx
+++ b/test/block-kit/block-elements/interactive-components.tsx
@@ -1163,7 +1163,7 @@ describe('Interactive components', () => {
       </Home>
     ).blocks
 
-    const values = section.accessory.initial_options.map(opt => opt.value)
+    const values = section.accessory.initial_options.map((opt) => opt.value)
     expect(values).toStrictEqual(['b', 'c'])
   })
 })

--- a/test/block-kit/layout-blocks.tsx
+++ b/test/block-kit/layout-blocks.tsx
@@ -192,7 +192,7 @@ describe('Layout blocks', () => {
         expect(ms.accessory.type.startsWith('multi_')).toBe(true)
         expect(ms.accessory.max_selected_items).toBe(2)
 
-        const initialKey: any = Object.keys(ms.accessory).find(k =>
+        const initialKey: any = Object.keys(ms.accessory).find((k) =>
           k.startsWith('initial_')
         )
         expect(ms.accessory[initialKey]).toHaveLength(1)

--- a/test/tag.tsx
+++ b/test/tag.tsx
@@ -164,7 +164,7 @@ describe('Tagged template', () => {
 
   describe('jsxslack.raw', () => {
     it('always returns raw node(s) for reusable as component', () => {
-      const func = title => jsxslack.raw`
+      const func = (title) => jsxslack.raw`
         <Section><b>${title}</b></Section>
         <Divider />
       `
@@ -204,7 +204,7 @@ describe('Tagged template', () => {
 
   describe('[DEPRECATED] jsxslack.fragment', () => {
     it('always returns raw node(s) for reusable as component', () => {
-      const func = title => jsxslack.fragment`
+      const func = (title) => jsxslack.fragment`
         <Section><b>${title}</b></Section>
         <Divider />
       `

--- a/tools/measure-font.js
+++ b/tools/measure-font.js
@@ -34,7 +34,7 @@ const saveTo = path.resolve(__dirname, '../src/data/font-width.json')
   await browser.close()
 
   return measuredData
-})().then(data => {
+})().then((data) => {
   fs.mkdirSync(path.dirname(saveTo), { recursive: true })
   fs.writeFileSync(saveTo, JSON.stringify(data, null, 2))
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,42 +9,43 @@
   dependencies:
     "@babel/highlight" "^7.8.3"
 
-"@babel/compat-data@^7.8.6":
-  version "7.8.6"
-  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.8.6.tgz#7eeaa0dfa17e50c7d9c0832515eee09b56f04e35"
-  integrity sha512-CurCIKPTkS25Mb8mz267vU95vy+TyUpnctEX2lV33xWNmHAfjruztgiPBbXZRh3xZZy1CYvGx6XfxyTVS+sk7Q==
+"@babel/compat-data@^7.8.6", "@babel/compat-data@^7.9.0":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.9.0.tgz#04815556fc90b0c174abd2c0c1bb966faa036a6c"
+  integrity sha512-zeFQrr+284Ekvd9e7KAX954LkapWiOmQtsfHirhxqfdlX6MEC32iRE+pqUGlYIBchdevaCwvzxWGSy/YBNI85g==
   dependencies:
-    browserslist "^4.8.5"
+    browserslist "^4.9.1"
     invariant "^2.2.4"
     semver "^5.5.0"
 
 "@babel/core@^7.1.0", "@babel/core@^7.4.4", "@babel/core@^7.7.5":
-  version "7.8.7"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.8.7.tgz#b69017d221ccdeb203145ae9da269d72cf102f3b"
-  integrity sha512-rBlqF3Yko9cynC5CCFy6+K/w2N+Sq/ff2BPy+Krp7rHlABIr5epbA7OxVeKoMHB39LZOp1UY5SuLjy6uWi35yA==
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.9.0.tgz#ac977b538b77e132ff706f3b8a4dbad09c03c56e"
+  integrity sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==
   dependencies:
     "@babel/code-frame" "^7.8.3"
-    "@babel/generator" "^7.8.7"
-    "@babel/helpers" "^7.8.4"
-    "@babel/parser" "^7.8.7"
+    "@babel/generator" "^7.9.0"
+    "@babel/helper-module-transforms" "^7.9.0"
+    "@babel/helpers" "^7.9.0"
+    "@babel/parser" "^7.9.0"
     "@babel/template" "^7.8.6"
-    "@babel/traverse" "^7.8.6"
-    "@babel/types" "^7.8.7"
+    "@babel/traverse" "^7.9.0"
+    "@babel/types" "^7.9.0"
     convert-source-map "^1.7.0"
     debug "^4.1.0"
     gensync "^1.0.0-beta.1"
-    json5 "^2.1.0"
+    json5 "^2.1.2"
     lodash "^4.17.13"
     resolve "^1.3.2"
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/generator@^7.4.4", "@babel/generator@^7.8.6", "@babel/generator@^7.8.7":
-  version "7.8.8"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.8.8.tgz#cdcd58caab730834cee9eeadb729e833b625da3e"
-  integrity sha512-HKyUVu69cZoclptr8t8U5b6sx6zoWjh8jiUhnuj3MpZuKT2dJ8zPTuiy31luq32swhI0SpwItCIlU8XW7BZeJg==
+"@babel/generator@^7.4.4", "@babel/generator@^7.9.0":
+  version "7.9.3"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.9.3.tgz#7c8b2956c6f68b3ab732bd16305916fbba521d94"
+  integrity sha512-RpxM252EYsz9qLUIq6F7YJyK1sv0wWDBFuztfDGWaQKzHjqDHysxSiRUpA/X9jmfqo+WzkAVKFaUily5h+gDCQ==
   dependencies:
-    "@babel/types" "^7.8.7"
+    "@babel/types" "^7.9.0"
     jsesc "^2.5.1"
     lodash "^4.17.13"
     source-map "^0.5.0"
@@ -64,22 +65,22 @@
     "@babel/helper-explode-assignable-expression" "^7.8.3"
     "@babel/types" "^7.8.3"
 
-"@babel/helper-builder-react-jsx@^7.8.3":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.8.3.tgz#dee98d7d79cc1f003d80b76fe01c7f8945665ff6"
-  integrity sha512-JT8mfnpTkKNCboTqZsQTdGo3l3Ik3l7QIt9hh0O9DYiwVel37VoJpILKM4YFbP2euF32nkQSb+F9cUk9b7DDXQ==
+"@babel/helper-builder-react-jsx-experimental@^7.9.0":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-builder-react-jsx-experimental/-/helper-builder-react-jsx-experimental-7.9.0.tgz#066d80262ade488f9c1b1823ce5db88a4cedaa43"
+  integrity sha512-3xJEiyuYU4Q/Ar9BsHisgdxZsRlsShMe90URZ0e6przL26CCs8NJbDoxH94kKT17PcxlMhsCAwZd90evCo26VQ==
   dependencies:
-    "@babel/types" "^7.8.3"
-    esutils "^2.0.0"
+    "@babel/helper-annotate-as-pure" "^7.8.3"
+    "@babel/helper-module-imports" "^7.8.3"
+    "@babel/types" "^7.9.0"
 
-"@babel/helper-call-delegate@^7.8.7":
-  version "7.8.7"
-  resolved "https://registry.yarnpkg.com/@babel/helper-call-delegate/-/helper-call-delegate-7.8.7.tgz#28a279c2e6c622a6233da548127f980751324cab"
-  integrity sha512-doAA5LAKhsFCR0LAFIf+r2RSMmC+m8f/oQ+URnUET/rWeEzC0yTRmAGyWkD4sSu3xwbS7MYQ2u+xlt1V5R56KQ==
+"@babel/helper-builder-react-jsx@^7.9.0":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.9.0.tgz#16bf391990b57732700a3278d4d9a81231ea8d32"
+  integrity sha512-weiIo4gaoGgnhff54GQ3P5wsUQmnSwpkvU0r6ZHq6TzoSzKy4JxHEgnxNytaKbov2a9z/CVNyzliuCOUPEX3Jw==
   dependencies:
-    "@babel/helper-hoist-variables" "^7.8.3"
-    "@babel/traverse" "^7.8.3"
-    "@babel/types" "^7.8.7"
+    "@babel/helper-annotate-as-pure" "^7.8.3"
+    "@babel/types" "^7.9.0"
 
 "@babel/helper-compilation-targets@^7.8.7":
   version "7.8.7"
@@ -155,17 +156,17 @@
   dependencies:
     "@babel/types" "^7.8.3"
 
-"@babel/helper-module-transforms@^7.8.3":
-  version "7.8.6"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.8.6.tgz#6a13b5eecadc35692047073a64e42977b97654a4"
-  integrity sha512-RDnGJSR5EFBJjG3deY0NiL0K9TO8SXxS9n/MPsbPK/s9LbQymuLNtlzvDiNS7IpecuL45cMeLVkA+HfmlrnkRg==
+"@babel/helper-module-transforms@^7.9.0":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.9.0.tgz#43b34dfe15961918707d247327431388e9fe96e5"
+  integrity sha512-0FvKyu0gpPfIQ8EkxlrAydOWROdHpBmiCiRwLkUiBGhCUPRRbVD2/tm3sFr/c/GWFrQ/ffutGUAnx7V0FzT2wA==
   dependencies:
     "@babel/helper-module-imports" "^7.8.3"
     "@babel/helper-replace-supers" "^7.8.6"
     "@babel/helper-simple-access" "^7.8.3"
     "@babel/helper-split-export-declaration" "^7.8.3"
     "@babel/template" "^7.8.6"
-    "@babel/types" "^7.8.6"
+    "@babel/types" "^7.9.0"
     lodash "^4.17.13"
 
 "@babel/helper-optimise-call-expression@^7.8.3":
@@ -223,6 +224,11 @@
   dependencies:
     "@babel/types" "^7.8.3"
 
+"@babel/helper-validator-identifier@^7.9.0":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.0.tgz#ad53562a7fc29b3b9a91bbf7d10397fd146346ed"
+  integrity sha512-6G8bQKjOh+of4PV/ThDm/rRqlU7+IGoJuofpagU5GlEl29Vv0RGqqt86ZGRV8ZuSOY3o+8yXl5y782SMcG7SHw==
+
 "@babel/helper-wrap-function@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-wrap-function/-/helper-wrap-function-7.8.3.tgz#9dbdb2bb55ef14aaa01fe8c99b629bd5352d8610"
@@ -233,28 +239,28 @@
     "@babel/traverse" "^7.8.3"
     "@babel/types" "^7.8.3"
 
-"@babel/helpers@^7.8.4":
-  version "7.8.4"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.8.4.tgz#754eb3ee727c165e0a240d6c207de7c455f36f73"
-  integrity sha512-VPbe7wcQ4chu4TDQjimHv/5tj73qz88o12EPkO2ValS2QiQS/1F2SsjyIGNnAD0vF/nZS6Cf9i+vW6HIlnaR8w==
+"@babel/helpers@^7.9.0":
+  version "7.9.2"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.9.2.tgz#b42a81a811f1e7313b88cba8adc66b3d9ae6c09f"
+  integrity sha512-JwLvzlXVPjO8eU9c/wF9/zOIN7X6h8DYf7mG4CiFRZRvZNKEF5dQ3H3V+ASkHoIB3mWhatgl5ONhyqHRI6MppA==
   dependencies:
     "@babel/template" "^7.8.3"
-    "@babel/traverse" "^7.8.4"
-    "@babel/types" "^7.8.3"
+    "@babel/traverse" "^7.9.0"
+    "@babel/types" "^7.9.0"
 
 "@babel/highlight@^7.8.3":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.8.3.tgz#28f173d04223eaaa59bc1d439a3836e6d1265797"
-  integrity sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.9.0.tgz#4e9b45ccb82b79607271b2979ad82c7b68163079"
+  integrity sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==
   dependencies:
+    "@babel/helper-validator-identifier" "^7.9.0"
     chalk "^2.0.0"
-    esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.4.4", "@babel/parser@^7.7.5", "@babel/parser@^7.8.6", "@babel/parser@^7.8.7":
-  version "7.8.8"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.8.8.tgz#4c3b7ce36db37e0629be1f0d50a571d2f86f6cd4"
-  integrity sha512-mO5GWzBPsPf6865iIbzNE0AvkKF3NE+2S3eRUpE+FE07BOAkXh6G+GW/Pj01hhXjve1WScbaIO4UlY1JKeqCcA==
+"@babel/parser@^7.1.0", "@babel/parser@^7.4.4", "@babel/parser@^7.7.5", "@babel/parser@^7.8.6", "@babel/parser@^7.9.0":
+  version "7.9.3"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.9.3.tgz#043a5fc2ad8b7ea9facddc4e802a1f0f25da7255"
+  integrity sha512-E6SpIDJZ0cZAKoCNk+qSDd0ChfTnpiJN9FfNf3RZ20dzwA2vL2oq5IX1XTVT+4vDmRlta2nGk5HGMMskJAR+4A==
 
 "@babel/plugin-proposal-async-generator-functions@^7.8.3":
   version "7.8.3"
@@ -289,10 +295,18 @@
     "@babel/helper-plugin-utils" "^7.8.3"
     "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.0"
 
-"@babel/plugin-proposal-object-rest-spread@^7.8.3":
+"@babel/plugin-proposal-numeric-separator@^7.8.3":
   version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.8.3.tgz#eb5ae366118ddca67bed583b53d7554cad9951bb"
-  integrity sha512-8qvuPwU/xxUCt78HocNlv0mXXo0wdh9VT1R04WU8HGOfaOob26pF+9P5/lYjN/q7DHOX1bvX60hnhOvuQUJdbA==
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.8.3.tgz#5d6769409699ec9b3b68684cd8116cedff93bad8"
+  integrity sha512-jWioO1s6R/R+wEHizfaScNsAx+xKgwTLNXSh7tTC4Usj3ItsPEhYkEpU4h+lpnBwq7NBVOJXfO6cRFYcX69JUQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.3"
+    "@babel/plugin-syntax-numeric-separator" "^7.8.3"
+
+"@babel/plugin-proposal-object-rest-spread@^7.9.0":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.9.0.tgz#a28993699fc13df165995362693962ba6b061d6f"
+  integrity sha512-UgqBv6bjq4fDb8uku9f+wcm1J7YxJ5nT7WO/jBr0cl0PLKb7t1O6RNR1kZbjgx2LQtsDI9hwoQVmn0yhXeQyow==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
     "@babel/plugin-syntax-object-rest-spread" "^7.8.0"
@@ -305,15 +319,15 @@
     "@babel/helper-plugin-utils" "^7.8.3"
     "@babel/plugin-syntax-optional-catch-binding" "^7.8.0"
 
-"@babel/plugin-proposal-optional-chaining@^7.8.3":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.8.3.tgz#ae10b3214cb25f7adb1f3bc87ba42ca10b7e2543"
-  integrity sha512-QIoIR9abkVn+seDE3OjA08jWcs3eZ9+wJCKSRgo3WdEU2csFYgdScb+8qHB3+WXsGJD55u+5hWCISI7ejXS+kg==
+"@babel/plugin-proposal-optional-chaining@^7.9.0":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.9.0.tgz#31db16b154c39d6b8a645292472b98394c292a58"
+  integrity sha512-NDn5tu3tcv4W30jNhmc2hyD5c56G6cXx4TesJubhxrJeCvuuMpttxr0OnNCqbZGhFjLrg+NIhxxC+BK5F6yS3w==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
     "@babel/plugin-syntax-optional-chaining" "^7.8.0"
 
-"@babel/plugin-proposal-unicode-property-regex@^7.8.3":
+"@babel/plugin-proposal-unicode-property-regex@^7.4.4", "@babel/plugin-proposal-unicode-property-regex@^7.8.3":
   version "7.8.8"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.8.8.tgz#ee3a95e90cdc04fe8cd92ec3279fa017d68a0d1d"
   integrity sha512-EVhjVsMpbhLw9ZfHWSx2iy13Q8Z/eg8e8ccVWt23sWQK5l1UdkoLJPN5w69UA4uITGBnEZD2JOe4QOHycYKv8A==
@@ -369,6 +383,13 @@
   integrity sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
+
+"@babel/plugin-syntax-numeric-separator@^7.8.0", "@babel/plugin-syntax-numeric-separator@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.8.3.tgz#0e3fb63e09bea1b11e96467271c8308007e7c41f"
+  integrity sha512-H7dCMAdN83PcCmqmkHB5dtp+Xa9a6LKSvA2hiFBC/5alSHxM5VgWZXFqDi0YFe8XNGT6iCa+z4V4zSt/PdZ7Dw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.3"
 
 "@babel/plugin-syntax-object-rest-spread@^7.0.0", "@babel/plugin-syntax-object-rest-spread@^7.8.0":
   version "7.8.3"
@@ -429,10 +450,10 @@
     "@babel/helper-plugin-utils" "^7.8.3"
     lodash "^4.17.13"
 
-"@babel/plugin-transform-classes@^7.8.6":
-  version "7.8.6"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-classes/-/plugin-transform-classes-7.8.6.tgz#77534447a477cbe5995ae4aee3e39fbc8090c46d"
-  integrity sha512-k9r8qRay/R6v5aWZkrEclEhKO6mc1CCQr2dLsVHBmOQiMpN6I2bpjX3vgnldUWeEI1GHVNByULVxZ4BdP4Hmdg==
+"@babel/plugin-transform-classes@^7.9.0":
+  version "7.9.2"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-classes/-/plugin-transform-classes-7.9.2.tgz#8603fc3cc449e31fdbdbc257f67717536a11af8d"
+  integrity sha512-TC2p3bPzsfvSsqBZo0kJnuelnoK9O3welkUpqSqBQuBF6R5MN2rysopri8kNvtlGIb2jmUO7i15IooAZJjZuMQ==
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.8.3"
     "@babel/helper-define-map" "^7.8.3"
@@ -457,7 +478,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
 
-"@babel/plugin-transform-dotall-regex@^7.8.3":
+"@babel/plugin-transform-dotall-regex@^7.4.4", "@babel/plugin-transform-dotall-regex@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.8.3.tgz#c3c6ec5ee6125c6993c5cbca20dc8621a9ea7a6e"
   integrity sha512-kLs1j9Nn4MQoBYdRXH6AeaXMbEJFaFu/v1nQkvib6QzTj8MZI5OQzqmD83/2jEM1z0DLilra5aWO5YpyC0ALIw==
@@ -481,17 +502,17 @@
     "@babel/helper-plugin-utils" "^7.8.3"
 
 "@babel/plugin-transform-flow-strip-types@^7.4.4":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.8.3.tgz#da705a655466b2a9b36046b57bf0cbcd53551bd4"
-  integrity sha512-g/6WTWG/xbdd2exBBzMfygjX/zw4eyNC4X8pRaq7aRHRoDUCzAIu3kGYIXviOv8BjCuWm8vDBwjHcjiRNgXrPA==
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.9.0.tgz#8a3538aa40434e000b8f44a3c5c9ac7229bd2392"
+  integrity sha512-7Qfg0lKQhEHs93FChxVLAvhBshOPQDtJUTVHr/ZwQNRccCm4O9D79r9tVSoV8iNwjP1YgfD+e/fgHcPkN1qEQg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
     "@babel/plugin-syntax-flow" "^7.8.3"
 
-"@babel/plugin-transform-for-of@^7.8.6":
-  version "7.8.6"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.8.6.tgz#a051bd1b402c61af97a27ff51b468321c7c2a085"
-  integrity sha512-M0pw4/1/KI5WAxPsdcUL/w2LJ7o89YHN3yLkzNjg7Yl15GlVGgzHyCU+FMeAxevHGsLVmUqbirlUIKTafPmzdw==
+"@babel/plugin-transform-for-of@^7.9.0":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.9.0.tgz#0f260e27d3e29cd1bb3128da5e76c761aa6c108e"
+  integrity sha512-lTAnWOpMwOXpyDx06N+ywmF3jNbafZEqZ96CGYabxHrxNX8l5ny7dt4bK/rGwAh9utyP2b2Hv7PlZh1AAS54FQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
 
@@ -517,41 +538,41 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
 
-"@babel/plugin-transform-modules-amd@^7.8.3":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.8.3.tgz#65606d44616b50225e76f5578f33c568a0b876a5"
-  integrity sha512-MadJiU3rLKclzT5kBH4yxdry96odTUwuqrZM+GllFI/VhxfPz+k9MshJM+MwhfkCdxxclSbSBbUGciBngR+kEQ==
+"@babel/plugin-transform-modules-amd@^7.9.0":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.9.0.tgz#19755ee721912cf5bb04c07d50280af3484efef4"
+  integrity sha512-vZgDDF003B14O8zJy0XXLnPH4sg+9X5hFBBGN1V+B2rgrB+J2xIypSN6Rk9imB2hSTHQi5OHLrFWsZab1GMk+Q==
   dependencies:
-    "@babel/helper-module-transforms" "^7.8.3"
+    "@babel/helper-module-transforms" "^7.9.0"
     "@babel/helper-plugin-utils" "^7.8.3"
     babel-plugin-dynamic-import-node "^2.3.0"
 
-"@babel/plugin-transform-modules-commonjs@^7.4.4", "@babel/plugin-transform-modules-commonjs@^7.8.3":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.8.3.tgz#df251706ec331bd058a34bdd72613915f82928a5"
-  integrity sha512-JpdMEfA15HZ/1gNuB9XEDlZM1h/gF/YOH7zaZzQu2xCFRfwc01NXBMHHSTT6hRjlXJJs5x/bfODM3LiCk94Sxg==
+"@babel/plugin-transform-modules-commonjs@^7.4.4", "@babel/plugin-transform-modules-commonjs@^7.9.0":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.9.0.tgz#e3e72f4cbc9b4a260e30be0ea59bdf5a39748940"
+  integrity sha512-qzlCrLnKqio4SlgJ6FMMLBe4bySNis8DFn1VkGmOcxG9gqEyPIOzeQrA//u0HAKrWpJlpZbZMPB1n/OPa4+n8g==
   dependencies:
-    "@babel/helper-module-transforms" "^7.8.3"
+    "@babel/helper-module-transforms" "^7.9.0"
     "@babel/helper-plugin-utils" "^7.8.3"
     "@babel/helper-simple-access" "^7.8.3"
     babel-plugin-dynamic-import-node "^2.3.0"
 
-"@babel/plugin-transform-modules-systemjs@^7.8.3":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.8.3.tgz#d8bbf222c1dbe3661f440f2f00c16e9bb7d0d420"
-  integrity sha512-8cESMCJjmArMYqa9AO5YuMEkE4ds28tMpZcGZB/jl3n0ZzlsxOAi3mC+SKypTfT8gjMupCnd3YiXCkMjj2jfOg==
+"@babel/plugin-transform-modules-systemjs@^7.9.0":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.9.0.tgz#e9fd46a296fc91e009b64e07ddaa86d6f0edeb90"
+  integrity sha512-FsiAv/nao/ud2ZWy4wFacoLOm5uxl0ExSQ7ErvP7jpoihLR6Cq90ilOFyX9UXct3rbtKsAiZ9kFt5XGfPe/5SQ==
   dependencies:
     "@babel/helper-hoist-variables" "^7.8.3"
-    "@babel/helper-module-transforms" "^7.8.3"
+    "@babel/helper-module-transforms" "^7.9.0"
     "@babel/helper-plugin-utils" "^7.8.3"
     babel-plugin-dynamic-import-node "^2.3.0"
 
-"@babel/plugin-transform-modules-umd@^7.8.3":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.8.3.tgz#592d578ce06c52f5b98b02f913d653ffe972661a"
-  integrity sha512-evhTyWhbwbI3/U6dZAnx/ePoV7H6OUG+OjiJFHmhr9FPn0VShjwC2kdxqIuQ/+1P50TMrneGzMeyMTFOjKSnAw==
+"@babel/plugin-transform-modules-umd@^7.9.0":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.9.0.tgz#e909acae276fec280f9b821a5f38e1f08b480697"
+  integrity sha512-uTWkXkIVtg/JGRSIABdBoMsoIeoHQHPTL0Y2E7xf5Oj7sLqwVsNXOkNk0VJc7vF0IMBsPeikHxFjGe+qmwPtTQ==
   dependencies:
-    "@babel/helper-module-transforms" "^7.8.3"
+    "@babel/helper-module-transforms" "^7.9.0"
     "@babel/helper-plugin-utils" "^7.8.3"
 
 "@babel/plugin-transform-named-capturing-groups-regex@^7.8.3":
@@ -577,11 +598,10 @@
     "@babel/helper-replace-supers" "^7.8.3"
 
 "@babel/plugin-transform-parameters@^7.8.7":
-  version "7.8.8"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.8.8.tgz#0381de466c85d5404565243660c4496459525daf"
-  integrity sha512-hC4Ld/Ulpf1psQciWWwdnUspQoQco2bMzSrwU6TmzRlvoYQe4rQFy9vnCZDTlVeCQj0JPfL+1RX0V8hCJvkgBA==
+  version "7.9.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.9.3.tgz#3028d0cc20ddc733166c6e9c8534559cee09f54a"
+  integrity sha512-fzrQFQhp7mIhOzmOtPiKffvCYQSK10NR8t6BBz2yPbeUHb9OLW8RZGtgDRBn8z2hGcwvKDL3vC7ojPTLNxmqEg==
   dependencies:
-    "@babel/helper-call-delegate" "^7.8.7"
     "@babel/helper-get-function-arity" "^7.8.3"
     "@babel/helper-plugin-utils" "^7.8.3"
 
@@ -593,11 +613,12 @@
     "@babel/helper-plugin-utils" "^7.8.3"
 
 "@babel/plugin-transform-react-jsx@^7.0.0":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.8.3.tgz#4220349c0390fdefa505365f68c103562ab2fc4a"
-  integrity sha512-r0h+mUiyL595ikykci+fbwm9YzmuOrUBi0b+FDIKmi3fPQyFokWVEMJnRWHJPPQEjyFJyna9WZC6Viv6UHSv1g==
+  version "7.9.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.9.1.tgz#d03af29396a6dc51bfa24eefd8005a9fd381152a"
+  integrity sha512-+xIZ6fPoix7h57CNO/ZeYADchg1tFyX9NDsnmNFFua8e1JNPln156mzS+8AQe1On2X2GLlANHJWHIXbMCqWDkQ==
   dependencies:
-    "@babel/helper-builder-react-jsx" "^7.8.3"
+    "@babel/helper-builder-react-jsx" "^7.9.0"
+    "@babel/helper-builder-react-jsx-experimental" "^7.9.0"
     "@babel/helper-plugin-utils" "^7.8.3"
     "@babel/plugin-syntax-jsx" "^7.8.3"
 
@@ -661,11 +682,11 @@
     "@babel/helper-plugin-utils" "^7.8.3"
 
 "@babel/preset-env@^7.4.4":
-  version "7.8.7"
-  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.8.7.tgz#1fc7d89c7f75d2d70c2b6768de6c2e049b3cb9db"
-  integrity sha512-BYftCVOdAYJk5ASsznKAUl53EMhfBbr8CJ1X+AJLfGPscQkwJFiaV/Wn9DPH/7fzm2v6iRYJKYHSqyynTGw0nw==
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.9.0.tgz#a5fc42480e950ae8f5d9f8f2bbc03f52722df3a8"
+  integrity sha512-712DeRXT6dyKAM/FMbQTV/FvRCms2hPCx+3weRjZ8iQVQWZejWWk1wwG6ViWMyqb/ouBbGOl5b6aCk0+j1NmsQ==
   dependencies:
-    "@babel/compat-data" "^7.8.6"
+    "@babel/compat-data" "^7.9.0"
     "@babel/helper-compilation-targets" "^7.8.7"
     "@babel/helper-module-imports" "^7.8.3"
     "@babel/helper-plugin-utils" "^7.8.3"
@@ -673,14 +694,16 @@
     "@babel/plugin-proposal-dynamic-import" "^7.8.3"
     "@babel/plugin-proposal-json-strings" "^7.8.3"
     "@babel/plugin-proposal-nullish-coalescing-operator" "^7.8.3"
-    "@babel/plugin-proposal-object-rest-spread" "^7.8.3"
+    "@babel/plugin-proposal-numeric-separator" "^7.8.3"
+    "@babel/plugin-proposal-object-rest-spread" "^7.9.0"
     "@babel/plugin-proposal-optional-catch-binding" "^7.8.3"
-    "@babel/plugin-proposal-optional-chaining" "^7.8.3"
+    "@babel/plugin-proposal-optional-chaining" "^7.9.0"
     "@babel/plugin-proposal-unicode-property-regex" "^7.8.3"
     "@babel/plugin-syntax-async-generators" "^7.8.0"
     "@babel/plugin-syntax-dynamic-import" "^7.8.0"
     "@babel/plugin-syntax-json-strings" "^7.8.0"
     "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.0"
+    "@babel/plugin-syntax-numeric-separator" "^7.8.0"
     "@babel/plugin-syntax-object-rest-spread" "^7.8.0"
     "@babel/plugin-syntax-optional-catch-binding" "^7.8.0"
     "@babel/plugin-syntax-optional-chaining" "^7.8.0"
@@ -689,20 +712,20 @@
     "@babel/plugin-transform-async-to-generator" "^7.8.3"
     "@babel/plugin-transform-block-scoped-functions" "^7.8.3"
     "@babel/plugin-transform-block-scoping" "^7.8.3"
-    "@babel/plugin-transform-classes" "^7.8.6"
+    "@babel/plugin-transform-classes" "^7.9.0"
     "@babel/plugin-transform-computed-properties" "^7.8.3"
     "@babel/plugin-transform-destructuring" "^7.8.3"
     "@babel/plugin-transform-dotall-regex" "^7.8.3"
     "@babel/plugin-transform-duplicate-keys" "^7.8.3"
     "@babel/plugin-transform-exponentiation-operator" "^7.8.3"
-    "@babel/plugin-transform-for-of" "^7.8.6"
+    "@babel/plugin-transform-for-of" "^7.9.0"
     "@babel/plugin-transform-function-name" "^7.8.3"
     "@babel/plugin-transform-literals" "^7.8.3"
     "@babel/plugin-transform-member-expression-literals" "^7.8.3"
-    "@babel/plugin-transform-modules-amd" "^7.8.3"
-    "@babel/plugin-transform-modules-commonjs" "^7.8.3"
-    "@babel/plugin-transform-modules-systemjs" "^7.8.3"
-    "@babel/plugin-transform-modules-umd" "^7.8.3"
+    "@babel/plugin-transform-modules-amd" "^7.9.0"
+    "@babel/plugin-transform-modules-commonjs" "^7.9.0"
+    "@babel/plugin-transform-modules-systemjs" "^7.9.0"
+    "@babel/plugin-transform-modules-umd" "^7.9.0"
     "@babel/plugin-transform-named-capturing-groups-regex" "^7.8.3"
     "@babel/plugin-transform-new-target" "^7.8.3"
     "@babel/plugin-transform-object-super" "^7.8.3"
@@ -716,17 +739,29 @@
     "@babel/plugin-transform-template-literals" "^7.8.3"
     "@babel/plugin-transform-typeof-symbol" "^7.8.4"
     "@babel/plugin-transform-unicode-regex" "^7.8.3"
-    "@babel/types" "^7.8.7"
-    browserslist "^4.8.5"
+    "@babel/preset-modules" "^0.1.3"
+    "@babel/types" "^7.9.0"
+    browserslist "^4.9.1"
     core-js-compat "^3.6.2"
     invariant "^2.2.2"
     levenary "^1.1.1"
     semver "^5.5.0"
 
+"@babel/preset-modules@^0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@babel/preset-modules/-/preset-modules-0.1.3.tgz#13242b53b5ef8c883c3cf7dddd55b36ce80fbc72"
+  integrity sha512-Ra3JXOHBq2xd56xSF7lMKXdjBn3T772Y1Wet3yWnkDly9zHvJki029tAFzvAAK5cf4YV3yoxuP61crYRol6SVg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-proposal-unicode-property-regex" "^7.4.4"
+    "@babel/plugin-transform-dotall-regex" "^7.4.4"
+    "@babel/types" "^7.4.4"
+    esutils "^2.0.2"
+
 "@babel/runtime@^7.4.4", "@babel/runtime@^7.8.4":
-  version "7.8.7"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.7.tgz#8fefce9802db54881ba59f90bb28719b4996324d"
-  integrity sha512-+AATMUFppJDw6aiR5NVPHqIQBlV/Pj8wY/EZH+lmvRdUo9xBaz/rF3alAwFJQavvKfeOlPE7oaaDHVbcySbCsg==
+  version "7.9.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.9.2.tgz#d90df0583a3a252f09aaa619665367bae518db06"
+  integrity sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -739,27 +774,27 @@
     "@babel/parser" "^7.8.6"
     "@babel/types" "^7.8.6"
 
-"@babel/traverse@^7.1.0", "@babel/traverse@^7.4.4", "@babel/traverse@^7.7.4", "@babel/traverse@^7.8.3", "@babel/traverse@^7.8.4", "@babel/traverse@^7.8.6":
-  version "7.8.6"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.8.6.tgz#acfe0c64e1cd991b3e32eae813a6eb564954b5ff"
-  integrity sha512-2B8l0db/DPi8iinITKuo7cbPznLCEk0kCxDoB9/N6gGNg/gxOXiR/IcymAFPiBwk5w6TtQ27w4wpElgp9btR9A==
+"@babel/traverse@^7.1.0", "@babel/traverse@^7.4.4", "@babel/traverse@^7.7.4", "@babel/traverse@^7.8.3", "@babel/traverse@^7.8.6", "@babel/traverse@^7.9.0":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.9.0.tgz#d3882c2830e513f4fe4cec9fe76ea1cc78747892"
+  integrity sha512-jAZQj0+kn4WTHO5dUZkZKhbFrqZE7K5LAQ5JysMnmvGij+wOdr+8lWqPeW0BcF4wFwrEXXtdGO7wcV6YPJcf3w==
   dependencies:
     "@babel/code-frame" "^7.8.3"
-    "@babel/generator" "^7.8.6"
+    "@babel/generator" "^7.9.0"
     "@babel/helper-function-name" "^7.8.3"
     "@babel/helper-split-export-declaration" "^7.8.3"
-    "@babel/parser" "^7.8.6"
-    "@babel/types" "^7.8.6"
+    "@babel/parser" "^7.9.0"
+    "@babel/types" "^7.9.0"
     debug "^4.1.0"
     globals "^11.1.0"
     lodash "^4.17.13"
 
-"@babel/types@^7.0.0", "@babel/types@^7.3.0", "@babel/types@^7.4.4", "@babel/types@^7.8.3", "@babel/types@^7.8.6", "@babel/types@^7.8.7":
-  version "7.8.7"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.8.7.tgz#1fc9729e1acbb2337d5b6977a63979b4819f5d1d"
-  integrity sha512-k2TreEHxFA4CjGkL+GYjRyx35W0Mr7DP5+9q6WMkyKXB+904bYmG40syjMFV0oLlhhFCwWl0vA0DyzTDkwAiJw==
+"@babel/types@^7.0.0", "@babel/types@^7.3.0", "@babel/types@^7.4.4", "@babel/types@^7.8.3", "@babel/types@^7.8.6", "@babel/types@^7.9.0":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.9.0.tgz#00b064c3df83ad32b2dbf5ff07312b15c7f1efb5"
+  integrity sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==
   dependencies:
-    esutils "^2.0.2"
+    "@babel/helper-validator-identifier" "^7.9.0"
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
@@ -1150,40 +1185,40 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/eslint-plugin@^2.22.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.23.0.tgz#aa7133bfb7b685379d9eafe4ae9e08b9037e129d"
-  integrity sha512-8iA4FvRsz8qTjR0L/nK9RcRUN3QtIHQiOm69FzV7WS3SE+7P7DyGGwh3k4UNR2JBbk+Ej2Io+jLAaqKibNhmtw==
+"@typescript-eslint/eslint-plugin@^2.24.0":
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.24.0.tgz#a86cf618c965a462cddf3601f594544b134d6d68"
+  integrity sha512-wJRBeaMeT7RLQ27UQkDFOu25MqFOBus8PtOa9KaT5ZuxC1kAsd7JEHqWt4YXuY9eancX0GK9C68i5OROnlIzBA==
   dependencies:
-    "@typescript-eslint/experimental-utils" "2.23.0"
+    "@typescript-eslint/experimental-utils" "2.24.0"
     eslint-utils "^1.4.3"
     functional-red-black-tree "^1.0.1"
     regexpp "^3.0.0"
     tsutils "^3.17.1"
 
-"@typescript-eslint/experimental-utils@2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.23.0.tgz#5d2261c8038ec1698ca4435a8da479c661dc9242"
-  integrity sha512-OswxY59RcXH3NNPmq+4Kis2CYZPurRU6mG5xPcn24CjFyfdVli5mySwZz/g/xDbJXgDsYqNGq7enV0IziWGXVQ==
+"@typescript-eslint/experimental-utils@2.24.0":
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.24.0.tgz#a5cb2ed89fedf8b59638dc83484eb0c8c35e1143"
+  integrity sha512-DXrwuXTdVh3ycNCMYmWhUzn/gfqu9N0VzNnahjiDJvcyhfBy4gb59ncVZVxdp5XzBC77dCncu0daQgOkbvPwBw==
   dependencies:
     "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/typescript-estree" "2.23.0"
+    "@typescript-eslint/typescript-estree" "2.24.0"
     eslint-scope "^5.0.0"
 
-"@typescript-eslint/parser@^2.22.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.23.0.tgz#f3d4e2928ff647fe77fc2fcef1a3534fee6a3212"
-  integrity sha512-k61pn/Nepk43qa1oLMiyqApC6x5eP5ddPz6VUYXCAuXxbmRLqkPYzkFRKl42ltxzB2luvejlVncrEpflgQoSUg==
+"@typescript-eslint/parser@^2.24.0":
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.24.0.tgz#2cf0eae6e6dd44d162486ad949c126b887f11eb8"
+  integrity sha512-H2Y7uacwSSg8IbVxdYExSI3T7uM1DzmOn2COGtCahCC3g8YtM1xYAPi2MAHyfPs61VKxP/J/UiSctcRgw4G8aw==
   dependencies:
     "@types/eslint-visitor-keys" "^1.0.0"
-    "@typescript-eslint/experimental-utils" "2.23.0"
-    "@typescript-eslint/typescript-estree" "2.23.0"
+    "@typescript-eslint/experimental-utils" "2.24.0"
+    "@typescript-eslint/typescript-estree" "2.24.0"
     eslint-visitor-keys "^1.1.0"
 
-"@typescript-eslint/typescript-estree@2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.23.0.tgz#d355960fab96bd550855488dcc34b9a4acac8d36"
-  integrity sha512-pmf7IlmvXdlEXvE/JWNNJpEvwBV59wtJqA8MLAxMKLXNKVRC3HZBXR/SlZLPWTCcwOSg9IM7GeRSV3SIerGVqw==
+"@typescript-eslint/typescript-estree@2.24.0":
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.24.0.tgz#38bbc8bb479790d2f324797ffbcdb346d897c62a"
+  integrity sha512-RJ0yMe5owMSix55qX7Mi9V6z2FDuuDpN6eR5fzRJrp+8in9UF41IGNQHbg5aMK4/PjVaEQksLvz0IA8n+Mr/FA==
   dependencies:
     debug "^4.1.1"
     eslint-visitor-keys "^1.1.0"
@@ -1699,14 +1734,15 @@ browserify-zlib@^0.2.0:
   dependencies:
     pako "~1.0.5"
 
-browserslist@^4.0.0, browserslist@^4.1.0, browserslist@^4.8.3, browserslist@^4.8.5, browserslist@^4.9.1:
-  version "4.9.1"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.9.1.tgz#01ffb9ca31a1aef7678128fc6a2253316aa7287c"
-  integrity sha512-Q0DnKq20End3raFulq6Vfp1ecB9fh8yUNV55s8sekaDDeqBaCtWlRHCUdaWyUeSSBJM7IbM6HcsyaeYqgeDhnw==
+browserslist@^4.0.0, browserslist@^4.1.0, browserslist@^4.8.3, browserslist@^4.9.1:
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.11.0.tgz#aef4357b10a8abda00f97aac7cd587b2082ba1ad"
+  integrity sha512-WqEC7Yr5wUH5sg6ruR++v2SGOQYpyUdYYd4tZoAq1F7y+QXoLoYGXVbxhtaIqWmAJjtNTRjVD3HuJc1OXTel2A==
   dependencies:
-    caniuse-lite "^1.0.30001030"
-    electron-to-chromium "^1.3.363"
-    node-releases "^1.1.50"
+    caniuse-lite "^1.0.30001035"
+    electron-to-chromium "^1.3.380"
+    node-releases "^1.1.52"
+    pkg-up "^3.1.0"
 
 bs-logger@0.x:
   version "0.2.6"
@@ -1810,7 +1846,7 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001030:
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001035:
   version "1.0.30001035"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001035.tgz#2bb53b8aa4716b2ed08e088d4dc816a5fe089a1e"
   integrity sha512-C1ZxgkuA4/bUEdMbU5WrGY4+UhMFFiXrgNAfxiMIqWgFTWfv/xsZCS2xEHT2LMq7xAZfuAnu6mcqyDl0ZR6wLQ==
@@ -1979,10 +2015,10 @@ codecov@^3.6.4:
     teeny-request "6.0.1"
     urlgrey "0.4.4"
 
-codemirror@^5.52.0:
-  version "5.52.0"
-  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.52.0.tgz#4dbd6aef7f0e63db826b9a23922f0c03ac75c0a7"
-  integrity sha512-K2UB6zjscrfME03HeRe/IuOmCeqNpw7PLKGHThYpLbZEuKf+ZoujJPhxZN4hHJS1O7QyzEsV7JJZGxuQWVaFCg==
+codemirror@^5.52.2:
+  version "5.52.2"
+  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.52.2.tgz#c29e1f7179f85eb0dd17c0586fa810e4838ff584"
+  integrity sha512-WCGCixNUck2HGvY8/ZNI1jYfxPG5cRHv0VjmWuNzbtCLz8qYA5d+je4QhSSCtCaagyeOwMi/HmmPTjBgiTm2lQ==
 
 collapse-white-space@^1.0.0:
   version "1.0.6"
@@ -2609,10 +2645,10 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
-electron-to-chromium@^1.3.363:
-  version "1.3.376"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.376.tgz#7cb7b5205564a06c8f8ecfbe832cbd47a1224bb1"
-  integrity sha512-cv/PYVz5szeMz192ngilmezyPNFkUjuynuL2vNdiqIrio440nfTDdc0JJU0TS2KHLSVCs9gBbt4CFqM+HcBnjw==
+electron-to-chromium@^1.3.380:
+  version "1.3.380"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.380.tgz#1e1f07091b42b54bccd0ad6d3a14f2b73b60dc9d"
+  integrity sha512-2jhQxJKcjcSpVOQm0NAfuLq8o+130blrcawoumdXT6411xG/xIAOyZodO/y7WTaYlz/NHe3sCCAe/cJLnDsqTw==
 
 elliptic@^6.0.0:
   version "6.5.2"
@@ -2672,9 +2708,9 @@ error-ex@^1.2.0, error-ex@^1.3.1:
     is-arrayish "^0.2.1"
 
 es-abstract@^1.17.0, es-abstract@^1.17.0-next.1, es-abstract@^1.17.2:
-  version "1.17.4"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.17.4.tgz#e3aedf19706b20e7c2594c35fc0d57605a79e184"
-  integrity sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==
+  version "1.17.5"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.17.5.tgz#d8c9d1d66c8981fb9200e2251d799eee92774ae9"
+  integrity sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==
   dependencies:
     es-to-primitive "^1.2.1"
     function-bind "^1.1.1"
@@ -2776,10 +2812,10 @@ eslint-config-airbnb-base@14.1.0:
     object.assign "^4.1.0"
     object.entries "^1.1.1"
 
-eslint-config-prettier@^6.10.0:
-  version "6.10.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-6.10.0.tgz#7b15e303bf9c956875c948f6b21500e48ded6a7f"
-  integrity sha512-AtndijGte1rPILInUdHjvKEGbIV06NuvPrqlIEaEaWtbtvJh464mDeyGMdZEQMsGvC0ZVkiex1fSNcC4HAbRGg==
+eslint-config-prettier@^6.10.1:
+  version "6.10.1"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-6.10.1.tgz#129ef9ec575d5ddc0e269667bf09defcd898642a"
+  integrity sha512-svTy6zh1ecQojvpbJSgH3aei/Rt7C6i090l5f2WQ4aB05lYHeZIR1qL4wZyyILTbtmnbHP5Yn8MrsOJMGa8RkQ==
   dependencies:
     get-stdin "^6.0.0"
 
@@ -2918,7 +2954,7 @@ estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
 
-esutils@^2.0.0, esutils@^2.0.2:
+esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
@@ -3250,9 +3286,9 @@ fs.realpath@^1.0.0:
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
 fsevents@^1.2.7:
-  version "1.2.11"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.11.tgz#67bf57f4758f02ede88fb2a1712fef4d15358be3"
-  integrity sha512-+ux3lx6peh0BpvY0JebGyZoiR4D+oYzdPZMKJwkZ+sFkNJzpL7tXc/wehS49gUAxg3tmMHPHZkA8JU2rhhgDHw==
+  version "1.2.12"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.12.tgz#db7e0d8ec3b0b45724fd4d83d43554a8f1f0de5c"
+  integrity sha512-Ggd/Ktt7E7I8pxZRbGIs7vwqAPscSESMrCSkx2FtWeqmheJgCo2R74fTsZFCifr0VTPwqRpPv17+6b8Zp7th0Q==
   dependencies:
     bindings "^1.5.0"
     nan "^2.12.1"
@@ -3327,9 +3363,9 @@ glob-parent@^3.1.0:
     path-dirname "^1.0.0"
 
 glob-parent@^5.0.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.0.tgz#5f4c1d1e748d30cd73ad2944b3577a81b081e8c2"
-  integrity sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.1.tgz#b6c1ef417c4e5663ea498f1c45afac6916bbc229"
+  integrity sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==
   dependencies:
     is-glob "^4.0.1"
 
@@ -3487,9 +3523,9 @@ hast-util-has-property@^1.0.0:
   integrity sha512-ghHup2voGfgFoHMGnaLHOjbYFACKrRh9KFttdCzMCbFoBMJXiNi2+XTrPP8+q6cDJM/RSqlCfVWrjp1H201rZg==
 
 hast-util-is-body-ok-link@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/hast-util-is-body-ok-link/-/hast-util-is-body-ok-link-1.0.2.tgz#5f232779c9dc5a1508ccc18410c32f2dd9a3dc21"
-  integrity sha512-eSxO9rgtb7dfKxNa8NAFS3VEYWHXnJWVsoH/Z4jSsq1J2i4H1GkdJ43kXv++xuambrtI5XQwcAx6jeZVMjoBMQ==
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/hast-util-is-body-ok-link/-/hast-util-is-body-ok-link-1.0.3.tgz#752b16a7ebd6d73d35dde55c02742c934a1aa47b"
+  integrity sha512-NB8jW4iqT+iVld2oCjSk0T2S2FyR86rDZ7nKHx3WNf/WX16fjjdfoog6T+YeJFsPzszVKsNlVJL+k5c4asAHog==
   dependencies:
     hast-util-has-property "^1.0.0"
     hast-util-is-element "^1.0.0"
@@ -3577,9 +3613,9 @@ html-encoding-sniffer@^1.0.2:
     whatwg-encoding "^1.0.1"
 
 html-escaper@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.0.tgz#71e87f931de3fe09e56661ab9a29aadec707b491"
-  integrity sha512-a4u9BeERWGu/S8JiWEAQcdrg9v4QArtP9keViQjGMdff20fBdd8waotXaNmODqBe6uZ3Nafi7K/ho4gCQHV3Ig==
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.1.tgz#beed86b5d2b921e92533aa11bce6d8e3b583dee7"
+  integrity sha512-hNX23TjWwD3q56HpWjUHOKj1+4KKlnjv9PcmBUYKVpga+2cnb9nDx/B1o0yO4n+RZXZdiNxzx6B24C9aNMTkkQ==
 
 html-tags@^1.0.0:
   version "1.2.0"
@@ -3587,9 +3623,9 @@ html-tags@^1.0.0:
   integrity sha1-x43mW1Zjqll5id0rerSSANfk25g=
 
 html-whitespace-sensitive-tag-names@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/html-whitespace-sensitive-tag-names/-/html-whitespace-sensitive-tag-names-1.0.1.tgz#df3c6d97cb825d38e5d9b7d29cccb115cfc139cb"
-  integrity sha512-TMdAWVry7Ld0k2sLqpHkWsFAHmU+VZZq/nR4bfwfxThD8q3ibhrpRTywyQkEiunYiZXmJ6gRcJiLbZm+jbQPgQ==
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/html-whitespace-sensitive-tag-names/-/html-whitespace-sensitive-tag-names-1.0.2.tgz#799324c6b1d8b4ada6af1d6d8e068abad79303fa"
+  integrity sha512-9jCcAq9ZsjUkZjNFDvxalDPhktOijpfzLyzBcqMLOFSbtcDNrPlKDvZeH7KdEbP7C6OjPpIdDMMPm0oq2Dpk0A==
 
 htmlnano@^0.2.2:
   version "0.2.5"
@@ -4642,12 +4678,12 @@ json-stringify-safe@~5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
-json5@2.x, json5@^2.1.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.1.tgz#81b6cb04e9ba496f1c7005d07b4368a2638f90b6"
-  integrity sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==
+json5@2.x, json5@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.2.tgz#43ef1f0af9835dd624751a6b7fa48874fb2d608e"
+  integrity sha512-MoUOQ4WdiN3yxhm7NEVJSJrieAo5hNSLQ5sj05OTRHPL9HOBy8u4Bu88jsC1jvqAdN+E1bJmsUcZH+1HQxliqQ==
   dependencies:
-    minimist "^1.2.0"
+    minimist "^1.2.5"
 
 json5@^1.0.1:
   version "1.0.1"
@@ -4989,7 +5025,7 @@ minimist@0.0.8, minimist@0.2.1:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.2.1.tgz#827ba4e7593464e7c221e8c5bed930904ee2c455"
   integrity sha512-GY8fANSrTMfBVfInqJAY41QkOM+upUTytK1jZ0c8+3HdHrJxBJ3rF5i9moClXTE8uUSnUo8cAsCoxDXvSY4DHg==
 
-minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
+minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
@@ -5002,12 +5038,19 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mkdirp@0.5.1, mkdirp@0.x, mkdirp@^0.5.1, mkdirp@~0.5.1:
+mkdirp@0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
   dependencies:
     minimist "0.0.8"
+
+mkdirp@0.x, mkdirp@^0.5.1, mkdirp@~0.5.1:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.3.tgz#5a514b7179259287952881e94410ec5465659f8c"
+  integrity sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==
+  dependencies:
+    minimist "^1.2.5"
 
 ms@2.0.0:
   version "2.0.0"
@@ -5131,7 +5174,7 @@ node-notifier@^6.0.0:
     shellwords "^0.1.1"
     which "^1.3.1"
 
-node-releases@^1.1.50:
+node-releases@^1.1.52:
   version "1.1.52"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.52.tgz#bcffee3e0a758e92e44ecfaecd0a47554b0bcba9"
   integrity sha512-snSiT1UypkgGt2wxPqS6ImEUICbNCMb31yaxWrOLXjhlt2z2/IBpaOxzONExqSm4y5oLnAqjjRWu+wsDzK5yNQ==
@@ -5636,9 +5679,9 @@ physical-cpu-count@^2.0.0:
   integrity sha1-GN4vl+S/epVRrXURlCtUlverpmA=
 
 picomatch@^2.0.4, picomatch@^2.0.5:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.1.tgz#21bac888b6ed8601f831ce7816e335bc779f0a4a"
-  integrity sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
+  integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
 
 pidtree@^0.3.0:
   version "0.3.0"
@@ -5675,6 +5718,13 @@ pkg-dir@^4.2.0:
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
+
+pkg-up@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-3.1.0.tgz#100ec235cc150e4fd42519412596a28512a0def5"
+  integrity sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==
+  dependencies:
+    find-up "^3.0.0"
 
 pn@^1.1.0:
   version "1.1.0"
@@ -6052,10 +6102,10 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-prettier@^1.19.1:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
-  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+prettier@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.1.tgz#3f00ac71263be34684b2b2c8d7e7f63737592dac"
+  integrity sha512-piXGBcY1zoFOG0MvHpNE5reAGseLmaCRifQ/fmfF49BcYkInEs/naD/unxGNAeOKFA5+JxVrPyMvMlpzcd20UA==
 
 pretty-format@^24.9.0:
   version "24.9.0"
@@ -6098,9 +6148,9 @@ progress@^2.0.0, progress@^2.0.1:
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
 prompts@^2.0.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.3.1.tgz#b63a9ce2809f106fa9ae1277c275b167af46ea05"
-  integrity sha512-qIP2lQyCwYbdzcqHIUi2HAxiWixhoM9OdLCWf8txXsapC/X9YdsCoeyRIXE/GP+Q0J37Q7+XN/MFqbUa7IzXNA==
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.3.2.tgz#480572d89ecf39566d2bd3fe2c9fccb7c4c0b068"
+  integrity sha512-Q06uKs2CkNYVID0VqwfAl9mipo99zkBv/n2JtWY89Yxa3ZabWSrs0e2KTudKVa3peLUvYXMefDqIleLPVUBZMA==
   dependencies:
     kleur "^3.0.3"
     sisteransi "^1.0.4"
@@ -6226,9 +6276,9 @@ range-parser@~1.2.1:
   integrity sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==
 
 react-is@^16.12.0, react-is@^16.8.4:
-  version "16.13.0"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.0.tgz#0f37c3613c34fe6b37cd7f763a0d6293ab15c527"
-  integrity sha512-GFMtL0vHkiBv9HluwNZTggSn/sCyEt9n02aM0dSAjGGyqyNlAyftYm4phPxdvCigG15JreC5biwxCgTAJZ7yAA==
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
+  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
 read-pkg-up@^2.0.0:
   version "2.0.0"
@@ -6317,9 +6367,9 @@ regenerator-runtime@^0.13.4:
   integrity sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==
 
 regenerator-transform@^0.14.2:
-  version "0.14.3"
-  resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.14.3.tgz#54aebff2ef58c0ae61e695ad1b9a9d65995fff78"
-  integrity sha512-zXHNKJspmONxBViAb3ZUmFoFPnTBs3zFhCEZJiwp/gkNzxVbTqNJVjYKx6Qk1tQ1P4XLf4TbH9+KBB7wGoAaUw==
+  version "0.14.4"
+  resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.14.4.tgz#5266857896518d1616a78a0479337a30ea974cc7"
+  integrity sha512-EaJaKPBI9GvKpvUz2mz4fhx7WPgvwRLY9v3hlNHWmAuJHI13T4nwKnNvm5RWJzEdnI5g5UwtOww+S8IdoUC2bw==
   dependencies:
     "@babel/runtime" "^7.8.4"
     private "^0.1.8"
@@ -6753,9 +6803,9 @@ simple-swizzle@^0.2.2:
     is-arrayish "^0.3.1"
 
 sisteransi@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.4.tgz#386713f1ef688c7c0304dc4c0632898941cad2e3"
-  integrity sha512-/ekMoM4NJ59ivGSfKapeG+FWtrmWvA1p6FBZwXrqojw90vJu8lBmrTxCMuBCydKtkaUe2zt4PlxeTKpjwMbyig==
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
+  integrity sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==
 
 slash@^3.0.0:
   version "3.0.0"
@@ -7209,9 +7259,9 @@ terser@^3.7.3:
     source-map-support "~0.5.10"
 
 terser@^4.3.9:
-  version "4.6.6"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-4.6.6.tgz#da2382e6cafbdf86205e82fb9a115bd664d54863"
-  integrity sha512-4lYPyeNmstjIIESr/ysHg2vUPRGf2tzF9z2yYwnowXVuVzLEamPN1Gfrz7f8I9uEPuHcbFlW4PLIAsJoxXyJ1g==
+  version "4.6.7"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-4.6.7.tgz#478d7f9394ec1907f0e488c5f6a6a9a2bad55e72"
+  integrity sha512-fmr7M1f7DBly5cX2+rFDvmGBAaaZyPrHYK4mMdHEDAdNTqXSZgSOfqsfGq2HqPGT/1V0foZZuCZFx8CHKgAk3g==
   dependencies:
     commander "^2.20.0"
     source-map "~0.6.1"
@@ -7886,10 +7936,10 @@ yargs-parser@^16.1.0:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
-yargs-parser@^18.1.0:
-  version "18.1.0"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.0.tgz#1b0ab1118ebd41f68bb30e729f4c83df36ae84c3"
-  integrity sha512-o/Jr6JBOv6Yx3pL+5naWSoIA2jJ+ZkMYQG/ie9qFbukBe4uzmBatlXFOiu/tNKRWEtyf+n5w7jc/O16ufqOTdQ==
+yargs-parser@^18.1.1:
+  version "18.1.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.1.tgz#bf7407b915427fc760fcbbccc6c82b4f0ffcbd37"
+  integrity sha512-KRHEsOM16IX7XuLnMOqImcPNbLVXMNHYAoFc3BKR8Ortl5gzDbtXvvEoGx9imk5E+X1VeNKNlcHr8B8vi+7ipA==
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
@@ -7912,9 +7962,9 @@ yargs@^14.0.0:
     yargs-parser "^15.0.1"
 
 yargs@^15.0.0:
-  version "15.3.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.3.0.tgz#403af6edc75b3ae04bf66c94202228ba119f0976"
-  integrity sha512-g/QCnmjgOl1YJjGsnUg2SatC7NUYEiLXJqxNOQU9qSpjzGtGXda9b+OKccr1kLTy8BN9yqEyqfq5lxlwdc13TA==
+  version "15.3.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.3.1.tgz#9505b472763963e54afe60148ad27a330818e98b"
+  integrity sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==
   dependencies:
     cliui "^6.0.0"
     decamelize "^1.2.0"
@@ -7926,7 +7976,7 @@ yargs@^15.0.0:
     string-width "^4.2.0"
     which-module "^2.0.0"
     y18n "^4.0.0"
-    yargs-parser "^18.1.0"
+    yargs-parser "^18.1.1"
 
 yauzl@2.4.1:
   version "2.4.1"


### PR DESCRIPTION
Upgrade dependent packages to the latest version through `yarn upgrade(-interactive) --latest`.

### Notable changes

- Prettier has bumped to v2 so a lot of changes have applied to code, caused by new default option `allowParens: always`.