### PR TITLE
JSX automatic runtime support for TypeScript 4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- JSX automatic runtime support for TypeScript 4.1 ([#214](https://github.com/speee/jsx-slack/pull/214), [#194](https://github.com/speee/jsx-slack/issues/194))
+
 ## v2.6.0 - 2020-10-20
 
 ### Added

--- a/docs/how-to-setup-jsx-transpiler.md
+++ b/docs/how-to-setup-jsx-transpiler.md
@@ -4,6 +4,10 @@
 
 When you want to use jsx-slack with JSX transpiler, you have to set up to use imported our parser `JSXSlack.createElement`, or its alias `JSXSlack.h`.
 
+> :information_source: You can also use jsx-slack without setting up JSX transpiler as well! Check out ["Quick start: Template literal"](../README.md#quick-start-template-literal) section.
+>
+> On the other hand, you'll get better developer experience in IDE (auto completion, static error check, etc...) if you've set up JSX transpiler.
+
 ## [Babel](https://babeljs.io/)
 
 You can use [`@babel/preset-react`](https://babeljs.io/docs/en/babel-preset-react) preset (or [`@babel/plugin-transform-react-jsx`](https://babeljs.io/docs/en/babel-plugin-transform-react-jsx) plugin) to transpile JSX.
@@ -51,7 +55,7 @@ You can also use comment pragma per JSX file if you have already set up JSX tran
 const { JSXSlack } = require('@speee-js/jsx-slack')
 ```
 
-### Automatic ([Babel >= 7.9](https://babeljs.io/blog/2020/03/16/7.9.0#a-new-jsx-transform-11154-https-githubcom-babel-babel-pull-11154)) _[experimental]_
+### Automatic ([Babel >= 7.9](https://babeljs.io/blog/2020/03/16/7.9.0#a-new-jsx-transform-11154-https-githubcom-babel-babel-pull-11154))
 
 We also have supported `automatic` runtime.
 
@@ -95,13 +99,15 @@ console.log(
 
 You can use TypeScript built-in JSX transpiler too.
 
+### Classic
+
 ```jsonc
 // tsconfig.json
 {
   "compilerOptions": {
     "jsx": "react",
     "jsxFactory": "JSXSlack.h",
-    // NOTE: jsxFragmentFactory is available only in TypeScript >= v4.
+    // NOTE: jsxFragmentFactory is available only in TypeScript >= 4.0.
     "jsxFragmentFactory": "JSXSlack.Fragment"
     // ...
   }
@@ -109,8 +115,6 @@ You can use TypeScript built-in JSX transpiler too.
 ```
 
 You should always import `JSXSlack` from `@speee-js/jsx-slack` in every JSX.
-
-In addition, we recommend to wrap JSX in `JSXSlack()` to deal with the mismatched type against SDK for Slack API. It's a helper function to cast into `any` type.
 
 ```jsx
 import { JSXSlack, Blocks, Section } from '@speee-js/jsx-slack'
@@ -128,12 +132,60 @@ console.log(
 
 #### Comment pragma
 
-Please note that `jsxFrag` pragma is available only in [TypeScript >= v4](https://devblogs.microsoft.com/typescript/announcing-typescript-4-0/#custom-jsx-factories).
+Please note that `jsxFrag` pragma is available only in [TypeScript >= 4.0](https://devblogs.microsoft.com/typescript/announcing-typescript-4-0/#custom-jsx-factories).
 
 ```jsx
 /** @jsx JSXSlack.h **/
 /** @jsxFrag JSXSlack.Fragment **/
 import { JSXSlack } from '@speee-js/jsx-slack'
+```
+
+### Automatic ([TypeScript >= 4.1](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-1.html#react-17-jsx-factories))
+
+```jsonc
+{
+  "compilerOptions": {
+    "jsx": "react-jsx", // or "react-jsxdev" for development
+    "jsxImportSource": "@speee-js/jsx-slack",
+    // ...
+  }
+}
+```
+
+#### Comment pragma
+
+```jsx
+/** @jsxImportSource @speee-js/jsx-slack **/
+import {} from '@speee-js/jsx-slack'
+```
+
+### Caveats
+
+In TypeScript, **you should always place import syntax from `@speee-js/jsx-slack`** even if you're not using any components, to avoid type error while compiling.
+
+```jsx
+// Should place empty import to avoid compile error
+import {} from '@speee-js/jsx-slack'
+
+export const CustomComponent = ({ a, b }) => <>{a},{b}</>
+```
+
+And we recommend to **wrap JSX with `JSXSlack()` when passing JSX to SDK for Slack API.** It's a helper function to cast JSX into `any` type, and you can deal with the mismatched JSX type against SDK.
+
+```jsx
+import { WebClient } from '@slack/client'
+import { JSXSlack, Blocks, Section } from '@speee-js/jsx-slack'
+
+const api = new WebClient(process.env.SLACK_TOKEN)
+
+api.chat.postMessage({
+  channel: 'C1234567890',
+  blocks: JSXSlack( // <- Important!
+    <Blocks>
+      <Section>Hello, world!</Section>
+    </Blocks>
+  ),
+})
 ```
 
 ---

--- a/docs/how-to-setup-jsx-transpiler.md
+++ b/docs/how-to-setup-jsx-transpiler.md
@@ -12,7 +12,48 @@ When you want to use jsx-slack with JSX transpiler, you have to set up to use im
 
 You can use [`@babel/preset-react`](https://babeljs.io/docs/en/babel-preset-react) preset (or [`@babel/plugin-transform-react-jsx`](https://babeljs.io/docs/en/babel-plugin-transform-react-jsx) plugin) to transpile JSX.
 
-### Classic
+```javascript
+// babel.config.js
+module.exports = (api) => ({
+  presets: [
+    [
+      '@babel/preset-react',
+      {
+        runtime: 'automatic',
+        importSource: '@speee-js/jsx-slack',
+        development: api.env('development'),
+      },
+    ],
+  ],
+})
+```
+
+```jsx
+const { Blocks, Section } = require('@speee-js/jsx-slack')
+
+console.log(
+  <Blocks>
+    <Section>
+      <p>Hello, world!</p>
+    </Section>
+  </Blocks>
+)
+```
+
+### Comment pragma
+
+If you have already set up JSX transpiler for React, you can also use comment pragma to switch the transformation way per JSX file.
+
+```jsx
+/** @jsxImportSource @speee-js/jsx-slack */
+```
+
+### Classic runtime (Babel <= 7.8)
+
+`runtime: 'automatic'` cannot use if you're using Babel <= 7.8. You have to consider using the classic runtime.
+
+<details>
+<summary>How to use the classic runtime...</summary>
 
 ```javascript
 // babel.config.js
@@ -31,7 +72,7 @@ module.exports = (api) => ({
 })
 ```
 
-You should always import `JSXSlack` from `@speee-js/jsx-slack` in every JSX.
+_You should always import `JSXSlack` from `@speee-js/jsx-slack` in every JSX._
 
 ```jsx
 const { JSXSlack, Blocks, Section } = require('@speee-js/jsx-slack')
@@ -47,38 +88,30 @@ console.log(
 
 #### Comment pragma
 
-You can also use comment pragma per JSX file if you have already set up JSX transpiler for React.
-
 ```jsx
 /** @jsx JSXSlack.h **/
 /** @jsxFrag JSXSlack.Fragment **/
 const { JSXSlack } = require('@speee-js/jsx-slack')
 ```
 
-### Automatic ([Babel >= 7.9](https://babeljs.io/blog/2020/03/16/7.9.0#a-new-jsx-transform-11154-https-githubcom-babel-babel-pull-11154))
+</details>
 
-We also have supported `automatic` runtime.
+## [TypeScript](https://www.typescriptlang.org/)
 
-```javascript
-// babel.config.js
-module.exports = (api) => ({
-  presets: [
-    [
-      '@babel/preset-react',
-      {
-        runtime: 'automatic',
-        importSource: '@speee-js/jsx-slack',
-        development: api.env('development'),
-      },
-    ],
-  ],
-})
+You can use TypeScript built-in JSX transpiler too.
+
+```jsonc
+{
+  "compilerOptions": {
+    "jsx": "react-jsx", // or "react-jsxdev" for development
+    "jsxImportSource": "@speee-js/jsx-slack"
+    // ...
+  }
+}
 ```
 
-Babel will automatically import functions for transpiling JSX. You only have to import required components from `@speee-js/jsx-slack`.
-
-```jsx
-const { Blocks, Section } = require('@speee-js/jsx-slack')
+```tsx
+import { Blocks, Section } from '@speee-js/jsx-slack'
 
 console.log(
   <Blocks>
@@ -89,17 +122,19 @@ console.log(
 )
 ```
 
-#### Comment pragma
+### Comment pragma
+
+Currently _the empty import at least is required to make recognize jsx-slack to TypeScript._
 
 ```jsx
-/** @jsxImportSource @speee-js/jsx-slack */
+/** @jsxImportSource @speee-js/jsx-slack **/
+import {} from '@speee-js/jsx-slack'
 ```
 
-## [TypeScript](https://www.typescriptlang.org/)
+### Classic (TypeScript <= 4.0)
 
-You can use TypeScript built-in JSX transpiler too.
-
-### Classic
+<details>
+<summary>How to transpile jsx-slack with the classic way...</summary>
 
 ```jsonc
 // tsconfig.json
@@ -107,14 +142,14 @@ You can use TypeScript built-in JSX transpiler too.
   "compilerOptions": {
     "jsx": "react",
     "jsxFactory": "JSXSlack.h",
-    // NOTE: jsxFragmentFactory is available only in TypeScript >= 4.0.
+    // NOTE: jsxFragmentFactory is available only in TypeScript >= v4.0.
     "jsxFragmentFactory": "JSXSlack.Fragment"
     // ...
   }
 }
 ```
 
-You should always import `JSXSlack` from `@speee-js/jsx-slack` in every JSX.
+_You should always import `JSXSlack` from `@speee-js/jsx-slack` in every JSX._
 
 ```jsx
 import { JSXSlack, Blocks, Section } from '@speee-js/jsx-slack'
@@ -140,41 +175,11 @@ Please note that `jsxFrag` pragma is available only in [TypeScript >= 4.0](https
 import { JSXSlack } from '@speee-js/jsx-slack'
 ```
 
-### Automatic ([TypeScript >= 4.1](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-1.html#react-17-jsx-factories))
-
-```jsonc
-{
-  "compilerOptions": {
-    "jsx": "react-jsx", // or "react-jsxdev" for development
-    "jsxImportSource": "@speee-js/jsx-slack"
-    // ...
-  }
-}
-```
-
-#### Comment pragma
-
-```jsx
-/** @jsxImportSource @speee-js/jsx-slack **/
-import {} from '@speee-js/jsx-slack'
-```
+</details>
 
 ### Caveats
 
-In TypeScript, **you should always place import syntax from `@speee-js/jsx-slack`** even if you're not using any components, to avoid type error while compiling.
-
-```jsx
-// Should place empty import to avoid compile error
-import {} from '@speee-js/jsx-slack'
-
-export const CustomComponent = ({ a, b }) => (
-  <b>
-    Hello, {a}, and {b}!
-  </b>
-)
-```
-
-And we recommend to **wrap JSX with `JSXSlack()` when passing JSX to SDK for Slack API.** It's a helper function to cast JSX into `any` type, and you can deal with the mismatched JSX type against SDK.
+In TypeScript, we recommend to **wrap JSX with `JSXSlack()` when passing JSX to SDK for Slack API.** It's a helper function to cast JSX into `any` type, and you can deal with the mismatched JSX type against SDK.
 
 ```jsx
 import { WebClient } from '@slack/client'
@@ -185,7 +190,7 @@ const api = new WebClient(process.env.SLACK_TOKEN)
 api.chat.postMessage({
   channel: 'C1234567890',
 
-  // Important using JSXSlack()!
+  // Please wrap in JSXSlack()!
   blocks: JSXSlack(
     <Blocks>
       <Section>Hello, world!</Section>

--- a/docs/how-to-setup-jsx-transpiler.md
+++ b/docs/how-to-setup-jsx-transpiler.md
@@ -146,7 +146,7 @@ import { JSXSlack } from '@speee-js/jsx-slack'
 {
   "compilerOptions": {
     "jsx": "react-jsx", // or "react-jsxdev" for development
-    "jsxImportSource": "@speee-js/jsx-slack",
+    "jsxImportSource": "@speee-js/jsx-slack"
     // ...
   }
 }
@@ -167,7 +167,11 @@ In TypeScript, **you should always place import syntax from `@speee-js/jsx-slack
 // Should place empty import to avoid compile error
 import {} from '@speee-js/jsx-slack'
 
-export const CustomComponent = ({ a, b }) => <>{a},{b}</>
+export const CustomComponent = ({ a, b }) => (
+  <b>
+    Hello, {a}, and {b}!
+  </b>
+)
 ```
 
 And we recommend to **wrap JSX with `JSXSlack()` when passing JSX to SDK for Slack API.** It's a helper function to cast JSX into `any` type, and you can deal with the mismatched JSX type against SDK.
@@ -180,7 +184,9 @@ const api = new WebClient(process.env.SLACK_TOKEN)
 
 api.chat.postMessage({
   channel: 'C1234567890',
-  blocks: JSXSlack( // <- Important!
+
+  // Important using JSXSlack()!
+  blocks: JSXSlack(
     <Blocks>
       <Section>Hello, world!</Section>
     </Blocks>

--- a/jsx-dev-runtime.d.ts
+++ b/jsx-dev-runtime.d.ts
@@ -1,0 +1,1 @@
+export * from './types/jsx-dev-runtime'

--- a/jsx-dev-runtime.d.ts
+++ b/jsx-dev-runtime.d.ts
@@ -1,1 +1,2 @@
+// eslint-disable-next-line import/no-unresolved
 export * from './types/jsx-dev-runtime'

--- a/jsx-runtime.d.ts
+++ b/jsx-runtime.d.ts
@@ -1,0 +1,1 @@
+export * from './types/jsx-runtime'

--- a/jsx-runtime.d.ts
+++ b/jsx-runtime.d.ts
@@ -1,1 +1,2 @@
+// eslint-disable-next-line import/no-unresolved
 export * from './types/jsx-runtime'

--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
     "module/",
     "types/",
     "jsx-dev-runtime.js",
-    "jsx-runtime.js"
+    "jsx-runtime.js",
+    "jsx-dev-runtime.d.ts",
+    "jsx-runtime.d.ts"
   ],
   "scripts": {
     "build": "rimraf lib module && rollup -c",

--- a/src/jsx-dev-runtime.ts
+++ b/src/jsx-dev-runtime.ts
@@ -1,6 +1,5 @@
-import { jsx } from './jsx-runtime'
+import { jsx, JSX } from './jsx-runtime'
 
-/** @experimental */
 export const jsxDEV = (
   type: any,
   props: Record<string, unknown>,
@@ -8,3 +7,5 @@ export const jsxDEV = (
   _: boolean, // isStaticChildren: not used in jsx-slack
   __source: Record<string, unknown>
 ) => jsx(type, { ...props, __source }, key)
+
+export type { JSX }

--- a/src/jsx-runtime.ts
+++ b/src/jsx-runtime.ts
@@ -1,11 +1,12 @@
-import { createElementInternal, FragmentInternal } from './jsx'
+import { JSXSlack, createElementInternal, FragmentInternal } from './jsx'
+import JSX = JSXSlack.JSX
 
-/** @experimental */
 export const jsx = (type: any, props: Record<string, unknown>, key: any) =>
   createElementInternal(type ?? FragmentInternal, {
     ...props,
     ...(key !== undefined ? { key } : {}),
   })
 
-/** @experimental */
 export const jsxs = jsx
+
+export type { JSX }


### PR DESCRIPTION
Our experimental automatic JSX runtime is not yet working on TypeScript 4.1 due to lacking corresponded type definitions.

I've confirmed JSX is working by the updated JSX type definition.

And this PR is also including the updated documentation to setup JSX transpiler. Now we can simplify docs to instruct automatic runtime as a primary way. Close #194.