### PR TITLE
Prevent over-escaping in Korean emoji shorthand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - [Configurable `dispatchAction` prop](https://github.com/speee/jsx-slack/blob/master/docs/block-elements.md#input) for `<Input type="text">` and `<Textarea>` (equivalent to [`dispatch_action_config` for the plain-text input](https://api.slack.com/reference/block-kit/block-elements#input)) ([#204](https://github.com/speee/jsx-slack/issues/204), [#205](https://github.com/speee/jsx-slack/pull/205))
 
+### Fixed
+
+- Escaped underscores within Korean emoji shorthand have broken ([#203](https://github.com/speee/jsx-slack/issues/203), [#206](https://github.com/speee/jsx-slack/pull/206))
+
 ## v2.5.1 - 2020-10-08
 
 ### Added

--- a/src/mrkdwn/escape.ts
+++ b/src/mrkdwn/escape.ts
@@ -1,5 +1,5 @@
 // An internal HTML tag and emoji shorthand should not escape
-const preventEscapeRegex = /(<.*?>|:[-a-z0-9ÀÁÂÃÄÇÈÉÊËÍÎÏÑÓÔÕÖŒœÙÚÛÜŸßàáâãäçèéêëíîïñóôõöùúûüÿ_＿+＋'\u2e80-\u2fd5\u3005\u3041-\u3096\u30a0-\u30ff\u3400-\u4db5\u4e00-\u9fcb\uff10-\uff19\uff41-\uff5a\uff61-\uff9f]+:)/
+const preventEscapeRegex = /(<.*?>|:[-a-z0-9ÀÁÂÃÄÇÈÉÊËÍÎÏÑÓÔÕÖŒœÙÚÛÜŸßàáâãäçèéêëíîïñóôõöùúûüÿ_＿+＋'\u1100-\u11ff\u2e80-\u2fd5\u3005\u3041-\u3096\u30a0-\u30ff\u3130-\u318f\u3400-\u4db5\u4e00-\u9fcb\ua960-\ua97f\uac00-\ud7ff\uff10-\uff19\uff41-\uff5a\uff61-\uff9f]+:)/
 
 const generateReplacerForEscape = (fallback: string) => (matched: string) =>
   `<span data-escape="${fallback.repeat(matched.length)}">${matched}</span>`

--- a/test/block-kit/builtin-components.tsx
+++ b/test/block-kit/builtin-components.tsx
@@ -50,7 +50,10 @@ describe('Built-in components', () => {
         JSXSlack(
           <Blocks>
             <Section>
-              <Escape>_:arrow_down: :custom_emoji: :カスタム＿絵文字:_</Escape>
+              <Escape>
+                _:arrow_down: :custom_emoji: :カスタム＿絵文字:
+                :커스텀_이모티콘:_
+              </Escape>
             </Section>
           </Blocks>
         )
@@ -58,7 +61,7 @@ describe('Built-in components', () => {
         expect.objectContaining({
           text: expect.objectContaining({
             text:
-              '<!date^00000000^{_}|_>:arrow_down: :custom_emoji: :カスタム＿絵文字:<!date^00000000^{_}|_>',
+              '<!date^00000000^{_}|_>:arrow_down: :custom_emoji: :カスタム＿絵文字: :커스텀_이모티콘:<!date^00000000^{_}|_>',
           }),
         }),
       ]))


### PR DESCRIPTION
It's just like #101 but I've updated regex for valid emoji shorthand to add Hangul unicode characters, for preventing over-escaping.

Closes #203.