### PR TITLE
Fix wrong path for type definition: js -> d.ts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix wrong extension for the path of type definition: `.js` -> `.d.ts` ([#171](https://github.com/speee/jsx-slack/pull/171))
+
 ## v2.2.0 - 2020-05-21
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "main": "lib/index.js",
   "module": "module/src/index.js",
   "sideEffects": false,
-  "types": "types/index.js",
+  "types": "types/index.d.ts",
   "files": [
     "lib/",
     "module/",


### PR DESCRIPTION
The actual entry point for emitted type definitions is `types/index.d.ts` but `package.json` has `.js` extension instead of `.d.ts`.