### PR TITLE
[v2] Suggest string literals on IDE when typing the kind of conversation in <ConversationsSelect include>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ jsx-slack v2 has improved JSX structure and built-in components to output the re
 - Added JSDoc to many public APIs and components
 - Support new JSX transpile via `automatic` runtime in Babel >= 7.9 _(experimental)_ ([#142](https://github.com/speee/jsx-slack/pull/142))
 
+### Fixed
+
+- Suggest string literals on IDE when typing the kind of conversation in `<ConversationsSelect include>` ([#145](https://github.com/speee/jsx-slack/pull/145))
+
 ### Removed
 
 - Deprecated features in v1: `JSXSlack.legacyParser()` and `jsxslack.fragment`

--- a/src/block-kit/composition/utils.ts
+++ b/src/block-kit/composition/utils.ts
@@ -2,12 +2,12 @@ import { ConversationsSelect, PlainTextElement } from '@slack/types'
 import { JSXSlack } from '../../jsx'
 
 type FilterComposition = ConversationsSelect['filter']
-type FilterIncludeKinds = 'im' | 'mpim' | 'private' | 'public'
+type FilterIncludeKind = 'im' | 'mpim' | 'private' | 'public'
 
 // It's a workaround for working auto-completion of string literals in IDE while
 // still allowing space-separated string. This hack has called `LiteralUnion`.
 // @see https://github.com/Microsoft/TypeScript/issues/29729
-type SpaceSeparatedString = string & { _?: never }
+type SpaceSeparatedKind = string & { _?: never }
 
 export interface FilterProps {
   /**
@@ -21,7 +21,7 @@ export interface FilterProps {
    *
    * By default, all conversation types are included.
    */
-  include?: FilterIncludeKinds | FilterIncludeKinds[] | SpaceSeparatedString
+  include?: FilterIncludeKind | FilterIncludeKind[] | SpaceSeparatedKind
 
   /**
    * A boolean value whether to exclude external

--- a/src/block-kit/composition/utils.ts
+++ b/src/block-kit/composition/utils.ts
@@ -2,6 +2,12 @@ import { ConversationsSelect, PlainTextElement } from '@slack/types'
 import { JSXSlack } from '../../jsx'
 
 type FilterComposition = ConversationsSelect['filter']
+type FilterIncludeKinds = 'im' | 'mpim' | 'private' | 'public'
+
+// It's a workaround for working auto-completion of string literals in IDE while
+// still allowing space-separated string. This hack has called `LiteralUnion`.
+// @see https://github.com/Microsoft/TypeScript/issues/29729
+type SpaceSeparatedString = string & { _?: never }
 
 export interface FilterProps {
   /**
@@ -15,7 +21,7 @@ export interface FilterProps {
    *
    * By default, all conversation types are included.
    */
-  include?: string | ('im' | 'mpim' | 'private' | 'public')[]
+  include?: FilterIncludeKinds | FilterIncludeKinds[] | SpaceSeparatedString
 
   /**
    * A boolean value whether to exclude external


### PR DESCRIPTION
`include` prop of `<ConversationsSelect>` allows `string` type, to accept the space-separated kind of conversations. jsx-slack v1 has suggested the kind while typing array value through `<Conversations include={[]}>`, but not while typing a string.

I've improved its type definition for auto-suggestion on IDE to work the suggestion in string.

![](https://user-images.githubusercontent.com/3993388/79560815-40b8b600-80e3-11ea-875e-1eea2cd6a0fe.png)

```typescript
type FilterIncludeKind = 'im' | 'mpim' | 'private' | 'public'
type SpaceSeparatedKind = string & { _?: never }

interface FilterProps {
  include?: FilterIncludeKind | FilterIncludeKind[] | SpaceSeparatedKind
}
```

This hack is called as `LiteralUnion` in https://github.com/Microsoft/TypeScript/issues/29729#issuecomment-471566609.