### PR TITLE
Test against Node 14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,15 +1,20 @@
 version: 2.1
 
 executors:
-  dubnium:
+  dubnium-10:
     working_directory: ~/jsx-slack
     docker:
-      - image: circleci/node:dubnium
+      - image: circleci/node:10
 
-  erbium:
+  erbium-12:
     working_directory: ~/jsx-slack
     docker:
-      - image: circleci/node:erbium
+      - image: circleci/node:12
+
+  fermium-14:
+    working_directory: ~/jsx-slack
+    docker:
+      - image: circleci/node:14
 
 commands:
   test:
@@ -59,20 +64,27 @@ commands:
       - run: yarn codecov
 
 jobs:
-  dubnium:
+  dubnium-10:
     executor:
-      name: dubnium
+      name: dubnium-10
     steps:
       - test
 
-  erbium:
+  erbium-12:
     executor:
-      name: erbium
+      name: erbium-12
+    steps:
+      - test
+
+  fermium-14:
+    executor:
+      name: erbium-14
     steps:
       - test
 
 workflows:
   build:
     jobs:
-      - dubnium
-      - erbium
+      - dubnium-10
+      - erbium-12
+      - fermium-14

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
 
   fermium-14:
     executor:
-      name: erbium-14
+      name: fermium-14
     steps:
       - test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - `type` prop and [`workflow_step` type](https://api.slack.com/reference/workflows/configuration-view) for `<Modal>` ([#176](https://github.com/speee/jsx-slack/issues/176), [#177](https://github.com/speee/jsx-slack/pull/177))
+- Test against Node 14 ([#181](https://github.com/speee/jsx-slack/pull/181))
 
 ### Changed
 


### PR DESCRIPTION
Added Node 14 executor to CircleCi to test jsx-slack against the latest Node.