### PR TITLE
Update how to generate Block Kit Builder URL in demo page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fix wrong extension for the path of type definition: `.js` -> `.d.ts` ([#171](https://github.com/speee/jsx-slack/pull/171))
+- Update how to generate Block Kit Builder URL in demo page ([#168](https://github.com/speee/jsx-slack/issues/168), [#172](https://github.com/speee/jsx-slack/pull/172))
 
 ## v2.2.0 - 2020-05-21
 

--- a/demo/convert.js
+++ b/demo/convert.js
@@ -1,12 +1,10 @@
 import { JSXSlack, jsxslack } from '../src/index'
 import { isValidComponent } from '../src/jsx'
 
-const generateUrl = (params) => {
-  const q = new URLSearchParams()
-  Object.keys(params).forEach((k) => q.append(k, params[k]))
-
-  return `https://api.slack.com/tools/block-kit-builder?${q}`
-}
+const generateUrl = (json) =>
+  `https://api.slack.com/tools/block-kit-builder#${encodeURIComponent(
+    JSON.stringify(json)
+  )}`
 
 export const convert = (jsx) => {
   const output = jsxslack([jsx])
@@ -15,17 +13,14 @@ export const convert = (jsx) => {
     throw new Error('Cannot parse as jsx-slack component.')
 
   const ret = { text: JSON.stringify(output, null, 2) }
-  const encoded = JSON.stringify(output).replace(/\+/g, '%2b')
 
   if (isValidComponent(output.$$jsxslack.type)) {
     const { name } = output.$$jsxslack.type.$$jsxslackComponent
 
     if (name === 'Blocks') {
-      ret.url = generateUrl({ blocks: encoded, mode: 'message' })
-    } else if (name === 'Modal') {
-      ret.url = generateUrl({ view: encoded, mode: 'modal' })
-    } else if (name === 'Home') {
-      ret.url = generateUrl({ view: encoded, mode: 'appHome' })
+      ret.url = generateUrl({ blocks: output })
+    } else if (name === 'Modal' || name === 'Home') {
+      ret.url = generateUrl(output)
     }
   }
 

--- a/demo/index.js
+++ b/demo/index.js
@@ -83,17 +83,11 @@ const jsxEditor = CodeMirror(jsx, {
 const setPreview = (url) => {
   previewBtnContainer.removeAttribute('data-title')
 
-  if (url && url.length <= 8000) {
+  if (url) {
     previewBtn.setAttribute('tabindex', 0)
     previewBtn.setAttribute('href', url)
     previewBtn.classList.remove('disabled')
   } else {
-    if (url) {
-      previewBtnContainer.setAttribute(
-        'data-title',
-        'Cannot preview directly because a generated JSON is too long. Try to paste copied JSON into Block Kit Builder.'
-      )
-    }
     previewBtn.setAttribute('tabindex', -1)
     previewBtn.classList.add('disabled')
   }


### PR DESCRIPTION
Resolves #168. We will remove a limitation of the length for preview URL.

The classic URL query could not preview the huge generated JSON in jsx-slack demo because Slack returns 414 error. (e.g. https://speee-jsx-slack.netlify.app/#modalListOfInformationTicketApp)

![limitation](https://user-images.githubusercontent.com/3993388/85828496-88cf1580-b7c3-11ea-8388-c57a2b177eea.png)

New Block Kit Builder allows passing JSON through hash (`#xxx`) as same as our demo. It won't be prevented preview even if to pass too long URI.