### PR TITLE
[v2] Provide runtimes for Babel 7.9 automatic JSX transpile (experimental)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,6 +30,7 @@ module.exports = {
     'import/no-extraneous-dependencies': 'off',
     'import/prefer-default-export': 'off',
     'no-restricted-syntax': 'off',
+    strict: 'off',
   },
   settings: {
     'import/resolver': {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ jsx-slack v2 has improved JSX structure and built-in components to output the re
 - HTML-compatible `<Option selected>` and `<RadioButton checked>`
 - `value` prop as an alias into `initialXXX` prop in some interactive components
 - Added JSDoc to many public APIs and components
+- Support new JSX transpile via `automatic` runtime in Babel >= 7.9 ([#142](https://github.com/speee/jsx-slack/pull/142))
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [npm]: https://www.npmjs.com/package/@speee-js/jsx-slack
 [license]: ./LICENSE
 
-Build JSON object for [Slack][block kit] surfaces from readable [JSX].
+Build JSON object for [Slack][slack] [block kit] surfaces from readable [JSX].
 
 [slack]: https://slack.com
 [jsx]: https://reactjs.org/docs/introducing-jsx.html

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [npm]: https://www.npmjs.com/package/@speee-js/jsx-slack
 [license]: ./LICENSE
 
-Build JSON object for [Slack][slack] [Block Kit] surfaces from readable [JSX].
+Build JSON object for [Slack][block kit] surfaces from readable [JSX].
 
 [slack]: https://slack.com
 [jsx]: https://reactjs.org/docs/introducing-jsx.html
@@ -26,7 +26,7 @@ Build JSON object for [Slack][slack] [Block Kit] surfaces from readable [JSX].
 
 ### Features
 
-:sparkles: **We have sparkling jsx-slack v2!** :sparkles: **▶︎ [See highlights of v2](docs/highlights/v2.md)**
+:sparkles: **We have sparkling jsx-slack v2!** :sparkles: **[▶︎ See highlights of v2](docs/highlights/v2.md)**
 
 - **[Block Kit as components](docs/jsx-components-for-block-kit.md)** - Build contents for any surfaces by composing components for Block Kit with JSX.
 - **[HTML-like formatting](docs/html-like-formatting.md)** - Keep a readability by using well-known elements.
@@ -81,9 +81,9 @@ export const exampleBlock = ({ name }) => jsxslack`
 `
 ```
 
-### JSX Transpiler
+### [JSX Transpiler](docs/how-to-setup-jsx-transpiler.md)
 
-When you want to use jsx-slack with JSX transpiler (Babel / TypeScript), you have to set up to use imported our parser `JSXSlack.createElement` or its alias `JSXSlack.h`. Typically, we recommend to use pragma comment `/** @jsx JSXSlack.h */`.
+When you want to use jsx-slack with JSX transpiler, you have to set up to use imported our parser `JSXSlack.createElement` or its alias `JSXSlack.h`.
 
 ```jsx
 /** @jsx JSXSlack.h */
@@ -98,23 +98,7 @@ export const exampleBlock = ({ name }) => (
 )
 ```
 
-A prgama would work in Babel ([@babel/plugin-transform-react-jsx](https://babeljs.io/docs/en/babel-plugin-transform-react-jsx)) and [TypeScript with `--jsx react`](https://www.typescriptlang.org/docs/handbook/jsx.html#factory-functions). You can use jsx-slack in either one.
-
-#### Tips for TypeScript
-
-When you are using JSX through TypeScript, the returned type from JSX would not match to Slack Node SDK so _require to cast JSX into the suitable type_.
-
-`JSXSlack()` works as a type helper to cast JSX into `any` type. We recommend for TS developer to wrap JSX in `JSXSlack()`.
-
-```typescript
-JSXSlack(
-  <Blocks>
-    <Section>TypeScript needs to cast</Section>
-  </Blocks>
-)
-```
-
-This usage is compatible with jsx-slack v1 too.
+**[▶︎ See how to setup JSX transpiler](docs/how-to-setup-jsx-transpiler.md)** (Babel / TypeScript)
 
 ### Use template in Slack API
 
@@ -245,7 +229,9 @@ By using jsx-slack, you can build a template with piling up Block Kit blocks by 
 
 ### References
 
-- **[JSX components for Block Kit](docs/jsx-components-for-block-kit.md)**
+- **[How to setup JSX transpiler](docs/how-to-setup-jsx-transpiler.md)**
+
+* **[JSX components for Block Kit](docs/jsx-components-for-block-kit.md)**
   - [Block containers](docs/block-containers.md)
   - [Layout blocks](docs/layout-blocks.md)
   - [Block elements](docs/block-elements.md)
@@ -253,8 +239,8 @@ By using jsx-slack, you can build a template with piling up Block Kit blocks by 
     - [Composition objects](docs/block-elements.md#composition-objects)
     - [Input components for modal](docs/block-elements.md#input-components-for-modal)
 
-* **[HTML-like formatting](docs/html-like-formatting.md)**
-* **[About escape and exact mode](docs/about-escape-and-exact-mode.md)**
+- **[HTML-like formatting](docs/html-like-formatting.md)**
+- **[About escape and exact mode](docs/about-escape-and-exact-mode.md)**
 
 ## Fragments
 
@@ -297,7 +283,7 @@ Now the defined block can use in `<Blocks>` as like as the other blocks:
 
 ### Short syntax for Babel transpiler
 
-If you want to use [the short syntax `<></>` for fragments](https://reactjs.org/docs/fragments.html#short-syntax) in Babel transpiler, we recommend to set [an extra pragma command `/** @jsxFrag JSXSlack.Fragment */`](https://babeljs.io/docs/en/babel-plugin-transform-react-jsx#custom-1).
+Babel transpiler can use [the short syntax `<></>` for fragments](https://reactjs.org/docs/fragments.html#short-syntax). See [how to setup JSX transpiler](docs/how-to-setup-jsx-transpiler.md#babel).
 
 ```javascript
 /** @jsx JSXSlack.h */
@@ -313,8 +299,6 @@ const Header = ({ children }) => (
   </>
 )
 ```
-
-> :warning: TypeScript cannot customize the factory method for fragment syntax. ([Microsoft/TypeScript#20469](https://github.com/Microsoft/TypeScript/issues/20469)) Please use `<Fragment>` component as usual.
 
 ### In the case of template literal tag
 

--- a/__mocks__/jsx-dev-runtime.js
+++ b/__mocks__/jsx-dev-runtime.js
@@ -1,0 +1,1 @@
+module.exports = require('../src/jsx-dev-runtime')

--- a/__mocks__/jsx-runtime.js
+++ b/__mocks__/jsx-runtime.js
@@ -1,0 +1,1 @@
+module.exports = require('../src/jsx-runtime')

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,19 @@
+// NOTE: jsx-slack uses Babel only for testing.
+const babelPresets = (development) => [
+  ['@babel/preset-env', { targets: { node: true } }],
+  ['@babel/preset-react', { development, runtime: 'automatic' }],
+]
+
+module.exports = {
+  presets: babelPresets(true),
+  overrides: [
+    {
+      test: './src/**/*',
+      presets: ['@babel/preset-typescript', { allowNamespace: true }],
+    },
+    {
+      test: './test/**/production.jsx',
+      presets: babelPresets(false),
+    },
+  ],
+}

--- a/docs/highlights/v2.md
+++ b/docs/highlights/v2.md
@@ -192,6 +192,46 @@ In the above case, v2 throws the error with more useful message: `<Actions> cann
 - `confirm` prop for interactive block elements accepts the raw confirm composition object.
 - `<a>` tag now renders short syntax for hyperlink if possible.
 
+### Experimental features
+
+#### Support `automatic` runtime of [Babel JSX transpiler](https://babeljs.io/docs/en/babel-preset-react)
+
+Babel has expected [many breaking changes for JSX transpiler](https://github.com/babel/babel/issues/10746) in next major version 8. Prior to them, [Babel 7.9.0 has shipped with a new JSX transformation](https://babeljs.io/blog/2020/03/16/7.9.0) that was based on [React RFC](https://github.com/reactjs/rfcs/blob/createlement-rfc/text/0000-create-element-changes.md), called as `automatic` runtime. It would be a default runtime of JSX in Babel 8.
+
+jsx-slack v2 has an experimental implementation to support new JSX transformation `automatic` runtime.
+
+```javascript
+// babel.config.js
+module.exports = (api) => ({
+  presets: [
+    [
+      '@babel/preset-react',
+      {
+        runtime: 'automatic',
+        importSource: '@speee-js/jsx-slack',
+        development: api.env('development'),
+      },
+    ],
+  ],
+})
+```
+
+The advantage is no longer need to require importing implicitly used `JSXSlack` manually.
+
+```jsx
+const { Blocks, Section } = require('@speee-js/js-slack')
+
+console.log(
+  <Blocks>
+    <Section>
+      <p>Hello, world!</p>
+    </Section>
+  </Blocks>
+)
+```
+
+Developers only have to import required built-in components so JSX code will look like more intuitive. See details in [#142](https://github.com/speee/jsx-slack/pull/142).
+
 ## Breaking change
 
 ### `<CheckboxGroup values={[...]}>` and `<Checkbox checked>`

--- a/docs/how-to-setup-jsx-transpiler.md
+++ b/docs/how-to-setup-jsx-transpiler.md
@@ -91,7 +91,7 @@ console.log(
 /** @jsxImportSource @speee-js/jsx-slack */
 ```
 
-## TypeScript
+## [TypeScript](https://www.typescriptlang.org/)
 
 You can use TypeScript built-in JSX transpiler too.
 

--- a/docs/how-to-setup-jsx-transpiler.md
+++ b/docs/how-to-setup-jsx-transpiler.md
@@ -1,0 +1,138 @@
+###### [Top](../README.md) &raquo; How to setup JSX transpiler
+
+# How to setup JSX transpiler
+
+When you want to use jsx-slack with JSX transpiler, you have to set up to use imported our parser `JSXSlack.createElement`, or its alias `JSXSlack.h`.
+
+## [Babel](https://babeljs.io/)
+
+You can use [`@babel/preset-react`](https://babeljs.io/docs/en/babel-preset-react) preset (or [`@babel/plugin-transform-react-jsx`](https://babeljs.io/docs/en/babel-plugin-transform-react-jsx) plugin) to transpile JSX.
+
+### Classic
+
+```javascript
+// babel.config.js
+module.exports = (api) => ({
+  presets: [
+    [
+      '@babel/preset-react',
+      {
+        runtime: 'classic',
+        pragma: 'JSXSlack.h',
+        pragmaFrag: 'JSXSlack.Fragment',
+        development: api.env('development'),
+      },
+    ],
+  ],
+})
+```
+
+You should always import `JSXSlack` from `@speee-js/jsx-slack` in every JSX.
+
+```jsx
+const { JSXSlack, Blocks, Section } = require('@speee-js/js-slack')
+
+console.log(
+  <Blocks>
+    <Section>
+      <p>Hello, world!</p>
+    </Section>
+  </Blocks>
+)
+```
+
+#### Comment pragma
+
+You can also use comment pragma per JSX file if you have already set up JSX transpiler for React.
+
+```jsx
+/** @jsx JSXSlack.h **/
+/** @jsxFrag JSXSlack.Fragment **/
+const { JSXSlack } = require('@speee-js/js-slack')
+```
+
+### Automatic ([Babel >= 7.9](https://babeljs.io/blog/2020/03/16/7.9.0#a-new-jsx-transform-11154-https-githubcom-babel-babel-pull-11154)) _[experimental]_
+
+We also have supported `automatic` runtime.
+
+```javascript
+// babel.config.js
+module.exports = (api) => ({
+  presets: [
+    [
+      '@babel/preset-react',
+      {
+        runtime: 'automatic',
+        importSource: '@speee-js/jsx-slack',
+        development: api.env('development'),
+      },
+    ],
+  ],
+})
+```
+
+Babel will automatically import functions for transpiling JSX. You only have to import required components from `@speee-js/jsx-slack`.
+
+```jsx
+const { Blocks, Section } = require('@speee-js/js-slack')
+
+console.log(
+  <Blocks>
+    <Section>
+      <p>Hello, world!</p>
+    </Section>
+  </Blocks>
+)
+```
+
+#### Comment pragma
+
+```jsx
+/** @jsxImportSource @speee-js/jsx-slack */
+```
+
+## TypeScript
+
+You can use TypeScript built-in JSX transpiler too.
+
+```jsonc
+// tsconfig.json
+{
+  "compilerOptions": {
+    "jsx": "react",
+    "jsxFactory": "JSXSlack.h"
+    // ...
+  }
+}
+```
+
+You should always import `JSXSlack` from `@speee-js/jsx-slack` in every JSX.
+
+In addition, we recommend to wrap JSX in `JSXSlack()` to deal with the mismatched type against SDK for Slack API. It's a helper function to cast into `any` type.
+
+```jsx
+import { JSXSlack, Blocks, Section } from '@speee-js/js-slack'
+
+console.log(
+  JSXSlack(
+    <Blocks>
+      <Section>
+        <p>Hello, world!</p>
+      </Section>
+    </Blocks>
+  )
+)
+```
+
+#### Comment pragma
+
+```jsx
+/** @jsx JSXSlack.h **/
+import { JSXSlack } from '@speee-js/js-slack'
+```
+
+> :warning: TypeScript cannot customize the factory method for fragment short syntax `<></>`. ([Microsoft/TypeScript#20469](https://github.com/Microsoft/TypeScript/issues/20469)) Please use `<Fragment>` component as same as other components.
+
+---
+
+###### [Top](../README.md) &raquo; How to setup JSX transpiler

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,3 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
-const { defaults: tsjPreset } = require('ts-jest/presets')
-
 module.exports = {
   collectCoverageFrom: [
     'src/**/*.js',
@@ -10,9 +7,12 @@ module.exports = {
   ],
   coveragePathIgnorePatterns: ['/node_modules/', '.*\\.d\\.ts'],
   coverageThreshold: { global: { lines: 95 } },
+  moduleNameMapper: {
+    '^@speee-js/jsx-slack(.*)$': '<rootDir>$1',
+  },
+  preset: 'ts-jest/presets/js-with-babel',
   resetMocks: true,
   restoreMocks: true,
   testEnvironment: 'node',
-  testRegex: '(/(test|__tests__)/(?![_.]).*|(\\.|/)(test|spec))\\.[jt]sx?$',
-  transform: { ...tsjPreset.transform },
+  testMatch: ['<rootDir>/test/**/!(_*).[jt]s?(x)'],
 }

--- a/jsx-dev-runtime.js
+++ b/jsx-dev-runtime.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = require('./lib/jsx-dev-runtime')

--- a/jsx-dev-runtime.js
+++ b/jsx-dev-runtime.js
@@ -1,3 +1,4 @@
 'use strict'
 
+// eslint-disable-next-line import/no-unresolved
 module.exports = require('./lib/jsx-dev-runtime')

--- a/jsx-runtime.js
+++ b/jsx-runtime.js
@@ -1,3 +1,4 @@
 'use strict'
 
+// eslint-disable-next-line import/no-unresolved
 module.exports = require('./lib/jsx-runtime')

--- a/jsx-runtime.js
+++ b/jsx-runtime.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = require('./lib/jsx-runtime')

--- a/package.json
+++ b/package.json
@@ -33,7 +33,9 @@
   "files": [
     "lib/",
     "module/",
-    "types/"
+    "types/",
+    "jsx-dev-runtime.js",
+    "jsx-runtime.js"
   ],
   "scripts": {
     "build": "run-p build:*",
@@ -64,6 +66,10 @@
     "access": "public"
   },
   "devDependencies": {
+    "@babel/core": "^7.9.0",
+    "@babel/preset-env": "^7.9.5",
+    "@babel/preset-react": "^7.9.4",
+    "@babel/preset-typescript": "^7.9.0",
     "@types/jest": "^25.2.1",
     "@typescript-eslint/eslint-plugin": "^2.27.0",
     "@typescript-eslint/parser": "^2.27.0",

--- a/src/jsx-dev-runtime.ts
+++ b/src/jsx-dev-runtime.ts
@@ -1,5 +1,6 @@
 import { jsx } from './jsx-runtime'
 
+/** @experimental */
 export const jsxDEV = (
   type: any,
   props: object,

--- a/src/jsx-dev-runtime.ts
+++ b/src/jsx-dev-runtime.ts
@@ -1,0 +1,11 @@
+import { jsx, jsxs } from './jsx-runtime'
+
+export { jsx, jsxs }
+
+export const jsxDEV = (
+  type: any,
+  props: object,
+  key: any,
+  _: boolean, // isStaticChildren: not used in jsx-slack
+  __source: object
+) => jsx(type, { ...props, __source }, key)

--- a/src/jsx-dev-runtime.ts
+++ b/src/jsx-dev-runtime.ts
@@ -1,6 +1,4 @@
-import { jsx, jsxs } from './jsx-runtime'
-
-export { jsx, jsxs }
+import { jsx } from './jsx-runtime'
 
 export const jsxDEV = (
   type: any,

--- a/src/jsx-runtime.ts
+++ b/src/jsx-runtime.ts
@@ -1,0 +1,9 @@
+import { createElementInternal, FragmentInternal } from './jsx'
+
+export const jsx = (type: any, props: object, key: any) =>
+  createElementInternal(type ?? FragmentInternal, {
+    ...props,
+    ...(key !== undefined ? { key } : {}),
+  })
+
+export const jsxs = jsx

--- a/src/jsx-runtime.ts
+++ b/src/jsx-runtime.ts
@@ -1,9 +1,11 @@
 import { createElementInternal, FragmentInternal } from './jsx'
 
+/** @experimental */
 export const jsx = (type: any, props: object, key: any) =>
   createElementInternal(type ?? FragmentInternal, {
     ...props,
     ...(key !== undefined ? { key } : {}),
   })
 
+/** @experimental */
 export const jsxs = jsx

--- a/test/babel/automatic.jsx
+++ b/test/babel/automatic.jsx
@@ -3,14 +3,15 @@ import { Blocks, Fragment, Section } from '../../src/index'
 
 jest.mock('../../jsx-dev-runtime')
 
-it('accepts JSX', () => {
-  expect(
-    <Blocks>
-      <Section>
-        <p>Hello, world!</p>
-      </Section>
-    </Blocks>
-  ).toMatchInlineSnapshot(`
+describe('Babel transpilation through automatic runtime (Development mode)', () => {
+  it('accepts JSX', () => {
+    expect(
+      <Blocks>
+        <Section>
+          <p>Hello, world!</p>
+        </Section>
+      </Blocks>
+    ).toMatchInlineSnapshot(`
     Array [
       Object {
         "text": Object {
@@ -22,36 +23,24 @@ it('accepts JSX', () => {
       },
     ]
   `)
-})
+  })
 
-it('has __source prop for development', () => {
-  const Component = ({ __source }) => __source
+  it('accepts fragment syntax', () => {
+    const fragment = (
+      <>
+        <Section>Section A</Section>
+        <Section>Section B</Section>
+        <Section>Section C</Section>
+      </>
+    )
 
-  expect(<Component />).toStrictEqual(
-    expect.objectContaining({
-      columnNumber: expect.any(Number),
-      fileName: expect.any(String),
-      lineNumber: expect.any(Number),
-    })
-  )
-})
+    const Component = () => fragment
 
-it('accepts fragment syntax', () => {
-  const fragment = (
-    <>
-      <Section>Section A</Section>
-      <Section>Section B</Section>
-      <Section>Section C</Section>
-    </>
-  )
-
-  const Component = () => fragment
-
-  expect(
-    <Blocks>
-      <Component />
-    </Blocks>
-  ).toMatchInlineSnapshot(`
+    expect(
+      <Blocks>
+        <Component />
+      </Blocks>
+    ).toMatchInlineSnapshot(`
     Array [
       Object {
         "text": Object {
@@ -80,10 +69,23 @@ it('accepts fragment syntax', () => {
     ]
   `)
 
-  expect(fragment.$$jsxslack.type).toBe(Fragment)
-})
+    expect(fragment.$$jsxslack.type).toBe(Fragment)
+  })
 
-it('merges key prop to props', () => {
-  const Component = ({ key }) => key
-  expect(<Component key="abc" />).toBe('abc')
+  it('merges key prop to props', () => {
+    const Component = ({ key }) => key
+    expect(<Component key="abc" />).toBe('abc')
+  })
+
+  it('has __source prop for development', () => {
+    const Component = ({ __source }) => __source
+
+    expect(<Component />).toStrictEqual(
+      expect.objectContaining({
+        columnNumber: expect.any(Number),
+        fileName: expect.any(String),
+        lineNumber: expect.any(Number),
+      })
+    )
+  })
 })

--- a/test/babel/automatic.jsx
+++ b/test/babel/automatic.jsx
@@ -1,0 +1,89 @@
+/** @jsxImportSource @speee-js/jsx-slack */
+import { Blocks, Fragment, Section } from '../../src/index'
+
+jest.mock('../../jsx-dev-runtime')
+
+it('accepts JSX', () => {
+  expect(
+    <Blocks>
+      <Section>
+        <p>Hello, world!</p>
+      </Section>
+    </Blocks>
+  ).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "text": Object {
+          "text": "Hello, world!",
+          "type": "mrkdwn",
+          "verbatim": true,
+        },
+        "type": "section",
+      },
+    ]
+  `)
+})
+
+it('has __source prop for development', () => {
+  const Component = ({ __source }) => __source
+
+  expect(<Component />).toStrictEqual(
+    expect.objectContaining({
+      columnNumber: expect.any(Number),
+      fileName: expect.any(String),
+      lineNumber: expect.any(Number),
+    })
+  )
+})
+
+it('accepts fragment syntax', () => {
+  const fragment = (
+    <>
+      <Section>Section A</Section>
+      <Section>Section B</Section>
+      <Section>Section C</Section>
+    </>
+  )
+
+  const Component = () => fragment
+
+  expect(
+    <Blocks>
+      <Component />
+    </Blocks>
+  ).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "text": Object {
+          "text": "Section A",
+          "type": "mrkdwn",
+          "verbatim": true,
+        },
+        "type": "section",
+      },
+      Object {
+        "text": Object {
+          "text": "Section B",
+          "type": "mrkdwn",
+          "verbatim": true,
+        },
+        "type": "section",
+      },
+      Object {
+        "text": Object {
+          "text": "Section C",
+          "type": "mrkdwn",
+          "verbatim": true,
+        },
+        "type": "section",
+      },
+    ]
+  `)
+
+  expect(fragment.$$jsxslack.type).toBe(Fragment)
+})
+
+it('merges key prop to props', () => {
+  const Component = ({ key }) => key
+  expect(<Component key="abc" />).toBe('abc')
+})

--- a/test/babel/classic.jsx
+++ b/test/babel/classic.jsx
@@ -1,0 +1,84 @@
+/** @jsxRuntime classic */
+/** @jsx JSXSlack.h */
+/** @jsxFrag JSXSlack.Fragment */
+import { JSXSlack, Blocks, Fragment, Section } from '../../src/index'
+
+it('accepts JSX', () => {
+  expect(
+    <Blocks>
+      <Section>
+        <p>Hello, world!</p>
+      </Section>
+    </Blocks>
+  ).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "text": Object {
+          "text": "Hello, world!",
+          "type": "mrkdwn",
+          "verbatim": true,
+        },
+        "type": "section",
+      },
+    ]
+  `)
+})
+
+it('has __source prop for development', () => {
+  const Component = ({ __source }) => __source
+
+  expect(<Component />).toStrictEqual(
+    expect.objectContaining({
+      columnNumber: expect.any(Number),
+      fileName: expect.any(String),
+      lineNumber: expect.any(Number),
+    })
+  )
+})
+
+it('accepts fragment syntax', () => {
+  const fragment = (
+    <>
+      <Section>Section A</Section>
+      <Section>Section B</Section>
+      <Section>Section C</Section>
+    </>
+  )
+
+  const Component = () => fragment
+
+  expect(
+    <Blocks>
+      <Component />
+    </Blocks>
+  ).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "text": Object {
+          "text": "Section A",
+          "type": "mrkdwn",
+          "verbatim": true,
+        },
+        "type": "section",
+      },
+      Object {
+        "text": Object {
+          "text": "Section B",
+          "type": "mrkdwn",
+          "verbatim": true,
+        },
+        "type": "section",
+      },
+      Object {
+        "text": Object {
+          "text": "Section C",
+          "type": "mrkdwn",
+          "verbatim": true,
+        },
+        "type": "section",
+      },
+    ]
+  `)
+
+  expect(fragment.$$jsxslack.type).toBe(Fragment)
+})

--- a/test/babel/classic.jsx
+++ b/test/babel/classic.jsx
@@ -3,14 +3,15 @@
 /** @jsxFrag JSXSlack.Fragment */
 import { JSXSlack, Blocks, Fragment, Section } from '../../src/index'
 
-it('accepts JSX', () => {
-  expect(
-    <Blocks>
-      <Section>
-        <p>Hello, world!</p>
-      </Section>
-    </Blocks>
-  ).toMatchInlineSnapshot(`
+describe('Babel transpilation through classic runtime', () => {
+  it('accepts JSX', () => {
+    expect(
+      <Blocks>
+        <Section>
+          <p>Hello, world!</p>
+        </Section>
+      </Blocks>
+    ).toMatchInlineSnapshot(`
     Array [
       Object {
         "text": Object {
@@ -22,36 +23,24 @@ it('accepts JSX', () => {
       },
     ]
   `)
-})
+  })
 
-it('has __source prop for development', () => {
-  const Component = ({ __source }) => __source
+  it('accepts fragment syntax', () => {
+    const fragment = (
+      <>
+        <Section>Section A</Section>
+        <Section>Section B</Section>
+        <Section>Section C</Section>
+      </>
+    )
 
-  expect(<Component />).toStrictEqual(
-    expect.objectContaining({
-      columnNumber: expect.any(Number),
-      fileName: expect.any(String),
-      lineNumber: expect.any(Number),
-    })
-  )
-})
+    const Component = () => fragment
 
-it('accepts fragment syntax', () => {
-  const fragment = (
-    <>
-      <Section>Section A</Section>
-      <Section>Section B</Section>
-      <Section>Section C</Section>
-    </>
-  )
-
-  const Component = () => fragment
-
-  expect(
-    <Blocks>
-      <Component />
-    </Blocks>
-  ).toMatchInlineSnapshot(`
+    expect(
+      <Blocks>
+        <Component />
+      </Blocks>
+    ).toMatchInlineSnapshot(`
     Array [
       Object {
         "text": Object {
@@ -80,5 +69,20 @@ it('accepts fragment syntax', () => {
     ]
   `)
 
-  expect(fragment.$$jsxslack.type).toBe(Fragment)
+    expect(fragment.$$jsxslack.type).toBe(Fragment)
+  })
+
+  describe('Development mode specific', () => {
+    it('has __source prop for development', () => {
+      const Component = ({ __source }) => __source
+
+      expect(<Component />).toStrictEqual(
+        expect.objectContaining({
+          columnNumber: expect.any(Number),
+          fileName: expect.any(String),
+          lineNumber: expect.any(Number),
+        })
+      )
+    })
+  })
 })

--- a/test/babel/production.jsx
+++ b/test/babel/production.jsx
@@ -1,0 +1,7 @@
+/** @jsxImportSource @speee-js/jsx-slack */
+jest.mock('../../jsx-runtime')
+
+it('does not have __source prop', () => {
+  const Component = ({ __source }) => __source
+  expect(<Component />).toBeUndefined()
+})

--- a/test/babel/production.jsx
+++ b/test/babel/production.jsx
@@ -1,7 +1,9 @@
 /** @jsxImportSource @speee-js/jsx-slack */
 jest.mock('../../jsx-runtime')
 
-it('does not have __source prop', () => {
-  const Component = ({ __source }) => __source
-  expect(<Component />).toBeUndefined()
+describe('Babel transpilation through automatic runtime (Production mode)', () => {
+  it('does not have __source prop', () => {
+    const Component = ({ __source }) => __source
+    expect(<Component />).toBeUndefined()
+  })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -18,7 +18,7 @@
     invariant "^2.2.4"
     semver "^5.5.0"
 
-"@babel/core@^7.1.0", "@babel/core@^7.4.4", "@babel/core@^7.7.5":
+"@babel/core@^7.1.0", "@babel/core@^7.4.4", "@babel/core@^7.7.5", "@babel/core@^7.9.0":
   version "7.9.0"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.9.0.tgz#ac977b538b77e132ff706f3b8a4dbad09c03c56e"
   integrity sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==
@@ -93,6 +93,18 @@
     levenary "^1.1.1"
     semver "^5.5.0"
 
+"@babel/helper-create-class-features-plugin@^7.8.3":
+  version "7.9.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.9.5.tgz#79753d44017806b481017f24b02fd4113c7106ea"
+  integrity sha512-IipaxGaQmW4TfWoXdqjY0TzoXQ1HRS0kPpEgvjosb3u7Uedcq297xFqDQiCcQtRRwzIMif+N1MLVI8C5a4/PAA==
+  dependencies:
+    "@babel/helper-function-name" "^7.9.5"
+    "@babel/helper-member-expression-to-functions" "^7.8.3"
+    "@babel/helper-optimise-call-expression" "^7.8.3"
+    "@babel/helper-plugin-utils" "^7.8.3"
+    "@babel/helper-replace-supers" "^7.8.6"
+    "@babel/helper-split-export-declaration" "^7.8.3"
+
 "@babel/helper-create-regexp-features-plugin@^7.8.3", "@babel/helper-create-regexp-features-plugin@^7.8.8":
   version "7.8.8"
   resolved "https://registry.yarnpkg.com/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.8.8.tgz#5d84180b588f560b7864efaeea89243e58312087"
@@ -127,6 +139,15 @@
     "@babel/helper-get-function-arity" "^7.8.3"
     "@babel/template" "^7.8.3"
     "@babel/types" "^7.8.3"
+
+"@babel/helper-function-name@^7.9.5":
+  version "7.9.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.9.5.tgz#2b53820d35275120e1874a82e5aabe1376920a5c"
+  integrity sha512-JVcQZeXM59Cd1qanDUxv9fgJpt3NeKUaqBqUEvfmQ+BCOKq2xUgaWZW2hr0dkbyJgezYuplEoh5knmrnS68efw==
+  dependencies:
+    "@babel/helper-get-function-arity" "^7.8.3"
+    "@babel/template" "^7.8.3"
+    "@babel/types" "^7.9.5"
 
 "@babel/helper-get-function-arity@^7.8.3":
   version "7.8.3"
@@ -229,6 +250,11 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.0.tgz#ad53562a7fc29b3b9a91bbf7d10397fd146346ed"
   integrity sha512-6G8bQKjOh+of4PV/ThDm/rRqlU7+IGoJuofpagU5GlEl29Vv0RGqqt86ZGRV8ZuSOY3o+8yXl5y782SMcG7SHw==
 
+"@babel/helper-validator-identifier@^7.9.5":
+  version "7.9.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz#90977a8e6fbf6b431a7dc31752eee233bf052d80"
+  integrity sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g==
+
 "@babel/helper-wrap-function@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-wrap-function/-/helper-wrap-function-7.8.3.tgz#9dbdb2bb55ef14aaa01fe8c99b629bd5352d8610"
@@ -310,6 +336,15 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
     "@babel/plugin-syntax-object-rest-spread" "^7.8.0"
+
+"@babel/plugin-proposal-object-rest-spread@^7.9.5":
+  version "7.9.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.9.5.tgz#3fd65911306d8746014ec0d0cf78f0e39a149116"
+  integrity sha512-VP2oXvAf7KCYTthbUHwBlewbl1Iq059f6seJGsxMizaCdgHIeczOr7FBqELhSqfkIl04Fi8okzWzl63UKbQmmg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.3"
+    "@babel/plugin-syntax-object-rest-spread" "^7.8.0"
+    "@babel/plugin-transform-parameters" "^7.9.5"
 
 "@babel/plugin-proposal-optional-catch-binding@^7.8.3":
   version "7.8.3"
@@ -419,6 +454,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
 
+"@babel/plugin-syntax-typescript@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.8.3.tgz#c1f659dda97711a569cef75275f7e15dcaa6cabc"
+  integrity sha512-GO1MQ/SGGGoiEXY0e0bSpHimJvxqB7lktLLIq2pv8xG7WZ8IMEle74jIe1FhprHBWjwjZtXHkycDLZXIWM5Wfg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.3"
+
 "@babel/plugin-transform-arrow-functions@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.8.3.tgz#82776c2ed0cd9e1a49956daeb896024c9473b8b6"
@@ -464,6 +506,20 @@
     "@babel/helper-split-export-declaration" "^7.8.3"
     globals "^11.1.0"
 
+"@babel/plugin-transform-classes@^7.9.5":
+  version "7.9.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-classes/-/plugin-transform-classes-7.9.5.tgz#800597ddb8aefc2c293ed27459c1fcc935a26c2c"
+  integrity sha512-x2kZoIuLC//O5iA7PEvecB105o7TLzZo8ofBVhP79N+DO3jaX+KYfww9TQcfBEZD0nikNyYcGB1IKtRq36rdmg==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.8.3"
+    "@babel/helper-define-map" "^7.8.3"
+    "@babel/helper-function-name" "^7.9.5"
+    "@babel/helper-optimise-call-expression" "^7.8.3"
+    "@babel/helper-plugin-utils" "^7.8.3"
+    "@babel/helper-replace-supers" "^7.8.6"
+    "@babel/helper-split-export-declaration" "^7.8.3"
+    globals "^11.1.0"
+
 "@babel/plugin-transform-computed-properties@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.8.3.tgz#96d0d28b7f7ce4eb5b120bb2e0e943343c86f81b"
@@ -475,6 +531,13 @@
   version "7.8.8"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.8.8.tgz#fadb2bc8e90ccaf5658de6f8d4d22ff6272a2f4b"
   integrity sha512-eRJu4Vs2rmttFCdhPUM3bV0Yo/xPSdPw6ML9KHs/bjB4bLA5HXlbvYXPOD5yASodGod+krjYx21xm1QmL8dCJQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.3"
+
+"@babel/plugin-transform-destructuring@^7.9.5":
+  version "7.9.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.9.5.tgz#72c97cf5f38604aea3abf3b935b0e17b1db76a50"
+  integrity sha512-j3OEsGel8nHL/iusv/mRd5fYZ3DrOxWC82x0ogmdN/vHfAP4MYw+AFKYanzWlktNwikKvlzUV//afBW5FTp17Q==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
 
@@ -605,6 +668,14 @@
     "@babel/helper-get-function-arity" "^7.8.3"
     "@babel/helper-plugin-utils" "^7.8.3"
 
+"@babel/plugin-transform-parameters@^7.9.5":
+  version "7.9.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.9.5.tgz#173b265746f5e15b2afe527eeda65b73623a0795"
+  integrity sha512-0+1FhHnMfj6lIIhVvS4KGQJeuhe1GI//h5uptK4PvLt+BGBxsoUJbd3/IW002yk//6sZPlFgsG1hY6OHLcy6kA==
+  dependencies:
+    "@babel/helper-get-function-arity" "^7.8.3"
+    "@babel/helper-plugin-utils" "^7.8.3"
+
 "@babel/plugin-transform-property-literals@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.8.3.tgz#33194300d8539c1ed28c62ad5087ba3807b98263"
@@ -612,7 +683,39 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
 
-"@babel/plugin-transform-react-jsx@^7.0.0":
+"@babel/plugin-transform-react-display-name@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.8.3.tgz#70ded987c91609f78353dd76d2fb2a0bb991e8e5"
+  integrity sha512-3Jy/PCw8Fe6uBKtEgz3M82ljt+lTg+xJaM4og+eyu83qLT87ZUSckn0wy7r31jflURWLO83TW6Ylf7lyXj3m5A==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.3"
+
+"@babel/plugin-transform-react-jsx-development@^7.9.0":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.9.0.tgz#3c2a130727caf00c2a293f0aed24520825dbf754"
+  integrity sha512-tK8hWKrQncVvrhvtOiPpKrQjfNX3DtkNLSX4ObuGcpS9p0QrGetKmlySIGR07y48Zft8WVgPakqd/bk46JrMSw==
+  dependencies:
+    "@babel/helper-builder-react-jsx-experimental" "^7.9.0"
+    "@babel/helper-plugin-utils" "^7.8.3"
+    "@babel/plugin-syntax-jsx" "^7.8.3"
+
+"@babel/plugin-transform-react-jsx-self@^7.9.0":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.9.0.tgz#f4f26a325820205239bb915bad8e06fcadabb49b"
+  integrity sha512-K2ObbWPKT7KUTAoyjCsFilOkEgMvFG+y0FqOl6Lezd0/13kMkkjHskVsZvblRPj1PHA44PrToaZANrryppzTvQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.3"
+    "@babel/plugin-syntax-jsx" "^7.8.3"
+
+"@babel/plugin-transform-react-jsx-source@^7.9.0":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.9.0.tgz#89ef93025240dd5d17d3122294a093e5e0183de0"
+  integrity sha512-K6m3LlSnTSfRkM6FcRk8saNEeaeyG5k7AVkBU2bZK3+1zdkSED3qNdsWrUgQBeTVD2Tp3VMmerxVO2yM5iITmw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.3"
+    "@babel/plugin-syntax-jsx" "^7.8.3"
+
+"@babel/plugin-transform-react-jsx@^7.0.0", "@babel/plugin-transform-react-jsx@^7.9.4":
   version "7.9.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.9.4.tgz#86f576c8540bd06d0e95e0b61ea76d55f6cbd03f"
   integrity sha512-Mjqf3pZBNLt854CK0C/kRuXAnE6H/bo7xYojP+WGtX8glDGSibcwnsWwhwoSuRg0+EBnxPC1ouVnuetUIlPSAw==
@@ -672,6 +775,15 @@
   integrity sha512-2QKyfjGdvuNfHsb7qnBBlKclbD4CfshH2KvDabiijLMGXPHJXGxtDzwIF7bQP+T0ysw8fYTtxPafgfs/c1Lrqg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
+
+"@babel/plugin-transform-typescript@^7.9.0":
+  version "7.9.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.9.4.tgz#4bb4dde4f10bbf2d787fce9707fb09b483e33359"
+  integrity sha512-yeWeUkKx2auDbSxRe8MusAG+n4m9BFY/v+lPjmQDgOFX5qnySkUY5oXzkp6FwPdsYqnKay6lorXYdC0n3bZO7w==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.8.3"
+    "@babel/helper-plugin-utils" "^7.8.3"
+    "@babel/plugin-syntax-typescript" "^7.8.3"
 
 "@babel/plugin-transform-unicode-regex@^7.8.3":
   version "7.8.3"
@@ -747,6 +859,72 @@
     levenary "^1.1.1"
     semver "^5.5.0"
 
+"@babel/preset-env@^7.9.5":
+  version "7.9.5"
+  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.9.5.tgz#8ddc76039bc45b774b19e2fc548f6807d8a8919f"
+  integrity sha512-eWGYeADTlPJH+wq1F0wNfPbVS1w1wtmMJiYk55Td5Yu28AsdR9AsC97sZ0Qq8fHqQuslVSIYSGJMcblr345GfQ==
+  dependencies:
+    "@babel/compat-data" "^7.9.0"
+    "@babel/helper-compilation-targets" "^7.8.7"
+    "@babel/helper-module-imports" "^7.8.3"
+    "@babel/helper-plugin-utils" "^7.8.3"
+    "@babel/plugin-proposal-async-generator-functions" "^7.8.3"
+    "@babel/plugin-proposal-dynamic-import" "^7.8.3"
+    "@babel/plugin-proposal-json-strings" "^7.8.3"
+    "@babel/plugin-proposal-nullish-coalescing-operator" "^7.8.3"
+    "@babel/plugin-proposal-numeric-separator" "^7.8.3"
+    "@babel/plugin-proposal-object-rest-spread" "^7.9.5"
+    "@babel/plugin-proposal-optional-catch-binding" "^7.8.3"
+    "@babel/plugin-proposal-optional-chaining" "^7.9.0"
+    "@babel/plugin-proposal-unicode-property-regex" "^7.8.3"
+    "@babel/plugin-syntax-async-generators" "^7.8.0"
+    "@babel/plugin-syntax-dynamic-import" "^7.8.0"
+    "@babel/plugin-syntax-json-strings" "^7.8.0"
+    "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.0"
+    "@babel/plugin-syntax-numeric-separator" "^7.8.0"
+    "@babel/plugin-syntax-object-rest-spread" "^7.8.0"
+    "@babel/plugin-syntax-optional-catch-binding" "^7.8.0"
+    "@babel/plugin-syntax-optional-chaining" "^7.8.0"
+    "@babel/plugin-syntax-top-level-await" "^7.8.3"
+    "@babel/plugin-transform-arrow-functions" "^7.8.3"
+    "@babel/plugin-transform-async-to-generator" "^7.8.3"
+    "@babel/plugin-transform-block-scoped-functions" "^7.8.3"
+    "@babel/plugin-transform-block-scoping" "^7.8.3"
+    "@babel/plugin-transform-classes" "^7.9.5"
+    "@babel/plugin-transform-computed-properties" "^7.8.3"
+    "@babel/plugin-transform-destructuring" "^7.9.5"
+    "@babel/plugin-transform-dotall-regex" "^7.8.3"
+    "@babel/plugin-transform-duplicate-keys" "^7.8.3"
+    "@babel/plugin-transform-exponentiation-operator" "^7.8.3"
+    "@babel/plugin-transform-for-of" "^7.9.0"
+    "@babel/plugin-transform-function-name" "^7.8.3"
+    "@babel/plugin-transform-literals" "^7.8.3"
+    "@babel/plugin-transform-member-expression-literals" "^7.8.3"
+    "@babel/plugin-transform-modules-amd" "^7.9.0"
+    "@babel/plugin-transform-modules-commonjs" "^7.9.0"
+    "@babel/plugin-transform-modules-systemjs" "^7.9.0"
+    "@babel/plugin-transform-modules-umd" "^7.9.0"
+    "@babel/plugin-transform-named-capturing-groups-regex" "^7.8.3"
+    "@babel/plugin-transform-new-target" "^7.8.3"
+    "@babel/plugin-transform-object-super" "^7.8.3"
+    "@babel/plugin-transform-parameters" "^7.9.5"
+    "@babel/plugin-transform-property-literals" "^7.8.3"
+    "@babel/plugin-transform-regenerator" "^7.8.7"
+    "@babel/plugin-transform-reserved-words" "^7.8.3"
+    "@babel/plugin-transform-shorthand-properties" "^7.8.3"
+    "@babel/plugin-transform-spread" "^7.8.3"
+    "@babel/plugin-transform-sticky-regex" "^7.8.3"
+    "@babel/plugin-transform-template-literals" "^7.8.3"
+    "@babel/plugin-transform-typeof-symbol" "^7.8.4"
+    "@babel/plugin-transform-unicode-regex" "^7.8.3"
+    "@babel/preset-modules" "^0.1.3"
+    "@babel/types" "^7.9.5"
+    browserslist "^4.9.1"
+    core-js-compat "^3.6.2"
+    invariant "^2.2.2"
+    levenary "^1.1.1"
+    semver "^5.5.0"
+
 "@babel/preset-modules@^0.1.3":
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/@babel/preset-modules/-/preset-modules-0.1.3.tgz#13242b53b5ef8c883c3cf7dddd55b36ce80fbc72"
@@ -757,6 +935,26 @@
     "@babel/plugin-transform-dotall-regex" "^7.4.4"
     "@babel/types" "^7.4.4"
     esutils "^2.0.2"
+
+"@babel/preset-react@^7.9.4":
+  version "7.9.4"
+  resolved "https://registry.yarnpkg.com/@babel/preset-react/-/preset-react-7.9.4.tgz#c6c97693ac65b6b9c0b4f25b948a8f665463014d"
+  integrity sha512-AxylVB3FXeOTQXNXyiuAQJSvss62FEotbX2Pzx3K/7c+MKJMdSg6Ose6QYllkdCFA8EInCJVw7M/o5QbLuA4ZQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.3"
+    "@babel/plugin-transform-react-display-name" "^7.8.3"
+    "@babel/plugin-transform-react-jsx" "^7.9.4"
+    "@babel/plugin-transform-react-jsx-development" "^7.9.0"
+    "@babel/plugin-transform-react-jsx-self" "^7.9.0"
+    "@babel/plugin-transform-react-jsx-source" "^7.9.0"
+
+"@babel/preset-typescript@^7.9.0":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@babel/preset-typescript/-/preset-typescript-7.9.0.tgz#87705a72b1f0d59df21c179f7c3d2ef4b16ce192"
+  integrity sha512-S4cueFnGrIbvYJgwsVFKdvOmpiL0XGw9MFW9D0vgRys5g36PBhZRL8NX8Gr2akz8XRtzq6HuDXPD/1nniagNUg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.3"
+    "@babel/plugin-transform-typescript" "^7.9.0"
 
 "@babel/runtime@^7.4.4", "@babel/runtime@^7.8.4":
   version "7.9.2"
@@ -795,6 +993,15 @@
   integrity sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==
   dependencies:
     "@babel/helper-validator-identifier" "^7.9.0"
+    lodash "^4.17.13"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.9.5":
+  version "7.9.5"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.9.5.tgz#89231f82915a8a566a703b3b20133f73da6b9444"
+  integrity sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.9.5"
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 


### PR DESCRIPTION
Babel has shipped [new JSX `automatic` transformation since v7.9.0](https://babeljs.io/blog/2020/03/16/7.9.0#a-new-jsx-transform-11154), and *would be a default runtime mode in Babel 8.* So jsx-slack also have to prepare `automatic` runtime before than Babel 8 is shipped out.

```javascript
// babel.config.js
modue.exports = {
  presets: [
    [
      '@babel/preset-react',
      {
        // "automatic" will be the default runtime in Babel 8
        runtime: 'automatic',
        development: process.env.NODE_ENV === 'development',
      }
    ],
  ]
}
```

```jsx
/** @jsxImportSource @speee-js/jsx-slack */
import { Blocks } from '@speee-js/jsx-slack'

console.log(
  <Blocks>
    <section>
      <p>Hello, world!</p>
    </section>
  </Blocks>
)
```

Babel will import specific function from `@speee-js/jsx-slack/jsx-runtime` or `@speee-js/jsx-slack/jsx-dev-runtime` automatically for transpiling JSX. No need to import `JSXSlack` manually.

In other words, we have to provide 2 new JSX transformation runtimes. The specification was proposed in [React RFC](https://github.com/reactjs/rfcs/blob/createlement-rfc/text/0000-create-element-changes.md) created in last year, and Babel 7.9 is the first stable implementation for transform. React has supported `automatic` runtime in experimental build but not yet stable.

```javascript
// Transpiled source code
import { jsx as _jsx } from '@speee-js/jsx-slack/jsx-runtime'
import { Blocks } from '@speee-js/jsx-slack

console.log(
  _jsx(Blocks, {
    children: _jsx('section', {
      children: _jsx('p', {
        children: 'Hello, world!'
      })
    })
  })
)
```

New JSX runtime has a lot of differences against classic `JSXSlack.createElement`: 3 different functions according to the role (`jsx` / `jsxs` / `jsxDEV`), Provided children always as props, special treatment of `key` prop for React, etc...

Fortunately they are not yet too complex, so jsx-slack can provide transformation funcs for `automatic` runtime by defining simple proxy to `JSXSlack.createElement`.

---

For implementing this, we've set up Jest to be able to test Babel transpiler. It may be a base to improve v2's helpful error more while transpiling with `@babel/preset-react` that was enabled `development` (#141).

### ToDo

- [x] Add new JSX transformation functions
- [x] Test Babel transpilation
- [x] Update documentation of setting up JSX transpiler